### PR TITLE
Remove non-relevant difference, resulting from commata

### DIFF
--- a/src/main/java/de/retest/web/WebData.java
+++ b/src/main/java/de/retest/web/WebData.java
@@ -40,8 +40,20 @@ public class WebData {
 		if ( result.startsWith( "\"" ) && result.endsWith( "\"" ) ) {
 			result = result.substring( 1, result.length() - 1 );
 		}
-		result = result.replaceAll( ",", "" );
+		result = normalizeComma( result );
 		return result.trim();
+	}
+
+	private static String normalizeComma( final String input ) {
+		if ( !input.contains( "," ) ) {
+			return input;
+		}
+		final String[] parts = input.split( "," );
+		final StringBuffer result = new StringBuffer( parts[0] );
+		for ( int idx = 1; idx < parts.length; idx++ ) {
+			result.append( " " ).append( parts[idx].trim() );
+		}
+		return result.toString();
 	}
 
 	public Rectangle getOutline() {

--- a/src/main/java/de/retest/web/WebData.java
+++ b/src/main/java/de/retest/web/WebData.java
@@ -40,6 +40,7 @@ public class WebData {
 		if ( result.startsWith( "\"" ) && result.endsWith( "\"" ) ) {
 			result = result.substring( 1, result.length() - 1 );
 		}
+		result = result.replaceAll( ",", "" );
 		return result.trim();
 	}
 

--- a/src/test/java/de/retest/web/WebDataTest.java
+++ b/src/test/java/de/retest/web/WebDataTest.java
@@ -33,9 +33,24 @@ class WebDataTest {
 	}
 
 	@Test
-	void normalize_should_remove_apostrophe() {
-		assertThat( WebData.normalize( null ) ).isEqualTo( null );
-		assertThat( WebData.normalize( "\"Times New Roman\"" ) ).isEqualTo( "Times New Roman" );
+	void normalize_should_trim() {
 		assertThat( WebData.normalize( "\" Times New Roman \"" ) ).isEqualTo( "Times New Roman" );
+	}
+
+	@Test
+	void normalize_should_be_null_safe() {
+		assertThat( WebData.normalize( null ) ).isEqualTo( null );
+	}
+
+	@Test
+	void normalize_should_remove_apostrophe() {
+		assertThat( WebData.normalize( "\"Times New Roman\"" ) ).isEqualTo( "Times New Roman" );
+	}
+
+	@Test
+	void normalize_should_remove_comma() {
+		// e.g. the clip attribute comes in flavors
+		assertThat( WebData.normalize( "rect(0px, 0px, 0px, 0px)" ) ).isEqualTo( "rect(0px 0px 0px 0px)" );
+
 	}
 }

--- a/src/test/java/de/retest/web/WebDataTest.java
+++ b/src/test/java/de/retest/web/WebDataTest.java
@@ -51,6 +51,6 @@ class WebDataTest {
 	void normalize_should_remove_comma() {
 		// e.g. the clip attribute comes in flavors
 		assertThat( WebData.normalize( "rect(0px, 0px, 0px, 0px)" ) ).isEqualTo( "rect(0px 0px 0px 0px)" );
-
+		assertThat( WebData.normalize( "rect(0px,0px,0px,0px)" ) ).isEqualTo( "rect(0px 0px 0px 0px)" );
 	}
 }


### PR DESCRIPTION
initial resulted in: [SPAN [Toggle navigation]: {clip = [expected=rect(0px, 0px, 0px, 0px), actual=rect(0px 0px 0px 0px)]}]