### PR TITLE
Add optional system property for ChromeDriver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,3 @@
 
 # Artifact from signing JARs.
 retest-gmbh-gpg.asc
-
-# Ignore OS-specific ChromeDriver.
-src/test/resources/chromedriver

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 
 # Artifact from signing JARs.
 retest-gmbh-gpg.asc
+
+# Ignore OS-specific ChromeDriver.
+src/test/resources/chromedriver

--- a/src/test/java/de/retest/web/ShowcaseIT.java
+++ b/src/test/java/de/retest/web/ShowcaseIT.java
@@ -20,8 +20,8 @@ public class ShowcaseIT {
 
 	@Before
 	public void setup() {
-		// If ChromeDriver is not in your PATH, copy/link your installation to the path below and uncomment.
-		//		System.setProperty( "webdriver.chrome.driver", "src/test/resources/chromedriver" );
+		// If ChromeDriver is not in your PATH, uncomment this and point to your installation.
+		//		System.setProperty( "webdriver.chrome.driver", "path/to/chromedriver" );
 
 		final ChromeOptions opts = new ChromeOptions();
 		opts.addArguments(

--- a/src/test/java/de/retest/web/ShowcaseIT.java
+++ b/src/test/java/de/retest/web/ShowcaseIT.java
@@ -20,11 +20,14 @@ public class ShowcaseIT {
 
 	@Before
 	public void setup() {
+		// If ChromeDriver is not in your PATH, copy/link your installation to the path below and uncomment.
+		//		System.setProperty( "webdriver.chrome.driver", "src/test/resources/chromedriver" );
+
 		final ChromeOptions opts = new ChromeOptions();
 		opts.addArguments(
 				// Enable headless mode for faster execution.
 				"--headless",
-				// Use chrome in container-based Travis CI environment (see https://docs.travis-ci.com/user/chrome#Sandboxing).
+				// Use Chrome in container-based Travis CI environment (see https://docs.travis-ci.com/user/chrome#Sandboxing).
 				"--no-sandbox",
 				// Fix window size for stable results.
 				"--window-size=1200,800" );

--- a/src/test/java/de/retest/web/ShowcaseIT.java
+++ b/src/test/java/de/retest/web/ShowcaseIT.java
@@ -21,6 +21,7 @@ public class ShowcaseIT {
 	@Before
 	public void setup() {
 		// If ChromeDriver is not in your PATH, uncomment this and point to your installation.
+		// e.g. it can be downloaded from http://chromedriver.chromium.org/downloads
 		//		System.setProperty( "webdriver.chrome.driver", "path/to/chromedriver" );
 
 		final ChromeOptions opts = new ChromeOptions();

--- a/src/test/java/de/retest/web/testutils/ChromeOptionsFactory.java
+++ b/src/test/java/de/retest/web/testutils/ChromeOptionsFactory.java
@@ -11,7 +11,7 @@ public class ChromeOptionsFactory {
 		opts.addArguments(
 				// Enable headless mode for faster execution.
 				"--headless",
-				// Use chrome in container-based Travis CI environment (see https://docs.travis-ci.com/user/chrome#Sandboxing).
+				// Use Chrome in container-based Travis CI environment (see https://docs.travis-ci.com/user/chrome#Sandboxing).
 				"--no-sandbox",
 				// Fix window size for stable results.
 				"--window-size=1200,800" );


### PR DESCRIPTION
Removed the property from the `ChromeOptionsFactory` because I thought it is more about making the showcase run, not the entire project (which requires ChromeDriver to be in PATH anyway).