### PR TITLE
Feature/ignore same child value

### DIFF
--- a/src/main/resources/javascript/getAllElementsByPath.js
+++ b/src/main/resources/javascript/getAllElementsByPath.js
@@ -43,10 +43,17 @@ function transform(node) {
 		result[attributeName] = attributValue;
 	}
 	var style = window.getComputedStyle(node);
+	var parentStyle = [];
+	try {
+	    parentStyle = window.getComputedStyle(node.parentNode);
+	}
+	catch(err) {}
 	for (var i = 0; i < args.length; i++) {
 		var attributeName = args[i];
 		if (!result[attributeName]) {
-			result[attributeName] = style[attributeName];
+			if (parentStyle[attributeName] != style[attributeName]) {
+				result[attributeName] = style[attributeName];
+			}
 		}
 	}
 	// They need special treatment

--- a/src/test/java/de/retest/web/PageFrameIT.java
+++ b/src/test/java/de/retest/web/PageFrameIT.java
@@ -31,6 +31,8 @@ class PageFrameIT {
 		final Path simplePagePath = Paths.get( "src/test/resources/pages/page-frame.html" );
 		driver.get( simplePagePath.toUri().toURL().toString() );
 
+		Thread.sleep( 1000 );
+
 		re.check( driver, "open" );
 
 		re.capTest();

--- a/src/test/java/de/retest/web/ShowcaseIT.java
+++ b/src/test/java/de/retest/web/ShowcaseIT.java
@@ -31,6 +31,8 @@ class ShowcaseIT {
 		final Path showcasePath = Paths.get( "src/test/resources/pages/showcase/retest.html" );
 		driver.get( showcasePath.toUri().toURL().toString() );
 
+		Thread.sleep( 1000 );
+
 		re.check( driver, "open" );
 
 		re.capTest();

--- a/src/test/java/de/retest/web/SimplePageIT.java
+++ b/src/test/java/de/retest/web/SimplePageIT.java
@@ -31,6 +31,8 @@ class SimplePageIT {
 		final Path simplePagePath = Paths.get( "src/test/resources/pages/simple-page.html" );
 		driver.get( simplePagePath.toUri().toURL().toString() );
 
+		Thread.sleep( 1000 );
+
 		re.check( driver, "open" );
 
 		re.capTest();

--- a/src/test/java/de/retest/web/SimpleShowcaseIT.java
+++ b/src/test/java/de/retest/web/SimpleShowcaseIT.java
@@ -49,6 +49,8 @@ public class SimpleShowcaseIT {
 		final Path showcasePath = Paths.get( "src/test/resources/pages/showcase/retest.html" );
 		driver.get( showcasePath.toUri().toURL().toString() );
 
+		Thread.sleep( 1000 );
+
 		// Single call instead of multiple assertions (doesn't fail on differences).
 		re.check( driver, "index" );
 

--- a/src/test/resources/retest/recheck/de.retest.web.PageFrameIT/page-frame-ChromeDriver.open.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.PageFrameIT/page-frame-ChromeDriver.open.recheck/retest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<reTestXmlDataContainer xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" reTestVersion="3.0.0-alpha.2018-09-24" dataType="de.retest.ui.descriptors.SutState" dataTypeVersion="1">
+<reTestXmlDataContainer xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" reTestVersion="3.0.0" dataType="de.retest.ui.descriptors.SutState" dataTypeVersion="2">
 	<data xsi:type="sutState">
-		<descriptors screenId="1" screen="We Leave From Here" title="We Leave From Here">
+		<descriptors retestId="html" screenId="1" screen="We Leave From Here" title="We Leave From Here">
 			<identifyingAttributes>
 				<attributes>
 					<attribute key="outline" xsi:type="outlineAttribute">
@@ -10,13 +10,13 @@
 						<height>800</height>
 						<width>1200</width>
 					</attribute>
-					<attribute key="path" xsi:type="pathAttribute">//HTML[1]</attribute>
+					<attribute key="path" xsi:type="pathAttribute">HTML[1]</attribute>
 					<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 					<attribute key="type" xsi:type="stringAttribute">HTML</attribute>
 				</attributes>
 			</identifyingAttributes>
 			<attributes/>
-			<containedComponents>
+			<containedComponents retestId="there_should">
 				<identifyingAttributes>
 					<attributes>
 						<attribute key="outline" xsi:type="outlineAttribute">
@@ -25,54 +25,58 @@
 							<height>784</height>
 							<width>1184</width>
 						</attribute>
-						<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]</attribute>
+						<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]</attribute>
 						<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 						<attribute key="text" xsi:type="textAttribute">There should be a form here:</attribute>
 						<attribute key="type" xsi:type="stringAttribute">BODY</attribute>
 					</attributes>
 				</identifyingAttributes>
 				<attributes/>
-				<containedComponents>
+				<containedComponents retestId="div">
 					<identifyingAttributes>
 						<attributes>
+							<attribute key="class" xsi:type="stringAttribute">gromit</attribute>
+							<attribute key="id" xsi:type="stringAttribute">wallace</attribute>
 							<attribute key="outline" xsi:type="outlineAttribute">
 								<x>8</x>
 								<y>664</y>
 								<height>0</height>
 								<width>1184</width>
 							</attribute>
-							<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/DIV[1]</attribute>
+							<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/DIV[1]</attribute>
 							<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 							<attribute key="type" xsi:type="stringAttribute">DIV</attribute>
 						</attributes>
 					</identifyingAttributes>
 					<attributes/>
 				</containedComponents>
-				<containedComponents>
+				<containedComponents retestId="form">
 					<identifyingAttributes>
 						<attributes>
+							<attribute key="name" xsi:type="stringAttribute">login</attribute>
 							<attribute key="outline" xsi:type="outlineAttribute">
 								<x>8</x>
 								<y>26</y>
 								<height>21</height>
 								<width>1184</width>
 							</attribute>
-							<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[1]</attribute>
+							<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[1]</attribute>
 							<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 							<attribute key="type" xsi:type="stringAttribute">FORM</attribute>
 						</attributes>
 					</identifyingAttributes>
 					<attributes/>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">email</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>8</x>
 									<y>26</y>
 									<height>21</height>
 									<width>181</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[1]/INPUT[1]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[1]/INPUT[1]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -136,10 +140,6 @@
 									<value xsi:type="xsd:string">0px</value>
 								</entry>
 								<entry>
-									<key>margin-top</key>
-									<value xsi:type="xsd:string">0px</value>
-								</entry>
-								<entry>
 									<key>padding-bottom</key>
 									<value xsi:type="xsd:string">1px</value>
 								</entry>
@@ -150,16 +150,17 @@
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">age</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>193</x>
 									<y>26</y>
 									<height>21</height>
 									<width>181</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[1]/INPUT[2]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[1]/INPUT[2]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -223,10 +224,6 @@
 									<value xsi:type="xsd:string">0px</value>
 								</entry>
 								<entry>
-									<key>margin-top</key>
-									<value xsi:type="xsd:string">0px</value>
-								</entry>
-								<entry>
 									<key>padding-bottom</key>
 									<value xsi:type="xsd:string">1px</value>
 								</entry>
@@ -237,16 +234,17 @@
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">submitButton</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>378</x>
 									<y>26</y>
 									<height>21</height>
 									<width>80</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[1]/INPUT[3]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[1]/INPUT[3]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">3</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -330,10 +328,6 @@
 									<value xsi:type="xsd:string">0px</value>
 								</entry>
 								<entry>
-									<key>margin-top</key>
-									<value xsi:type="xsd:string">0px</value>
-								</entry>
-								<entry>
 									<key>padding-bottom</key>
 									<value xsi:type="xsd:string">1px</value>
 								</entry>
@@ -361,41 +355,39 @@
 						</attributes>
 					</containedComponents>
 				</containedComponents>
-				<containedComponents>
+				<containedComponents retestId="form">
 					<identifyingAttributes>
 						<attributes>
+							<attribute key="name" xsi:type="stringAttribute">image</attribute>
 							<attribute key="outline" xsi:type="outlineAttribute">
 								<x>8</x>
 								<y>63</y>
 								<height>16</height>
 								<width>1184</width>
 							</attribute>
-							<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[2]</attribute>
+							<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[2]</attribute>
 							<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 							<attribute key="type" xsi:type="stringAttribute">FORM</attribute>
 						</attributes>
 					</identifyingAttributes>
 					<attributes/>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">imageButton</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>8</x>
 									<y>63</y>
 									<height>16</height>
 									<width>68</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[2]/INPUT[1]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[2]/INPUT[1]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
 						</identifyingAttributes>
 						<attributes>
 							<attributes>
-								<entry>
-									<key>box-sizing</key>
-									<value xsi:type="xsd:string">content-box</value>
-								</entry>
 								<entry>
 									<key>font-family</key>
 									<value xsi:type="xsd:string">Arial</value>
@@ -408,31 +400,28 @@
 									<key>margin-bottom</key>
 									<value xsi:type="xsd:string">0px</value>
 								</entry>
-								<entry>
-									<key>margin-top</key>
-									<value xsi:type="xsd:string">0px</value>
-								</entry>
 							</attributes>
 						</attributes>
 					</containedComponents>
 				</containedComponents>
-				<containedComponents>
+				<containedComponents retestId="heres_a_checkbox">
 					<identifyingAttributes>
 						<attributes>
+							<attribute key="name" xsi:type="stringAttribute">optional</attribute>
 							<attribute key="outline" xsi:type="outlineAttribute">
 								<x>8</x>
 								<y>95</y>
 								<height>283</height>
 								<width>1184</width>
 							</attribute>
-							<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]</attribute>
+							<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]</attribute>
 							<attribute key="suffix" xsi:type="suffixAttribute">3</attribute>
 							<attribute key="text" xsi:type="textAttribute">Here's a checkbox:</attribute>
 							<attribute key="type" xsi:type="stringAttribute">FORM</attribute>
 						</attributes>
 					</identifyingAttributes>
 					<attributes/>
-					<containedComponents>
+					<containedComponents retestId="br">
 						<identifyingAttributes>
 							<attributes>
 								<attribute key="outline" xsi:type="outlineAttribute">
@@ -441,14 +430,14 @@
 									<height>0</height>
 									<width>0</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/BR[1]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/BR[1]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 								<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 							</attributes>
 						</identifyingAttributes>
 						<attributes/>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="br">
 						<identifyingAttributes>
 							<attributes>
 								<attribute key="outline" xsi:type="outlineAttribute">
@@ -457,14 +446,14 @@
 									<height>0</height>
 									<width>0</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/BR[2]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/BR[2]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 								<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 							</attributes>
 						</identifyingAttributes>
 						<attributes/>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="br">
 						<identifyingAttributes>
 							<attributes>
 								<attribute key="outline" xsi:type="outlineAttribute">
@@ -473,14 +462,14 @@
 									<height>0</height>
 									<width>0</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/BR[3]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/BR[3]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">3</attribute>
 								<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 							</attributes>
 						</identifyingAttributes>
 						<attributes/>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="br">
 						<identifyingAttributes>
 							<attributes>
 								<attribute key="outline" xsi:type="outlineAttribute">
@@ -489,14 +478,14 @@
 									<height>0</height>
 									<width>0</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/BR[4]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/BR[4]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">4</attribute>
 								<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 							</attributes>
 						</identifyingAttributes>
 						<attributes/>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="br">
 						<identifyingAttributes>
 							<attributes>
 								<attribute key="outline" xsi:type="outlineAttribute">
@@ -505,14 +494,14 @@
 									<height>0</height>
 									<width>0</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/BR[5]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/BR[5]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">5</attribute>
 								<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 							</attributes>
 						</identifyingAttributes>
 						<attributes/>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="br">
 						<identifyingAttributes>
 							<attributes>
 								<attribute key="outline" xsi:type="outlineAttribute">
@@ -521,23 +510,24 @@
 									<height>0</height>
 									<width>0</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/BR[6]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/BR[6]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">6</attribute>
 								<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 							</attributes>
 						</identifyingAttributes>
 						<attributes/>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="name" xsi:type="stringAttribute">hidden</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>0</x>
 									<y>0</y>
 									<height>0</height>
 									<width>0</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/INPUT[10]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/INPUT[10]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">10</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -560,14 +550,10 @@
 									<key>margin-bottom</key>
 									<value xsi:type="xsd:string">0px</value>
 								</entry>
-								<entry>
-									<key>margin-top</key>
-									<value xsi:type="xsd:string">0px</value>
-								</entry>
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
 								<attribute key="outline" xsi:type="outlineAttribute">
@@ -576,7 +562,7 @@
 									<height>21</height>
 									<width>49</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/INPUT[11]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/INPUT[11]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">11</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -660,10 +646,6 @@
 									<value xsi:type="xsd:string">0px</value>
 								</entry>
 								<entry>
-									<key>margin-top</key>
-									<value xsi:type="xsd:string">0px</value>
-								</entry>
-								<entry>
 									<key>padding-bottom</key>
 									<value xsi:type="xsd:string">1px</value>
 								</entry>
@@ -690,16 +672,18 @@
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">lone_disabled_selected_radio</attribute>
+								<attribute key="name" xsi:type="stringAttribute">not_a_snack</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>66</x>
 									<y>359</y>
 									<height>13</height>
 									<width>13</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/INPUT[12]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/INPUT[12]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">12</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -773,16 +757,18 @@
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">checky</attribute>
+								<attribute key="name" xsi:type="stringAttribute">checky</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>137</x>
 									<y>98</y>
 									<height>13</height>
 									<width>13</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/INPUT[1]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/INPUT[1]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -816,16 +802,18 @@
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">checkedchecky</attribute>
+								<attribute key="name" xsi:type="stringAttribute">checkedchecky</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>161</x>
 									<y>98</y>
 									<height>13</height>
 									<width>13</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/INPUT[2]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/INPUT[2]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -859,16 +847,18 @@
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">disabledchecky</attribute>
+								<attribute key="name" xsi:type="stringAttribute">disabledchecky</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>185</x>
 									<y>98</y>
 									<height>13</height>
 									<width>13</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/INPUT[3]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/INPUT[3]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">3</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -938,16 +928,18 @@
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">randomly_disabled_checky</attribute>
+								<attribute key="name" xsi:type="stringAttribute">randomlydisabledchecky</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>209</x>
 									<y>98</y>
 									<height>13</height>
 									<width>13</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/INPUT[4]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/INPUT[4]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">4</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -1017,16 +1009,18 @@
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">cheese</attribute>
+								<attribute key="name" xsi:type="stringAttribute">snack</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>13</x>
 									<y>209</y>
 									<height>13</height>
 									<width>13</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/INPUT[5]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/INPUT[5]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">5</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -1064,16 +1058,18 @@
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">peas</attribute>
+								<attribute key="name" xsi:type="stringAttribute">snack</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>13</x>
 									<y>229</y>
 									<height>13</height>
 									<width>13</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/INPUT[6]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/INPUT[6]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">6</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -1111,16 +1107,18 @@
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">cheese_and_peas</attribute>
+								<attribute key="name" xsi:type="stringAttribute">snack</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>13</x>
 									<y>249</y>
 									<height>13</height>
 									<width>13</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/INPUT[7]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/INPUT[7]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">7</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -1158,16 +1156,18 @@
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">nothing</attribute>
+								<attribute key="name" xsi:type="stringAttribute">snack</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>13</x>
 									<y>269</y>
 									<height>13</height>
 									<width>13</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/INPUT[8]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/INPUT[8]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">8</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -1241,16 +1241,18 @@
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">randomly_disabled_nothing</attribute>
+								<attribute key="name" xsi:type="stringAttribute">snack</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>13</x>
 									<y>289</y>
 									<height>13</height>
 									<width>13</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/INPUT[9]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/INPUT[9]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">9</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -1324,16 +1326,17 @@
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="i_like_cheese">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">cheeseLiker</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>8</x>
 									<y>322</y>
 									<height>18</height>
 									<width>1184</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/P[1]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/P[1]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 								<attribute key="text" xsi:type="textAttribute">I like cheese</attribute>
 								<attribute key="type" xsi:type="stringAttribute">P</attribute>
@@ -1341,7 +1344,7 @@
 						</identifyingAttributes>
 						<attributes/>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="select">
 						<identifyingAttributes>
 							<attributes>
 								<attribute key="outline" xsi:type="outlineAttribute">
@@ -1350,7 +1353,7 @@
 									<height>19</height>
 									<width>66</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[10]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[10]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">10</attribute>
 								<attribute key="type" xsi:type="stringAttribute">SELECT</attribute>
 							</attributes>
@@ -1378,10 +1381,6 @@
 									<value xsi:type="xsd:string">1px</value>
 								</entry>
 								<entry>
-									<key>border-image-width</key>
-									<value xsi:type="xsd:string">1</value>
-								</entry>
-								<entry>
 									<key>border-left-color</key>
 									<value xsi:type="xsd:string">rgb(169, 169, 169)</value>
 								</entry>
@@ -1447,34 +1446,23 @@
 								</entry>
 							</attributes>
 						</attributes>
-						<containedComponents>
+						<containedComponents retestId="option">
 							<identifyingAttributes>
 								<attributes>
+									<attribute key="id" xsi:type="stringAttribute">blankOption</attribute>
 									<attribute key="outline" xsi:type="outlineAttribute">
 										<x>0</x>
 										<y>0</y>
 										<height>0</height>
 										<width>0</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[10]/OPTION[1]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[10]/OPTION[1]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
 								</attributes>
 							</identifyingAttributes>
 							<attributes>
 								<attributes>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">Arial</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">13.3333px</value>
-									</entry>
 									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">16px</value>
@@ -1491,23 +1479,20 @@
 										<key>padding-right</key>
 										<value xsi:type="xsd:string">2px</value>
 									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">pre</value>
-									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="nothing">
 							<identifyingAttributes>
 								<attributes>
+									<attribute key="id" xsi:type="stringAttribute">optionEmptyValueSet</attribute>
 									<attribute key="outline" xsi:type="outlineAttribute">
 										<x>0</x>
 										<y>0</y>
 										<height>0</height>
 										<width>0</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[10]/OPTION[2]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[10]/OPTION[2]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 									<attribute key="text" xsi:type="textAttribute">nothing</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -1516,18 +1501,6 @@
 							<attributes>
 								<attributes>
 									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">Arial</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">13.3333px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">16px</value>
 									</entry>
@@ -1543,24 +1516,21 @@
 										<key>padding-right</key>
 										<value xsi:type="xsd:string">2px</value>
 									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">pre</value>
-									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="select">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="name" xsi:type="stringAttribute">selectomatic</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>8</x>
 									<y>168</y>
 									<height>19</height>
 									<width>244</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[1]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[1]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 								<attribute key="type" xsi:type="stringAttribute">SELECT</attribute>
 							</attributes>
@@ -1588,10 +1558,6 @@
 									<value xsi:type="xsd:string">1px</value>
 								</entry>
 								<entry>
-									<key>border-image-width</key>
-									<value xsi:type="xsd:string">1</value>
-								</entry>
-								<entry>
 									<key>border-left-color</key>
 									<value xsi:type="xsd:string">rgb(169, 169, 169)</value>
 								</entry>
@@ -1657,16 +1623,17 @@
 								</entry>
 							</attributes>
 						</attributes>
-						<containedComponents>
+						<containedComponents retestId="one">
 							<identifyingAttributes>
 								<attributes>
+									<attribute key="id" xsi:type="stringAttribute">non_multi_option</attribute>
 									<attribute key="outline" xsi:type="outlineAttribute">
 										<x>0</x>
 										<y>0</y>
 										<height>0</height>
 										<width>0</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[1]/OPTION[1]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[1]/OPTION[1]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 									<attribute key="text" xsi:type="textAttribute">One</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -1675,18 +1642,6 @@
 							<attributes>
 								<attributes>
 									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">Arial</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">13.3333px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">16px</value>
 									</entry>
@@ -1702,14 +1657,10 @@
 										<key>padding-right</key>
 										<value xsi:type="xsd:string">2px</value>
 									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">pre</value>
-									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="two">
 							<identifyingAttributes>
 								<attributes>
 									<attribute key="outline" xsi:type="outlineAttribute">
@@ -1718,7 +1669,7 @@
 										<height>0</height>
 										<width>0</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[1]/OPTION[2]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[1]/OPTION[2]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 									<attribute key="text" xsi:type="textAttribute">Two</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -1727,18 +1678,6 @@
 							<attributes>
 								<attributes>
 									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">Arial</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">13.3333px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">16px</value>
 									</entry>
@@ -1754,14 +1693,10 @@
 										<key>padding-right</key>
 										<value xsi:type="xsd:string">2px</value>
 									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">pre</value>
-									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="four">
 							<identifyingAttributes>
 								<attributes>
 									<attribute key="outline" xsi:type="outlineAttribute">
@@ -1770,7 +1705,7 @@
 										<height>0</height>
 										<width>0</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[1]/OPTION[3]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[1]/OPTION[3]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">3</attribute>
 									<attribute key="text" xsi:type="textAttribute">Four</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -1779,18 +1714,6 @@
 							<attributes>
 								<attributes>
 									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">Arial</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">13.3333px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">16px</value>
 									</entry>
@@ -1806,14 +1729,10 @@
 										<key>padding-right</key>
 										<value xsi:type="xsd:string">2px</value>
 									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">pre</value>
-									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="still_learning">
 							<identifyingAttributes>
 								<attributes>
 									<attribute key="outline" xsi:type="outlineAttribute">
@@ -1822,7 +1741,7 @@
 										<height>0</height>
 										<width>0</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[1]/OPTION[4]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[1]/OPTION[4]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">4</attribute>
 									<attribute key="text" xsi:type="textAttribute">Still learning how to count, apparently</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -1830,18 +1749,6 @@
 							</identifyingAttributes>
 							<attributes>
 								<attributes>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">Arial</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">13.3333px</value>
-									</entry>
 									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">16px</value>
@@ -1858,24 +1765,22 @@
 										<key>padding-right</key>
 										<value xsi:type="xsd:string">2px</value>
 									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">pre</value>
-									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="select">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">multi</attribute>
+								<attribute key="name" xsi:type="stringAttribute">multi</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>256</x>
 									<y>115</y>
 									<height>70</height>
 									<width>93</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[2]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[2]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 								<attribute key="type" xsi:type="stringAttribute">SELECT</attribute>
 							</attributes>
@@ -1901,10 +1806,6 @@
 								<entry>
 									<key>border-bottom-width</key>
 									<value xsi:type="xsd:string">1px</value>
-								</entry>
-								<entry>
-									<key>border-image-width</key>
-									<value xsi:type="xsd:string">1</value>
 								</entry>
 								<entry>
 									<key>border-left-color</key>
@@ -1988,7 +1889,7 @@
 								</entry>
 							</attributes>
 						</attributes>
-						<containedComponents>
+						<containedComponents retestId="eggs">
 							<identifyingAttributes>
 								<attributes>
 									<attribute key="outline" xsi:type="outlineAttribute">
@@ -1997,7 +1898,7 @@
 										<height>17</height>
 										<width>76</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[2]/OPTION[1]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[2]/OPTION[1]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 									<attribute key="text" xsi:type="textAttribute">Eggs</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -2014,10 +1915,6 @@
 										<value xsi:type="xsd:string">rgb(50, 50, 50)</value>
 									</entry>
 									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
 										<key>border-left-color</key>
 										<value xsi:type="xsd:string">rgb(50, 50, 50)</value>
 									</entry>
@@ -2040,14 +1937,6 @@
 									<entry>
 										<key>column-rule-color</key>
 										<value xsi:type="xsd:string">rgb(50, 50, 50)</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">Arial</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">13.3333px</value>
 									</entry>
 									<entry>
 										<key>min-height</key>
@@ -2080,7 +1969,7 @@
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="ham">
 							<identifyingAttributes>
 								<attributes>
 									<attribute key="outline" xsi:type="outlineAttribute">
@@ -2089,7 +1978,7 @@
 										<height>17</height>
 										<width>76</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[2]/OPTION[2]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[2]/OPTION[2]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 									<attribute key="text" xsi:type="textAttribute">Ham</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -2097,18 +1986,6 @@
 							</identifyingAttributes>
 							<attributes>
 								<attributes>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">Arial</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">13.3333px</value>
-									</entry>
 									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">16px</value>
@@ -2132,7 +2009,7 @@
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="sausages">
 							<identifyingAttributes>
 								<attributes>
 									<attribute key="outline" xsi:type="outlineAttribute">
@@ -2141,7 +2018,7 @@
 										<height>17</height>
 										<width>76</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[2]/OPTION[3]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[2]/OPTION[3]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">3</attribute>
 									<attribute key="text" xsi:type="textAttribute">Sausages</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -2158,10 +2035,6 @@
 										<value xsi:type="xsd:string">rgb(50, 50, 50)</value>
 									</entry>
 									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
 										<key>border-left-color</key>
 										<value xsi:type="xsd:string">rgb(50, 50, 50)</value>
 									</entry>
@@ -2184,14 +2057,6 @@
 									<entry>
 										<key>column-rule-color</key>
 										<value xsi:type="xsd:string">rgb(50, 50, 50)</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">Arial</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">13.3333px</value>
 									</entry>
 									<entry>
 										<key>min-height</key>
@@ -2224,7 +2089,7 @@
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="onion_gravy">
 							<identifyingAttributes>
 								<attributes>
 									<attribute key="outline" xsi:type="outlineAttribute">
@@ -2233,7 +2098,7 @@
 										<height>17</height>
 										<width>76</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[2]/OPTION[4]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[2]/OPTION[4]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">4</attribute>
 									<attribute key="text" xsi:type="textAttribute">Onion gravy</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -2241,18 +2106,6 @@
 							</identifyingAttributes>
 							<attributes>
 								<attributes>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">Arial</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">13.3333px</value>
-									</entry>
 									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">16px</value>
@@ -2277,16 +2130,17 @@
 							</attributes>
 						</containedComponents>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="select">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="name" xsi:type="stringAttribute">no-select</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>353</x>
 									<y>168</y>
 									<height>19</height>
 									<width>45</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[3]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[3]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">3</attribute>
 								<attribute key="type" xsi:type="stringAttribute">SELECT</attribute>
 							</attributes>
@@ -2312,10 +2166,6 @@
 								<entry>
 									<key>border-bottom-width</key>
 									<value xsi:type="xsd:string">1px</value>
-								</entry>
-								<entry>
-									<key>border-image-width</key>
-									<value xsi:type="xsd:string">1</value>
 								</entry>
 								<entry>
 									<key>border-left-color</key>
@@ -2403,7 +2253,7 @@
 								</entry>
 							</attributes>
 						</attributes>
-						<containedComponents>
+						<containedComponents retestId="foo">
 							<identifyingAttributes>
 								<attributes>
 									<attribute key="outline" xsi:type="outlineAttribute">
@@ -2412,7 +2262,7 @@
 										<height>0</height>
 										<width>0</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[3]/OPTION[1]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[3]/OPTION[1]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 									<attribute key="text" xsi:type="textAttribute">Foo</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -2425,10 +2275,6 @@
 										<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 									</entry>
 									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
 										<key>border-left-color</key>
 										<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 									</entry>
@@ -2441,32 +2287,8 @@
 										<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 									</entry>
 									<entry>
-										<key>caret-color</key>
-										<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-									</entry>
-									<entry>
-										<key>color</key>
-										<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-									</entry>
-									<entry>
-										<key>column-rule-color</key>
-										<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">Arial</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">13.3333px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">16px</value>
-									</entry>
-									<entry>
-										<key>outline-color</key>
-										<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 									</entry>
 									<entry>
 										<key>padding-bottom</key>
@@ -2480,18 +2302,10 @@
 										<key>padding-right</key>
 										<value xsi:type="xsd:string">2px</value>
 									</entry>
-									<entry>
-										<key>text-decoration-color</key>
-										<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">pre</value>
-									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="bar">
 							<identifyingAttributes>
 								<attributes>
 									<attribute key="outline" xsi:type="outlineAttribute">
@@ -2500,7 +2314,7 @@
 										<height>0</height>
 										<width>0</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[3]/OPTION[2]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[3]/OPTION[2]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 									<attribute key="text" xsi:type="textAttribute">Bar</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -2513,10 +2327,6 @@
 										<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 									</entry>
 									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
 										<key>border-left-color</key>
 										<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 									</entry>
@@ -2529,32 +2339,8 @@
 										<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 									</entry>
 									<entry>
-										<key>caret-color</key>
-										<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-									</entry>
-									<entry>
-										<key>color</key>
-										<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-									</entry>
-									<entry>
-										<key>column-rule-color</key>
-										<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">Arial</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">13.3333px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">16px</value>
-									</entry>
-									<entry>
-										<key>outline-color</key>
-										<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 									</entry>
 									<entry>
 										<key>padding-bottom</key>
@@ -2568,28 +2354,21 @@
 										<key>padding-right</key>
 										<value xsi:type="xsd:string">2px</value>
 									</entry>
-									<entry>
-										<key>text-decoration-color</key>
-										<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">pre</value>
-									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="select">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="name" xsi:type="stringAttribute">select_empty_multiple</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>402</x>
 									<y>115</y>
 									<height>70</height>
 									<width>71</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[4]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[4]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">4</attribute>
 								<attribute key="type" xsi:type="stringAttribute">SELECT</attribute>
 							</attributes>
@@ -2617,10 +2396,6 @@
 									<value xsi:type="xsd:string">1px</value>
 								</entry>
 								<entry>
-									<key>border-image-width</key>
-									<value xsi:type="xsd:string">1</value>
-								</entry>
-								<entry>
 									<key>border-left-color</key>
 									<value xsi:type="xsd:string">rgb(169, 169, 169)</value>
 								</entry>
@@ -2702,16 +2477,17 @@
 								</entry>
 							</attributes>
 						</attributes>
-						<containedComponents>
+						<containedComponents retestId="select_1">
 							<identifyingAttributes>
 								<attributes>
+									<attribute key="id" xsi:type="stringAttribute">multi_1</attribute>
 									<attribute key="outline" xsi:type="outlineAttribute">
 										<x>403</x>
 										<y>116</y>
 										<height>17</height>
 										<width>54</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[4]/OPTION[1]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[4]/OPTION[1]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 									<attribute key="text" xsi:type="textAttribute">select_1</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -2720,18 +2496,6 @@
 							<attributes>
 								<attributes>
 									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">Arial</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">13.3333px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">16px</value>
 									</entry>
@@ -2754,16 +2518,17 @@
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="select_2">
 							<identifyingAttributes>
 								<attributes>
+									<attribute key="id" xsi:type="stringAttribute">multi_2</attribute>
 									<attribute key="outline" xsi:type="outlineAttribute">
 										<x>403</x>
 										<y>133</y>
 										<height>17</height>
 										<width>54</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[4]/OPTION[2]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[4]/OPTION[2]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 									<attribute key="text" xsi:type="textAttribute">select_2</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -2772,18 +2537,6 @@
 							<attributes>
 								<attributes>
 									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">Arial</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">13.3333px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">16px</value>
 									</entry>
@@ -2806,16 +2559,17 @@
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="select_3">
 							<identifyingAttributes>
 								<attributes>
+									<attribute key="id" xsi:type="stringAttribute">multi_3</attribute>
 									<attribute key="outline" xsi:type="outlineAttribute">
 										<x>403</x>
 										<y>150</y>
 										<height>17</height>
 										<width>54</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[4]/OPTION[3]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[4]/OPTION[3]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">3</attribute>
 									<attribute key="text" xsi:type="textAttribute">select_3</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -2824,18 +2578,6 @@
 							<attributes>
 								<attributes>
 									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">Arial</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">13.3333px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">16px</value>
 									</entry>
@@ -2858,16 +2600,17 @@
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="select_4">
 							<identifyingAttributes>
 								<attributes>
+									<attribute key="id" xsi:type="stringAttribute">multi_4</attribute>
 									<attribute key="outline" xsi:type="outlineAttribute">
 										<x>403</x>
 										<y>167</y>
 										<height>17</height>
 										<width>54</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[4]/OPTION[4]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[4]/OPTION[4]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">4</attribute>
 									<attribute key="text" xsi:type="textAttribute">select_4</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -2875,18 +2618,6 @@
 							</identifyingAttributes>
 							<attributes>
 								<attributes>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">Arial</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">13.3333px</value>
-									</entry>
 									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">16px</value>
@@ -2911,16 +2642,17 @@
 							</attributes>
 						</containedComponents>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="select">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="name" xsi:type="stringAttribute">multi_true</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>477</x>
 									<y>115</y>
 									<height>70</height>
 									<width>71</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[5]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[5]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">5</attribute>
 								<attribute key="type" xsi:type="stringAttribute">SELECT</attribute>
 							</attributes>
@@ -2948,10 +2680,6 @@
 									<value xsi:type="xsd:string">1px</value>
 								</entry>
 								<entry>
-									<key>border-image-width</key>
-									<value xsi:type="xsd:string">1</value>
-								</entry>
-								<entry>
 									<key>border-left-color</key>
 									<value xsi:type="xsd:string">rgb(169, 169, 169)</value>
 								</entry>
@@ -3033,16 +2761,17 @@
 								</entry>
 							</attributes>
 						</attributes>
-						<containedComponents>
+						<containedComponents retestId="select_1">
 							<identifyingAttributes>
 								<attributes>
+									<attribute key="id" xsi:type="stringAttribute">multi_true_1</attribute>
 									<attribute key="outline" xsi:type="outlineAttribute">
 										<x>478</x>
 										<y>116</y>
 										<height>17</height>
 										<width>54</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[5]/OPTION[1]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[5]/OPTION[1]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 									<attribute key="text" xsi:type="textAttribute">select_1</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -3050,18 +2779,6 @@
 							</identifyingAttributes>
 							<attributes>
 								<attributes>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">Arial</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">13.3333px</value>
-									</entry>
 									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">16px</value>
@@ -3085,16 +2802,17 @@
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="select_2">
 							<identifyingAttributes>
 								<attributes>
+									<attribute key="id" xsi:type="stringAttribute">multi_true_2</attribute>
 									<attribute key="outline" xsi:type="outlineAttribute">
 										<x>478</x>
 										<y>133</y>
 										<height>17</height>
 										<width>54</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[5]/OPTION[2]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[5]/OPTION[2]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 									<attribute key="text" xsi:type="textAttribute">select_2</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -3102,18 +2820,6 @@
 							</identifyingAttributes>
 							<attributes>
 								<attributes>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">Arial</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">13.3333px</value>
-									</entry>
 									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">16px</value>
@@ -3138,16 +2844,17 @@
 							</attributes>
 						</containedComponents>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="select">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="name" xsi:type="stringAttribute">multi_false</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>551</x>
 									<y>115</y>
 									<height>70</height>
 									<width>71</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[6]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[6]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">6</attribute>
 								<attribute key="type" xsi:type="stringAttribute">SELECT</attribute>
 							</attributes>
@@ -3175,10 +2882,6 @@
 									<value xsi:type="xsd:string">1px</value>
 								</entry>
 								<entry>
-									<key>border-image-width</key>
-									<value xsi:type="xsd:string">1</value>
-								</entry>
-								<entry>
 									<key>border-left-color</key>
 									<value xsi:type="xsd:string">rgb(169, 169, 169)</value>
 								</entry>
@@ -3260,16 +2963,17 @@
 								</entry>
 							</attributes>
 						</attributes>
-						<containedComponents>
+						<containedComponents retestId="select_1">
 							<identifyingAttributes>
 								<attributes>
+									<attribute key="id" xsi:type="stringAttribute">multi_false_1</attribute>
 									<attribute key="outline" xsi:type="outlineAttribute">
 										<x>552</x>
 										<y>116</y>
 										<height>17</height>
 										<width>54</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[6]/OPTION[1]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[6]/OPTION[1]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 									<attribute key="text" xsi:type="textAttribute">select_1</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -3277,18 +2981,6 @@
 							</identifyingAttributes>
 							<attributes>
 								<attributes>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">Arial</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">13.3333px</value>
-									</entry>
 									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">16px</value>
@@ -3312,16 +3004,17 @@
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="select_2">
 							<identifyingAttributes>
 								<attributes>
+									<attribute key="id" xsi:type="stringAttribute">multi_false_2</attribute>
 									<attribute key="outline" xsi:type="outlineAttribute">
 										<x>552</x>
 										<y>133</y>
 										<height>17</height>
 										<width>54</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[6]/OPTION[2]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[6]/OPTION[2]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 									<attribute key="text" xsi:type="textAttribute">select_2</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -3329,18 +3022,6 @@
 							</identifyingAttributes>
 							<attributes>
 								<attributes>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">Arial</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">13.3333px</value>
-									</entry>
 									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">16px</value>
@@ -3365,16 +3046,17 @@
 							</attributes>
 						</containedComponents>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="select">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">invisi_select</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>626</x>
 									<y>168</y>
 									<height>19</height>
 									<width>74</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[7]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[7]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">7</attribute>
 								<attribute key="type" xsi:type="stringAttribute">SELECT</attribute>
 							</attributes>
@@ -3400,10 +3082,6 @@
 								<entry>
 									<key>border-bottom-width</key>
 									<value xsi:type="xsd:string">1px</value>
-								</entry>
-								<entry>
-									<key>border-image-width</key>
-									<value xsi:type="xsd:string">1</value>
 								</entry>
 								<entry>
 									<key>border-left-color</key>
@@ -3475,7 +3153,7 @@
 								</entry>
 							</attributes>
 						</attributes>
-						<containedComponents>
+						<containedComponents retestId="apples">
 							<identifyingAttributes>
 								<attributes>
 									<attribute key="outline" xsi:type="outlineAttribute">
@@ -3484,7 +3162,7 @@
 										<height>0</height>
 										<width>0</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[7]/OPTION[1]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[7]/OPTION[1]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 									<attribute key="text" xsi:type="textAttribute">Apples</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -3493,18 +3171,6 @@
 							<attributes>
 								<attributes>
 									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">Arial</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">13.3333px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">16px</value>
 									</entry>
@@ -3520,14 +3186,10 @@
 										<key>padding-right</key>
 										<value xsi:type="xsd:string">2px</value>
 									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">pre</value>
-									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="oranges">
 							<identifyingAttributes>
 								<attributes>
 									<attribute key="outline" xsi:type="outlineAttribute">
@@ -3536,7 +3198,7 @@
 										<height>0</height>
 										<width>0</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[7]/OPTION[2]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[7]/OPTION[2]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 									<attribute key="text" xsi:type="textAttribute">Oranges</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -3544,18 +3206,6 @@
 							</identifyingAttributes>
 							<attributes>
 								<attributes>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">Arial</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">13.3333px</value>
-									</entry>
 									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">16px</value>
@@ -3572,24 +3222,21 @@
 										<key>padding-right</key>
 										<value xsi:type="xsd:string">2px</value>
 									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">pre</value>
-									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="select">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="name" xsi:type="stringAttribute">select-default</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>704</x>
 									<y>168</y>
 									<height>19</height>
 									<width>244</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[8]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[8]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">8</attribute>
 								<attribute key="type" xsi:type="stringAttribute">SELECT</attribute>
 							</attributes>
@@ -3617,10 +3264,6 @@
 									<value xsi:type="xsd:string">1px</value>
 								</entry>
 								<entry>
-									<key>border-image-width</key>
-									<value xsi:type="xsd:string">1</value>
-								</entry>
-								<entry>
 									<key>border-left-color</key>
 									<value xsi:type="xsd:string">rgb(169, 169, 169)</value>
 								</entry>
@@ -3686,7 +3329,7 @@
 								</entry>
 							</attributes>
 						</attributes>
-						<containedComponents>
+						<containedComponents retestId="one">
 							<identifyingAttributes>
 								<attributes>
 									<attribute key="outline" xsi:type="outlineAttribute">
@@ -3695,7 +3338,7 @@
 										<height>0</height>
 										<width>0</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[8]/OPTION[1]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[8]/OPTION[1]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 									<attribute key="text" xsi:type="textAttribute">One</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -3704,18 +3347,6 @@
 							<attributes>
 								<attributes>
 									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">Arial</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">13.3333px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">16px</value>
 									</entry>
@@ -3731,14 +3362,10 @@
 										<key>padding-right</key>
 										<value xsi:type="xsd:string">2px</value>
 									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">pre</value>
-									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="two">
 							<identifyingAttributes>
 								<attributes>
 									<attribute key="outline" xsi:type="outlineAttribute">
@@ -3747,7 +3374,7 @@
 										<height>0</height>
 										<width>0</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[8]/OPTION[2]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[8]/OPTION[2]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 									<attribute key="text" xsi:type="textAttribute">Two</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -3756,18 +3383,6 @@
 							<attributes>
 								<attributes>
 									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">Arial</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">13.3333px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">16px</value>
 									</entry>
@@ -3783,14 +3398,10 @@
 										<key>padding-right</key>
 										<value xsi:type="xsd:string">2px</value>
 									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">pre</value>
-									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="four">
 							<identifyingAttributes>
 								<attributes>
 									<attribute key="outline" xsi:type="outlineAttribute">
@@ -3799,7 +3410,7 @@
 										<height>0</height>
 										<width>0</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[8]/OPTION[3]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[8]/OPTION[3]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">3</attribute>
 									<attribute key="text" xsi:type="textAttribute">Four</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -3808,18 +3419,6 @@
 							<attributes>
 								<attributes>
 									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">Arial</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">13.3333px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">16px</value>
 									</entry>
@@ -3835,14 +3434,10 @@
 										<key>padding-right</key>
 										<value xsi:type="xsd:string">2px</value>
 									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">pre</value>
-									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="still_learning">
 							<identifyingAttributes>
 								<attributes>
 									<attribute key="outline" xsi:type="outlineAttribute">
@@ -3851,7 +3446,7 @@
 										<height>0</height>
 										<width>0</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[8]/OPTION[4]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[8]/OPTION[4]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">4</attribute>
 									<attribute key="text" xsi:type="textAttribute">Still learning how to count, apparently</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -3859,18 +3454,6 @@
 							</identifyingAttributes>
 							<attributes>
 								<attributes>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">Arial</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">13.3333px</value>
-									</entry>
 									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">16px</value>
@@ -3887,24 +3470,21 @@
 										<key>padding-right</key>
 										<value xsi:type="xsd:string">2px</value>
 									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">pre</value>
-									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="select">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="name" xsi:type="stringAttribute">select_with_spaces</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>8</x>
 									<y>187</y>
 									<height>19</height>
 									<width>244</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[9]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[9]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">9</attribute>
 								<attribute key="type" xsi:type="stringAttribute">SELECT</attribute>
 							</attributes>
@@ -3932,10 +3512,6 @@
 									<value xsi:type="xsd:string">1px</value>
 								</entry>
 								<entry>
-									<key>border-image-width</key>
-									<value xsi:type="xsd:string">1</value>
-								</entry>
-								<entry>
 									<key>border-left-color</key>
 									<value xsi:type="xsd:string">rgb(169, 169, 169)</value>
 								</entry>
@@ -4001,7 +3577,7 @@
 								</entry>
 							</attributes>
 						</attributes>
-						<containedComponents>
+						<containedComponents retestId="one">
 							<identifyingAttributes>
 								<attributes>
 									<attribute key="outline" xsi:type="outlineAttribute">
@@ -4010,7 +3586,7 @@
 										<height>0</height>
 										<width>0</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[9]/OPTION[1]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[9]/OPTION[1]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 									<attribute key="text" xsi:type="textAttribute">One</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -4019,18 +3595,6 @@
 							<attributes>
 								<attributes>
 									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">Arial</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">13.3333px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">16px</value>
 									</entry>
@@ -4046,14 +3610,10 @@
 										<key>padding-right</key>
 										<value xsi:type="xsd:string">2px</value>
 									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">pre</value>
-									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="two">
 							<identifyingAttributes>
 								<attributes>
 									<attribute key="outline" xsi:type="outlineAttribute">
@@ -4062,7 +3622,7 @@
 										<height>0</height>
 										<width>0</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[9]/OPTION[2]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[9]/OPTION[2]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 									<attribute key="text" xsi:type="textAttribute">Two</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -4071,18 +3631,6 @@
 							<attributes>
 								<attributes>
 									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">Arial</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">13.3333px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">16px</value>
 									</entry>
@@ -4098,14 +3646,10 @@
 										<key>padding-right</key>
 										<value xsi:type="xsd:string">2px</value>
 									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">pre</value>
-									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="four">
 							<identifyingAttributes>
 								<attributes>
 									<attribute key="outline" xsi:type="outlineAttribute">
@@ -4114,7 +3658,7 @@
 										<height>0</height>
 										<width>0</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[9]/OPTION[3]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[9]/OPTION[3]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">3</attribute>
 									<attribute key="text" xsi:type="textAttribute">Four</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -4123,18 +3667,6 @@
 							<attributes>
 								<attributes>
 									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">Arial</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">13.3333px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">16px</value>
 									</entry>
@@ -4150,14 +3682,10 @@
 										<key>padding-right</key>
 										<value xsi:type="xsd:string">2px</value>
 									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">pre</value>
-									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="still_learning">
 							<identifyingAttributes>
 								<attributes>
 									<attribute key="outline" xsi:type="outlineAttribute">
@@ -4166,7 +3694,7 @@
 										<height>0</height>
 										<width>0</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[9]/OPTION[4]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[9]/OPTION[4]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">4</attribute>
 									<attribute key="text" xsi:type="textAttribute">Still learning how to count, apparently</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -4174,18 +3702,6 @@
 							</identifyingAttributes>
 							<attributes>
 								<attributes>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">Arial</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">13.3333px</value>
-									</entry>
 									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">16px</value>
@@ -4202,40 +3718,38 @@
 										<key>padding-right</key>
 										<value xsi:type="xsd:string">2px</value>
 									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">pre</value>
-									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
 					</containedComponents>
 				</containedComponents>
-				<containedComponents>
+				<containedComponents retestId="form">
 					<identifyingAttributes>
 						<attributes>
+							<attribute key="name" xsi:type="stringAttribute">disable</attribute>
 							<attribute key="outline" xsi:type="outlineAttribute">
 								<x>8</x>
 								<y>394</y>
 								<height>85</height>
 								<width>1184</width>
 							</attribute>
-							<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[4]</attribute>
+							<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[4]</attribute>
 							<attribute key="suffix" xsi:type="suffixAttribute">4</attribute>
 							<attribute key="type" xsi:type="stringAttribute">FORM</attribute>
 						</attributes>
 					</identifyingAttributes>
 					<attributes/>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">working</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>8</x>
 									<y>458</y>
 									<height>21</height>
 									<width>181</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[4]/INPUT[1]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[4]/INPUT[1]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -4299,10 +3813,6 @@
 									<value xsi:type="xsd:string">0px</value>
 								</entry>
 								<entry>
-									<key>margin-top</key>
-									<value xsi:type="xsd:string">0px</value>
-								</entry>
-								<entry>
 									<key>padding-bottom</key>
 									<value xsi:type="xsd:string">1px</value>
 								</entry>
@@ -4313,16 +3823,17 @@
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">notWorking</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>193</x>
 									<y>458</y>
 									<height>21</height>
 									<width>181</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[4]/INPUT[2]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[4]/INPUT[2]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -4414,10 +3925,6 @@
 									<value xsi:type="xsd:string">0px</value>
 								</entry>
 								<entry>
-									<key>margin-top</key>
-									<value xsi:type="xsd:string">0px</value>
-								</entry>
-								<entry>
 									<key>outline-color</key>
 									<value xsi:type="xsd:string">rgb(84, 84, 84)</value>
 								</entry>
@@ -4436,16 +3943,17 @@
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">inputWithText</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>441</x>
 									<y>458</y>
 									<height>21</height>
 									<width>181</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[4]/INPUT[3]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[4]/INPUT[3]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">3</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -4509,10 +4017,6 @@
 									<value xsi:type="xsd:string">0px</value>
 								</entry>
 								<entry>
-									<key>margin-top</key>
-									<value xsi:type="xsd:string">0px</value>
-								</entry>
-								<entry>
 									<key>padding-bottom</key>
 									<value xsi:type="xsd:string">1px</value>
 								</entry>
@@ -4523,16 +4027,17 @@
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="textarea">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">notWorkingArea</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>378</x>
 									<y>394</y>
 									<height>79</height>
 									<width>59</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[4]/TEXTAREA[1]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[4]/TEXTAREA[1]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 								<attribute key="type" xsi:type="stringAttribute">TEXTAREA</attribute>
 							</attributes>
@@ -4554,10 +4059,6 @@
 								<entry>
 									<key>border-bottom-width</key>
 									<value xsi:type="xsd:string">1px</value>
-								</entry>
-								<entry>
-									<key>border-image-width</key>
-									<value xsi:type="xsd:string">1</value>
 								</entry>
 								<entry>
 									<key>border-left-color</key>
@@ -4678,16 +4179,17 @@
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="example_text">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">withText</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>626</x>
 									<y>394</y>
 									<height>79</height>
 									<width>59</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[4]/TEXTAREA[2]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[4]/TEXTAREA[2]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 								<attribute key="text" xsi:type="textAttribute">Example text</attribute>
 								<attribute key="type" xsi:type="stringAttribute">TEXTAREA</attribute>
@@ -4712,10 +4214,6 @@
 									<value xsi:type="xsd:string">1px</value>
 								</entry>
 								<entry>
-									<key>border-image-width</key>
-									<value xsi:type="xsd:string">1</value>
-								</entry>
-								<entry>
 									<key>border-left-color</key>
 									<value xsi:type="xsd:string">rgb(169, 169, 169)</value>
 								</entry>
@@ -4814,16 +4312,17 @@
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="textarea">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">emptyTextArea</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>689</x>
 									<y>394</y>
 									<height>79</height>
 									<width>59</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[4]/TEXTAREA[3]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[4]/TEXTAREA[3]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">3</attribute>
 								<attribute key="type" xsi:type="stringAttribute">TEXTAREA</attribute>
 							</attributes>
@@ -4845,10 +4344,6 @@
 								<entry>
 									<key>border-bottom-width</key>
 									<value xsi:type="xsd:string">1px</value>
-								</entry>
-								<entry>
-									<key>border-image-width</key>
-									<value xsi:type="xsd:string">1</value>
 								</entry>
 								<entry>
 									<key>border-left-color</key>
@@ -4950,7 +4445,7 @@
 						</attributes>
 					</containedComponents>
 				</containedComponents>
-				<containedComponents>
+				<containedComponents retestId="form">
 					<identifyingAttributes>
 						<attributes>
 							<attribute key="outline" xsi:type="outlineAttribute">
@@ -4959,22 +4454,23 @@
 								<height>21</height>
 								<width>1184</width>
 							</attribute>
-							<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[5]</attribute>
+							<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[5]</attribute>
 							<attribute key="suffix" xsi:type="suffixAttribute">5</attribute>
 							<attribute key="type" xsi:type="stringAttribute">FORM</attribute>
 						</attributes>
 					</identifyingAttributes>
 					<attributes/>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">no-type</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>60</x>
 									<y>495</y>
 									<height>21</height>
 									<width>181</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[5]/INPUT[1]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[5]/INPUT[1]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -5038,10 +4534,6 @@
 									<value xsi:type="xsd:string">0px</value>
 								</entry>
 								<entry>
-									<key>margin-top</key>
-									<value xsi:type="xsd:string">0px</value>
-								</entry>
-								<entry>
 									<key>padding-bottom</key>
 									<value xsi:type="xsd:string">1px</value>
 								</entry>
@@ -5052,16 +4544,17 @@
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">upload</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>245</x>
 									<y>495</y>
 									<height>21</height>
 									<width>253</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[5]/INPUT[2]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[5]/INPUT[2]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -5084,14 +4577,10 @@
 									<key>margin-bottom</key>
 									<value xsi:type="xsd:string">0px</value>
 								</entry>
-								<entry>
-									<key>margin-top</key>
-									<value xsi:type="xsd:string">0px</value>
-								</entry>
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
 								<attribute key="outline" xsi:type="outlineAttribute">
@@ -5100,7 +4589,7 @@
 									<height>21</height>
 									<width>62</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[5]/INPUT[3]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[5]/INPUT[3]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">3</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -5184,10 +4673,6 @@
 									<value xsi:type="xsd:string">0px</value>
 								</entry>
 								<entry>
-									<key>margin-top</key>
-									<value xsi:type="xsd:string">0px</value>
-								</entry>
-								<entry>
 									<key>padding-bottom</key>
 									<value xsi:type="xsd:string">1px</value>
 								</entry>
@@ -5214,16 +4699,18 @@
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="select">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">redirect</attribute>
+								<attribute key="name" xsi:type="stringAttribute">redirect</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>8</x>
 									<y>496</y>
 									<height>19</height>
 									<width>48</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[5]/SELECT[1]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[5]/SELECT[1]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 								<attribute key="type" xsi:type="stringAttribute">SELECT</attribute>
 							</attributes>
@@ -5249,10 +4736,6 @@
 								<entry>
 									<key>border-bottom-width</key>
 									<value xsi:type="xsd:string">1px</value>
-								</entry>
-								<entry>
-									<key>border-image-width</key>
-									<value xsi:type="xsd:string">1</value>
 								</entry>
 								<entry>
 									<key>border-left-color</key>
@@ -5320,7 +4803,7 @@
 								</entry>
 							</attributes>
 						</attributes>
-						<containedComponents>
+						<containedComponents retestId="one">
 							<identifyingAttributes>
 								<attributes>
 									<attribute key="outline" xsi:type="outlineAttribute">
@@ -5329,7 +4812,7 @@
 										<height>0</height>
 										<width>0</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[5]/SELECT[1]/OPTION[1]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[5]/SELECT[1]/OPTION[1]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 									<attribute key="text" xsi:type="textAttribute">One</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -5338,18 +4821,6 @@
 							<attributes>
 								<attributes>
 									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">Arial</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">13.3333px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">16px</value>
 									</entry>
@@ -5365,23 +4836,20 @@
 										<key>padding-right</key>
 										<value xsi:type="xsd:string">2px</value>
 									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">pre</value>
-									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="two">
 							<identifyingAttributes>
 								<attributes>
+									<attribute key="id" xsi:type="stringAttribute">changeme</attribute>
 									<attribute key="outline" xsi:type="outlineAttribute">
 										<x>0</x>
 										<y>0</y>
 										<height>0</height>
 										<width>0</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[5]/SELECT[1]/OPTION[2]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[5]/SELECT[1]/OPTION[2]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 									<attribute key="text" xsi:type="textAttribute">Two</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -5390,18 +4858,6 @@
 							<attributes>
 								<attributes>
 									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">Arial</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">13.3333px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">16px</value>
 									</entry>
@@ -5417,24 +4873,21 @@
 										<key>padding-right</key>
 										<value xsi:type="xsd:string">2px</value>
 									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">pre</value>
-									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="span">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">fileResults</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>8</x>
 									<y>495</y>
 									<height>0</height>
 									<width>0</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[5]/SPAN[1]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[5]/SPAN[1]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 								<attribute key="type" xsi:type="stringAttribute">SPAN</attribute>
 							</attributes>
@@ -5442,7 +4895,7 @@
 						<attributes/>
 					</containedComponents>
 				</containedComponents>
-				<containedComponents>
+				<containedComponents retestId="form">
 					<identifyingAttributes>
 						<attributes>
 							<attribute key="outline" xsi:type="outlineAttribute">
@@ -5451,22 +4904,23 @@
 								<height>21</height>
 								<width>1184</width>
 							</attribute>
-							<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[6]</attribute>
+							<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[6]</attribute>
 							<attribute key="suffix" xsi:type="suffixAttribute">6</attribute>
 							<attribute key="type" xsi:type="stringAttribute">FORM</attribute>
 						</attributes>
 					</identifyingAttributes>
 					<attributes/>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="name" xsi:type="stringAttribute">id-name1</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>8</x>
 									<y>532</y>
 									<height>21</height>
 									<width>181</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[6]/INPUT[1]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[6]/INPUT[1]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -5530,10 +4984,6 @@
 									<value xsi:type="xsd:string">0px</value>
 								</entry>
 								<entry>
-									<key>margin-top</key>
-									<value xsi:type="xsd:string">0px</value>
-								</entry>
-								<entry>
 									<key>padding-bottom</key>
 									<value xsi:type="xsd:string">1px</value>
 								</entry>
@@ -5544,16 +4994,17 @@
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">id-name1</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>193</x>
 									<y>532</y>
 									<height>21</height>
 									<width>181</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[6]/INPUT[2]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[6]/INPUT[2]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -5617,10 +5068,6 @@
 									<value xsi:type="xsd:string">0px</value>
 								</entry>
 								<entry>
-									<key>margin-top</key>
-									<value xsi:type="xsd:string">0px</value>
-								</entry>
-								<entry>
 									<key>padding-bottom</key>
 									<value xsi:type="xsd:string">1px</value>
 								</entry>
@@ -5631,16 +5078,17 @@
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">id-name2</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>378</x>
 									<y>532</y>
 									<height>21</height>
 									<width>181</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[6]/INPUT[3]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[6]/INPUT[3]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">3</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -5704,10 +5152,6 @@
 									<value xsi:type="xsd:string">0px</value>
 								</entry>
 								<entry>
-									<key>margin-top</key>
-									<value xsi:type="xsd:string">0px</value>
-								</entry>
-								<entry>
 									<key>padding-bottom</key>
 									<value xsi:type="xsd:string">1px</value>
 								</entry>
@@ -5718,16 +5162,17 @@
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="name" xsi:type="stringAttribute">id-name2</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>563</x>
 									<y>532</y>
 									<height>21</height>
 									<width>181</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[6]/INPUT[4]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[6]/INPUT[4]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">4</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -5791,10 +5236,6 @@
 									<value xsi:type="xsd:string">0px</value>
 								</entry>
 								<entry>
-									<key>margin-top</key>
-									<value xsi:type="xsd:string">0px</value>
-								</entry>
-								<entry>
 									<key>padding-bottom</key>
 									<value xsi:type="xsd:string">1px</value>
 								</entry>
@@ -5805,16 +5246,17 @@
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="name" xsi:type="stringAttribute">readonly</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>748</x>
 									<y>532</y>
 									<height>21</height>
 									<width>181</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[6]/INPUT[5]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[6]/INPUT[5]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">5</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -5878,10 +5320,6 @@
 									<value xsi:type="xsd:string">0px</value>
 								</entry>
 								<entry>
-									<key>margin-top</key>
-									<value xsi:type="xsd:string">0px</value>
-								</entry>
-								<entry>
 									<key>padding-bottom</key>
 									<value xsi:type="xsd:string">1px</value>
 								</entry>
@@ -5893,22 +5331,23 @@
 						</attributes>
 					</containedComponents>
 				</containedComponents>
-				<containedComponents>
+				<containedComponents retestId="form">
 					<identifyingAttributes>
 						<attributes>
+							<attribute key="id" xsi:type="stringAttribute">nested_form</attribute>
 							<attribute key="outline" xsi:type="outlineAttribute">
 								<x>8</x>
 								<y>569</y>
 								<height>42</height>
 								<width>1184</width>
 							</attribute>
-							<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[7]</attribute>
+							<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[7]</attribute>
 							<attribute key="suffix" xsi:type="suffixAttribute">7</attribute>
 							<attribute key="type" xsi:type="stringAttribute">FORM</attribute>
 						</attributes>
 					</identifyingAttributes>
 					<attributes/>
-					<containedComponents>
+					<containedComponents retestId="div">
 						<identifyingAttributes>
 							<attributes>
 								<attribute key="outline" xsi:type="outlineAttribute">
@@ -5917,22 +5356,23 @@
 									<height>21</height>
 									<width>1184</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[7]/DIV[1]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[7]/DIV[1]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 								<attribute key="type" xsi:type="stringAttribute">DIV</attribute>
 							</attributes>
 						</identifyingAttributes>
 						<attributes/>
-						<containedComponents>
+						<containedComponents retestId="input">
 							<identifyingAttributes>
 								<attributes>
+									<attribute key="name" xsi:type="stringAttribute">x</attribute>
 									<attribute key="outline" xsi:type="outlineAttribute">
 										<x>8</x>
 										<y>569</y>
 										<height>21</height>
 										<width>181</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[7]/DIV[1]/INPUT[1]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[7]/DIV[1]/INPUT[1]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 									<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 								</attributes>
@@ -5992,14 +5432,6 @@
 										<value xsi:type="xsd:string">13.3333px</value>
 									</entry>
 									<entry>
-										<key>margin-bottom</key>
-										<value xsi:type="xsd:string">0px</value>
-									</entry>
-									<entry>
-										<key>margin-top</key>
-										<value xsi:type="xsd:string">0px</value>
-									</entry>
-									<entry>
 										<key>padding-bottom</key>
 										<value xsi:type="xsd:string">1px</value>
 									</entry>
@@ -6011,7 +5443,7 @@
 							</attributes>
 						</containedComponents>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
 								<attribute key="outline" xsi:type="outlineAttribute">
@@ -6020,7 +5452,7 @@
 									<height>21</height>
 									<width>62</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[7]/INPUT[1]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[7]/INPUT[1]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -6104,10 +5536,6 @@
 									<value xsi:type="xsd:string">0px</value>
 								</entry>
 								<entry>
-									<key>margin-top</key>
-									<value xsi:type="xsd:string">0px</value>
-								</entry>
-								<entry>
 									<key>padding-bottom</key>
 									<value xsi:type="xsd:string">1px</value>
 								</entry>
@@ -6135,7 +5563,7 @@
 						</attributes>
 					</containedComponents>
 				</containedComponents>
-				<containedComponents>
+				<containedComponents retestId="form">
 					<identifyingAttributes>
 						<attributes>
 							<attribute key="outline" xsi:type="outlineAttribute">
@@ -6144,13 +5572,13 @@
 								<height>21</height>
 								<width>1184</width>
 							</attribute>
-							<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[8]</attribute>
+							<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[8]</attribute>
 							<attribute key="suffix" xsi:type="suffixAttribute">8</attribute>
 							<attribute key="type" xsi:type="stringAttribute">FORM</attribute>
 						</attributes>
 					</identifyingAttributes>
 					<attributes/>
-					<containedComponents>
+					<containedComponents retestId="p">
 						<identifyingAttributes>
 							<attributes>
 								<attribute key="outline" xsi:type="outlineAttribute">
@@ -6159,22 +5587,23 @@
 									<height>21</height>
 									<width>1184</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[8]/P[1]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[8]/P[1]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 								<attribute key="type" xsi:type="stringAttribute">P</attribute>
 							</attributes>
 						</identifyingAttributes>
 						<attributes/>
-						<containedComponents>
+						<containedComponents retestId="input">
 							<identifyingAttributes>
 								<attributes>
+									<attribute key="id" xsi:type="stringAttribute">disabledTextElement1</attribute>
 									<attribute key="outline" xsi:type="outlineAttribute">
 										<x>8</x>
 										<y>627</y>
 										<height>21</height>
 										<width>181</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[8]/P[1]/INPUT[1]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[8]/P[1]/INPUT[1]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 									<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 								</attributes>
@@ -6288,16 +5717,17 @@
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="input">
 							<identifyingAttributes>
 								<attributes>
+									<attribute key="id" xsi:type="stringAttribute">disabledTextElement2</attribute>
 									<attribute key="outline" xsi:type="outlineAttribute">
 										<x>193</x>
 										<y>627</y>
 										<height>21</height>
 										<width>181</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[8]/P[1]/INPUT[2]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[8]/P[1]/INPUT[2]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 									<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 								</attributes>
@@ -6411,16 +5841,17 @@
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="input">
 							<identifyingAttributes>
 								<attributes>
+									<attribute key="id" xsi:type="stringAttribute">disabledSubmitElement</attribute>
 									<attribute key="outline" xsi:type="outlineAttribute">
 										<x>378</x>
 										<y>627</y>
 										<height>21</height>
 										<width>57</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[8]/P[1]/INPUT[3]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[8]/P[1]/INPUT[3]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">3</attribute>
 									<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 								</attributes>
@@ -6556,7 +5987,7 @@
 						</containedComponents>
 					</containedComponents>
 				</containedComponents>
-				<containedComponents>
+				<containedComponents retestId="form">
 					<identifyingAttributes>
 						<attributes>
 							<attribute key="outline" xsi:type="outlineAttribute">
@@ -6565,13 +5996,13 @@
 								<height>20</height>
 								<width>1184</width>
 							</attribute>
-							<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[9]</attribute>
+							<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[9]</attribute>
 							<attribute key="suffix" xsi:type="suffixAttribute">9</attribute>
 							<attribute key="type" xsi:type="stringAttribute">FORM</attribute>
 						</attributes>
 					</identifyingAttributes>
 					<attributes/>
-					<containedComponents>
+					<containedComponents retestId="p">
 						<identifyingAttributes>
 							<attributes>
 								<attribute key="outline" xsi:type="outlineAttribute">
@@ -6580,22 +6011,23 @@
 									<height>20</height>
 									<width>1184</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[9]/P[1]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[9]/P[1]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 								<attribute key="type" xsi:type="stringAttribute">P</attribute>
 							</attributes>
 						</identifyingAttributes>
 						<attributes/>
-						<containedComponents>
+						<containedComponents retestId="input">
 							<identifyingAttributes>
 								<attributes>
+									<attribute key="id" xsi:type="stringAttribute">checkbox-with-label</attribute>
 									<attribute key="outline" xsi:type="outlineAttribute">
 										<x>48</x>
 										<y>704</y>
 										<height>13</height>
 										<width>13</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[9]/P[1]/INPUT[1]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[9]/P[1]/INPUT[1]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 									<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 								</attributes>
@@ -6629,16 +6061,17 @@
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="label">
 							<identifyingAttributes>
 								<attributes>
+									<attribute key="id" xsi:type="stringAttribute">label-for-checkbox-with-label</attribute>
 									<attribute key="outline" xsi:type="outlineAttribute">
 										<x>8</x>
 										<y>703</y>
 										<height>17</height>
 										<width>36</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[9]/P[1]/LABEL[1]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[9]/P[1]/LABEL[1]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 									<attribute key="text" xsi:type="textAttribute">Label</attribute>
 									<attribute key="type" xsi:type="stringAttribute">LABEL</attribute>
@@ -6648,16 +6081,17 @@
 						</containedComponents>
 					</containedComponents>
 				</containedComponents>
-				<containedComponents>
+				<containedComponents retestId="input">
 					<identifyingAttributes>
 						<attributes>
+							<attribute key="id" xsi:type="stringAttribute">killIframe</attribute>
 							<attribute key="outline" xsi:type="outlineAttribute">
 								<x>8</x>
 								<y>664</y>
 								<height>21</height>
 								<width>139</width>
 							</attribute>
-							<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/INPUT[1]</attribute>
+							<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/INPUT[1]</attribute>
 							<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 							<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 						</attributes>
@@ -6771,16 +6205,19 @@
 						</attributes>
 					</attributes>
 				</containedComponents>
-				<containedComponents>
+				<containedComponents retestId="input">
 					<identifyingAttributes>
 						<attributes>
+							<attribute key="class" xsi:type="stringAttribute">inputLabel</attribute>
+							<attribute key="id" xsi:type="stringAttribute">vsearchGadget</attribute>
+							<attribute key="name" xsi:type="stringAttribute">SearchableText</attribute>
 							<attribute key="outline" xsi:type="outlineAttribute">
 								<x>8</x>
 								<y>737</y>
 								<height>21</height>
 								<width>165</width>
 							</attribute>
-							<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/INPUT[2]</attribute>
+							<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/INPUT[2]</attribute>
 							<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 							<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 						</attributes>
@@ -6859,7 +6296,7 @@
 					</attributes>
 				</containedComponents>
 			</containedComponents>
-			<containedComponents>
+			<containedComponents retestId="head">
 				<identifyingAttributes>
 					<attributes>
 						<attribute key="outline" xsi:type="outlineAttribute">
@@ -6868,13 +6305,13 @@
 							<height>0</height>
 							<width>0</width>
 						</attribute>
-						<attribute key="path" xsi:type="pathAttribute">//HTML[1]/HEAD[1]</attribute>
+						<attribute key="path" xsi:type="pathAttribute">HTML[1]/HEAD[1]</attribute>
 						<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 						<attribute key="type" xsi:type="stringAttribute">HEAD</attribute>
 					</attributes>
 				</identifyingAttributes>
 				<attributes/>
-				<containedComponents>
+				<containedComponents retestId="function_change">
 					<identifyingAttributes>
 						<attributes>
 							<attribute key="outline" xsi:type="outlineAttribute">
@@ -6883,7 +6320,7 @@
 								<height>0</height>
 								<width>0</width>
 							</attribute>
-							<attribute key="path" xsi:type="pathAttribute">//HTML[1]/HEAD[1]/SCRIPT[1]</attribute>
+							<attribute key="path" xsi:type="pathAttribute">HTML[1]/HEAD[1]/SCRIPT[1]</attribute>
 							<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 							<attribute key="text" xsi:type="textAttribute">function changePage() {
             var newLocation = '/common/page/3';
@@ -6894,7 +6331,7 @@
 					</identifyingAttributes>
 					<attributes/>
 				</containedComponents>
-				<containedComponents>
+				<containedComponents retestId="we_leave_from">
 					<identifyingAttributes>
 						<attributes>
 							<attribute key="outline" xsi:type="outlineAttribute">
@@ -6903,7 +6340,7 @@
 								<height>0</height>
 								<width>0</width>
 							</attribute>
-							<attribute key="path" xsi:type="pathAttribute">//HTML[1]/HEAD[1]/TITLE[1]</attribute>
+							<attribute key="path" xsi:type="pathAttribute">HTML[1]/HEAD[1]/TITLE[1]</attribute>
 							<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 							<attribute key="text" xsi:type="textAttribute">We Leave From Here</attribute>
 							<attribute key="type" xsi:type="stringAttribute">TITLE</attribute>

--- a/src/test/resources/retest/recheck/de.retest.web.PageFrameIT/page-frame-FirefoxDriver.open.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.PageFrameIT/page-frame-FirefoxDriver.open.recheck/retest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<reTestXmlDataContainer xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" reTestVersion="2.4.1" dataType="de.retest.ui.descriptors.SutState" dataTypeVersion="1">
+<reTestXmlDataContainer xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" reTestVersion="3.0.0" dataType="de.retest.ui.descriptors.SutState" dataTypeVersion="2">
 	<data xsi:type="sutState">
-		<descriptors screenId="1" screen="We Leave From Here" title="We Leave From Here">
+		<descriptors retestId="html" screenId="1" screen="We Leave From Here" title="We Leave From Here">
 			<identifyingAttributes>
 				<attributes>
 					<attribute key="outline" xsi:type="outlineAttribute">
@@ -10,7 +10,7 @@
 						<height>908</height>
 						<width>1356</width>
 					</attribute>
-					<attribute key="path" xsi:type="pathAttribute">//HTML[1]</attribute>
+					<attribute key="path" xsi:type="pathAttribute">HTML[1]</attribute>
 					<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 					<attribute key="type" xsi:type="stringAttribute">HTML</attribute>
 				</attributes>
@@ -47,7 +47,7 @@
 					</entry>
 				</attributes>
 			</attributes>
-			<containedComponents>
+			<containedComponents retestId="there_should">
 				<identifyingAttributes>
 					<attributes>
 						<attribute key="outline" xsi:type="outlineAttribute">
@@ -56,147 +56,58 @@
 							<height>892</height>
 							<width>1340</width>
 						</attribute>
-						<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]</attribute>
+						<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]</attribute>
 						<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 						<attribute key="text" xsi:type="textAttribute">There should be a form here:</attribute>
 						<attribute key="type" xsi:type="stringAttribute">BODY</attribute>
 					</attributes>
 				</identifyingAttributes>
-				<attributes>
-					<attributes>
-						<entry>
-							<key>background-size</key>
-							<value xsi:type="xsd:string">auto auto</value>
-						</entry>
-						<entry>
-							<key>border-image-outset</key>
-							<value xsi:type="xsd:string">0</value>
-						</entry>
-						<entry>
-							<key>border-image-repeat</key>
-							<value xsi:type="xsd:string">stretch stretch</value>
-						</entry>
-						<entry>
-							<key>font-family</key>
-							<value xsi:type="xsd:string">serif</value>
-						</entry>
-						<entry>
-							<key>line-height</key>
-							<value xsi:type="xsd:string">19px</value>
-						</entry>
-						<entry>
-							<key>quotes</key>
-							<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-						</entry>
-						<entry>
-							<key>unicode-bidi</key>
-							<value xsi:type="xsd:string">isolate</value>
-						</entry>
-					</attributes>
-				</attributes>
-				<containedComponents>
+				<attributes/>
+				<containedComponents retestId="div">
 					<identifyingAttributes>
 						<attributes>
+							<attribute key="class" xsi:type="stringAttribute">gromit</attribute>
+							<attribute key="id" xsi:type="stringAttribute">wallace</attribute>
 							<attribute key="outline" xsi:type="outlineAttribute">
 								<x>8</x>
 								<y>785</y>
 								<height>0</height>
 								<width>1340</width>
 							</attribute>
-							<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/DIV[1]</attribute>
+							<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/DIV[1]</attribute>
 							<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 							<attribute key="type" xsi:type="stringAttribute">DIV</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">19px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>unicode-bidi</key>
-								<value xsi:type="xsd:string">isolate</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
-				<containedComponents>
+				<containedComponents retestId="form">
 					<identifyingAttributes>
 						<attributes>
+							<attribute key="name" xsi:type="stringAttribute">login</attribute>
 							<attribute key="outline" xsi:type="outlineAttribute">
 								<x>8</x>
 								<y>27</y>
 								<height>29</height>
 								<width>1340</width>
 							</attribute>
-							<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[1]</attribute>
+							<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[1]</attribute>
 							<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 							<attribute key="type" xsi:type="stringAttribute">FORM</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">19px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>unicode-bidi</key>
-								<value xsi:type="xsd:string">isolate</value>
-							</entry>
-						</attributes>
-					</attributes>
-					<containedComponents>
+					<attributes/>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">email</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>8</x>
 									<y>27</y>
 									<height>29</height>
 									<width>211</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[1]/INPUT[1]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[1]/INPUT[1]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -208,10 +119,6 @@
 									<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
 								</entry>
 								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
 									<key>border-bottom-color</key>
 									<value xsi:type="xsd:string">rgb(227, 227, 227)</value>
 								</entry>
@@ -222,14 +129,6 @@
 								<entry>
 									<key>border-bottom-width</key>
 									<value xsi:type="xsd:string">5px</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
 								</entry>
 								<entry>
 									<key>border-left-color</key>
@@ -300,10 +199,6 @@
 									<value xsi:type="xsd:string">0px</value>
 								</entry>
 								<entry>
-									<key>margin-top</key>
-									<value xsi:type="xsd:string">0px</value>
-								</entry>
-								<entry>
 									<key>outline-color</key>
 									<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 								</entry>
@@ -324,26 +219,23 @@
 									<value xsi:type="xsd:string">1px</value>
 								</entry>
 								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
 									<key>text-decoration-color</key>
 									<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 								</entry>
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">age</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>224</x>
 									<y>27</y>
 									<height>29</height>
 									<width>180</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[1]/INPUT[2]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[1]/INPUT[2]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -355,10 +247,6 @@
 									<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
 								</entry>
 								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
 									<key>border-bottom-color</key>
 									<value xsi:type="xsd:string">rgb(227, 227, 227)</value>
 								</entry>
@@ -369,14 +257,6 @@
 								<entry>
 									<key>border-bottom-width</key>
 									<value xsi:type="xsd:string">5px</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
 								</entry>
 								<entry>
 									<key>border-left-color</key>
@@ -447,10 +327,6 @@
 									<value xsi:type="xsd:string">0px</value>
 								</entry>
 								<entry>
-									<key>margin-top</key>
-									<value xsi:type="xsd:string">0px</value>
-								</entry>
-								<entry>
 									<key>outline-color</key>
 									<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 								</entry>
@@ -471,26 +347,23 @@
 									<value xsi:type="xsd:string">1px</value>
 								</entry>
 								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
 									<key>text-decoration-color</key>
 									<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 								</entry>
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">submitButton</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>409</x>
 									<y>27</y>
 									<height>29</height>
 									<width>109</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[1]/INPUT[3]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[1]/INPUT[3]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">3</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -500,10 +373,6 @@
 								<entry>
 									<key>background-color</key>
 									<value xsi:type="xsd:string">rgb(240, 240, 240)</value>
-								</entry>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
 								</entry>
 								<entry>
 									<key>border-bottom-color</key>
@@ -516,14 +385,6 @@
 								<entry>
 									<key>border-bottom-width</key>
 									<value xsi:type="xsd:string">6px</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
 								</entry>
 								<entry>
 									<key>border-left-color</key>
@@ -582,20 +443,12 @@
 									<value xsi:type="xsd:string">0px</value>
 								</entry>
 								<entry>
-									<key>margin-top</key>
-									<value xsi:type="xsd:string">0px</value>
-								</entry>
-								<entry>
 									<key>padding-left</key>
 									<value xsi:type="xsd:string">8px</value>
 								</entry>
 								<entry>
 									<key>padding-right</key>
 									<value xsi:type="xsd:string">8px</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
 								</entry>
 								<entry>
 									<key>text-align</key>
@@ -609,62 +462,33 @@
 						</attributes>
 					</containedComponents>
 				</containedComponents>
-				<containedComponents>
+				<containedComponents retestId="form">
 					<identifyingAttributes>
 						<attributes>
+							<attribute key="name" xsi:type="stringAttribute">image</attribute>
 							<attribute key="outline" xsi:type="outlineAttribute">
 								<x>8</x>
 								<y>72</y>
 								<height>17</height>
 								<width>1340</width>
 							</attribute>
-							<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[2]</attribute>
+							<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[2]</attribute>
 							<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 							<attribute key="type" xsi:type="stringAttribute">FORM</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">19px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>unicode-bidi</key>
-								<value xsi:type="xsd:string">isolate</value>
-							</entry>
-						</attributes>
-					</attributes>
-					<containedComponents>
+					<attributes/>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">imageButton</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>8</x>
 									<y>72</y>
 									<height>17</height>
 									<width>60</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[2]/INPUT[1]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[2]/INPUT[1]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -672,20 +496,8 @@
 						<attributes>
 							<attributes>
 								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
 									<key>border-bottom-color</key>
 									<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
 								</entry>
 								<entry>
 									<key>border-left-color</key>
@@ -698,10 +510,6 @@
 								<entry>
 									<key>border-top-color</key>
 									<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-								</entry>
-								<entry>
-									<key>box-sizing</key>
-									<value xsi:type="xsd:string">content-box</value>
 								</entry>
 								<entry>
 									<key>caret-color</key>
@@ -736,16 +544,8 @@
 									<value xsi:type="xsd:string">0px</value>
 								</entry>
 								<entry>
-									<key>margin-top</key>
-									<value xsi:type="xsd:string">0px</value>
-								</entry>
-								<entry>
 									<key>outline-color</key>
 									<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
 								</entry>
 								<entry>
 									<key>text-decoration-color</key>
@@ -755,54 +555,24 @@
 						</attributes>
 					</containedComponents>
 				</containedComponents>
-				<containedComponents>
+				<containedComponents retestId="heres_a_checkbox">
 					<identifyingAttributes>
 						<attributes>
+							<attribute key="name" xsi:type="stringAttribute">optional</attribute>
 							<attribute key="outline" xsi:type="outlineAttribute">
 								<x>8</x>
 								<y>105</y>
 								<height>342</height>
 								<width>1340</width>
 							</attribute>
-							<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]</attribute>
+							<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]</attribute>
 							<attribute key="suffix" xsi:type="suffixAttribute">3</attribute>
 							<attribute key="text" xsi:type="textAttribute">Here's a checkbox:</attribute>
 							<attribute key="type" xsi:type="stringAttribute">FORM</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">19px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>unicode-bidi</key>
-								<value xsi:type="xsd:string">isolate</value>
-							</entry>
-						</attributes>
-					</attributes>
-					<containedComponents>
+					<attributes/>
+					<containedComponents retestId="br">
 						<identifyingAttributes>
 							<attributes>
 								<attribute key="outline" xsi:type="outlineAttribute">
@@ -811,41 +581,14 @@
 									<height>0</height>
 									<width>0</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/BR[1]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/BR[1]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 								<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 							</attributes>
 						</identifyingAttributes>
-						<attributes>
-							<attributes>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">serif</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">19px</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-							</attributes>
-						</attributes>
+						<attributes/>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="br">
 						<identifyingAttributes>
 							<attributes>
 								<attribute key="outline" xsi:type="outlineAttribute">
@@ -854,41 +597,14 @@
 									<height>0</height>
 									<width>0</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/BR[2]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/BR[2]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 								<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 							</attributes>
 						</identifyingAttributes>
-						<attributes>
-							<attributes>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">serif</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">19px</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-							</attributes>
-						</attributes>
+						<attributes/>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="br">
 						<identifyingAttributes>
 							<attributes>
 								<attribute key="outline" xsi:type="outlineAttribute">
@@ -897,41 +613,14 @@
 									<height>0</height>
 									<width>0</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/BR[3]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/BR[3]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">3</attribute>
 								<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 							</attributes>
 						</identifyingAttributes>
-						<attributes>
-							<attributes>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">serif</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">19px</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-							</attributes>
-						</attributes>
+						<attributes/>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="br">
 						<identifyingAttributes>
 							<attributes>
 								<attribute key="outline" xsi:type="outlineAttribute">
@@ -940,41 +629,14 @@
 									<height>0</height>
 									<width>0</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/BR[4]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/BR[4]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">4</attribute>
 								<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 							</attributes>
 						</identifyingAttributes>
-						<attributes>
-							<attributes>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">serif</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">19px</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-							</attributes>
-						</attributes>
+						<attributes/>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="br">
 						<identifyingAttributes>
 							<attributes>
 								<attribute key="outline" xsi:type="outlineAttribute">
@@ -983,41 +645,14 @@
 									<height>0</height>
 									<width>0</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/BR[5]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/BR[5]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">5</attribute>
 								<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 							</attributes>
 						</identifyingAttributes>
-						<attributes>
-							<attributes>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">serif</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">19px</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-							</attributes>
-						</attributes>
+						<attributes/>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="br">
 						<identifyingAttributes>
 							<attributes>
 								<attribute key="outline" xsi:type="outlineAttribute">
@@ -1026,50 +661,24 @@
 									<height>0</height>
 									<width>0</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/BR[6]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/BR[6]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">6</attribute>
 								<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 							</attributes>
 						</identifyingAttributes>
-						<attributes>
-							<attributes>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">serif</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">19px</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-							</attributes>
-						</attributes>
+						<attributes/>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="name" xsi:type="stringAttribute">hidden</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>0</x>
 									<y>0</y>
 									<height>0</height>
 									<width>0</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/INPUT[10]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/INPUT[10]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">10</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -1081,20 +690,8 @@
 									<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
 								</entry>
 								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
 									<key>border-bottom-color</key>
 									<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
 								</entry>
 								<entry>
 									<key>border-left-color</key>
@@ -1141,16 +738,8 @@
 									<value xsi:type="xsd:string">0px</value>
 								</entry>
 								<entry>
-									<key>margin-top</key>
-									<value xsi:type="xsd:string">0px</value>
-								</entry>
-								<entry>
 									<key>outline-color</key>
 									<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
 								</entry>
 								<entry>
 									<key>text-decoration-color</key>
@@ -1159,7 +748,7 @@
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
 								<attribute key="outline" xsi:type="outlineAttribute">
@@ -1168,7 +757,7 @@
 									<height>29</height>
 									<width>70</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/INPUT[11]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/INPUT[11]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">11</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -1178,10 +767,6 @@
 								<entry>
 									<key>background-color</key>
 									<value xsi:type="xsd:string">rgb(240, 240, 240)</value>
-								</entry>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
 								</entry>
 								<entry>
 									<key>border-bottom-color</key>
@@ -1194,14 +779,6 @@
 								<entry>
 									<key>border-bottom-width</key>
 									<value xsi:type="xsd:string">6px</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
 								</entry>
 								<entry>
 									<key>border-left-color</key>
@@ -1260,20 +837,12 @@
 									<value xsi:type="xsd:string">0px</value>
 								</entry>
 								<entry>
-									<key>margin-top</key>
-									<value xsi:type="xsd:string">0px</value>
-								</entry>
-								<entry>
 									<key>padding-left</key>
 									<value xsi:type="xsd:string">8px</value>
 								</entry>
 								<entry>
 									<key>padding-right</key>
 									<value xsi:type="xsd:string">8px</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
 								</entry>
 								<entry>
 									<key>text-align</key>
@@ -1286,16 +855,18 @@
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">lone_disabled_selected_radio</attribute>
+								<attribute key="name" xsi:type="stringAttribute">not_a_snack</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>88</x>
 									<y>419</y>
 									<height>18</height>
 									<width>18</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/INPUT[12]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/INPUT[12]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">12</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -1303,18 +874,6 @@
 						<attributes>
 							<attributes>
 								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
 									<key>font-family</key>
 									<value xsi:type="xsd:string">sans-serif</value>
 								</entry>
@@ -1338,41 +897,27 @@
 									<key>margin-right</key>
 									<value xsi:type="xsd:string">3px</value>
 								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">checky</attribute>
+								<attribute key="name" xsi:type="stringAttribute">checky</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>170</x>
 									<y>108</y>
 									<height>18</height>
 									<width>18</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/INPUT[1]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/INPUT[1]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
 						</identifyingAttributes>
 						<attributes>
 							<attributes>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
 								<entry>
 									<key>font-family</key>
 									<value xsi:type="xsd:string">sans-serif</value>
@@ -1393,23 +938,21 @@
 									<key>margin-right</key>
 									<value xsi:type="xsd:string">3px</value>
 								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">checkedchecky</attribute>
+								<attribute key="name" xsi:type="stringAttribute">checkedchecky</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>200</x>
 									<y>108</y>
 									<height>18</height>
 									<width>18</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/INPUT[2]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/INPUT[2]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -1417,18 +960,6 @@
 						<attributes>
 							<attributes>
 								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
 									<key>font-family</key>
 									<value xsi:type="xsd:string">sans-serif</value>
 								</entry>
@@ -1448,23 +979,21 @@
 									<key>margin-right</key>
 									<value xsi:type="xsd:string">3px</value>
 								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">disabledchecky</attribute>
+								<attribute key="name" xsi:type="stringAttribute">disabledchecky</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>230</x>
 									<y>108</y>
 									<height>18</height>
 									<width>18</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/INPUT[3]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/INPUT[3]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">3</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -1472,18 +1001,6 @@
 						<attributes>
 							<attributes>
 								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
 									<key>font-family</key>
 									<value xsi:type="xsd:string">sans-serif</value>
 								</entry>
@@ -1503,23 +1020,21 @@
 									<key>margin-right</key>
 									<value xsi:type="xsd:string">3px</value>
 								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">randomly_disabled_checky</attribute>
+								<attribute key="name" xsi:type="stringAttribute">randomlydisabledchecky</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>260</x>
 									<y>108</y>
 									<height>18</height>
 									<width>18</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/INPUT[4]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/INPUT[4]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">4</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -1527,18 +1042,6 @@
 						<attributes>
 							<attributes>
 								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
 									<key>font-family</key>
 									<value xsi:type="xsd:string">sans-serif</value>
 								</entry>
@@ -1558,23 +1061,21 @@
 									<key>margin-right</key>
 									<value xsi:type="xsd:string">3px</value>
 								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">cheese</attribute>
+								<attribute key="name" xsi:type="stringAttribute">snack</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>13</x>
 									<y>243</y>
 									<height>18</height>
 									<width>18</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/INPUT[5]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/INPUT[5]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">5</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -1582,18 +1083,6 @@
 						<attributes>
 							<attributes>
 								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
 									<key>font-family</key>
 									<value xsi:type="xsd:string">sans-serif</value>
 								</entry>
@@ -1617,23 +1106,21 @@
 									<key>margin-right</key>
 									<value xsi:type="xsd:string">3px</value>
 								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">peas</attribute>
+								<attribute key="name" xsi:type="stringAttribute">snack</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>13</x>
 									<y>268</y>
 									<height>18</height>
 									<width>18</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/INPUT[6]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/INPUT[6]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">6</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -1641,18 +1128,6 @@
 						<attributes>
 							<attributes>
 								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
 									<key>font-family</key>
 									<value xsi:type="xsd:string">sans-serif</value>
 								</entry>
@@ -1676,23 +1151,21 @@
 									<key>margin-right</key>
 									<value xsi:type="xsd:string">3px</value>
 								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">cheese_and_peas</attribute>
+								<attribute key="name" xsi:type="stringAttribute">snack</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>13</x>
 									<y>293</y>
 									<height>18</height>
 									<width>18</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/INPUT[7]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/INPUT[7]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">7</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -1700,18 +1173,6 @@
 						<attributes>
 							<attributes>
 								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
 									<key>font-family</key>
 									<value xsi:type="xsd:string">sans-serif</value>
 								</entry>
@@ -1735,23 +1196,21 @@
 									<key>margin-right</key>
 									<value xsi:type="xsd:string">3px</value>
 								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">nothing</attribute>
+								<attribute key="name" xsi:type="stringAttribute">snack</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>13</x>
 									<y>318</y>
 									<height>18</height>
 									<width>18</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/INPUT[8]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/INPUT[8]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">8</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -1759,18 +1218,6 @@
 						<attributes>
 							<attributes>
 								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
 									<key>font-family</key>
 									<value xsi:type="xsd:string">sans-serif</value>
 								</entry>
@@ -1794,23 +1241,21 @@
 									<key>margin-right</key>
 									<value xsi:type="xsd:string">3px</value>
 								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">randomly_disabled_nothing</attribute>
+								<attribute key="name" xsi:type="stringAttribute">snack</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>13</x>
 									<y>343</y>
 									<height>18</height>
 									<width>18</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/INPUT[9]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/INPUT[9]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">9</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -1818,18 +1263,6 @@
 						<attributes>
 							<attributes>
 								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
 									<key>font-family</key>
 									<value xsi:type="xsd:string">sans-serif</value>
 								</entry>
@@ -1853,62 +1286,28 @@
 									<key>margin-right</key>
 									<value xsi:type="xsd:string">3px</value>
 								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="i_like_cheese">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">cheeseLiker</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>8</x>
 									<y>381</y>
 									<height>19</height>
 									<width>1340</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/P[1]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/P[1]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 								<attribute key="text" xsi:type="textAttribute">I like cheese</attribute>
 								<attribute key="type" xsi:type="stringAttribute">P</attribute>
 							</attributes>
 						</identifyingAttributes>
-						<attributes>
-							<attributes>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">serif</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">19px</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
-									<key>unicode-bidi</key>
-									<value xsi:type="xsd:string">isolate</value>
-								</entry>
-							</attributes>
-						</attributes>
+						<attributes/>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="select">
 						<identifyingAttributes>
 							<attributes>
 								<attribute key="outline" xsi:type="outlineAttribute">
@@ -1917,7 +1316,7 @@
 									<height>31</height>
 									<width>91</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[10]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[10]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">10</attribute>
 								<attribute key="type" xsi:type="stringAttribute">SELECT</attribute>
 							</attributes>
@@ -1927,10 +1326,6 @@
 								<entry>
 									<key>background-color</key>
 									<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
-								</entry>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
 								</entry>
 								<entry>
 									<key>border-bottom-color</key>
@@ -1943,18 +1338,6 @@
 								<entry>
 									<key>border-bottom-width</key>
 									<value xsi:type="xsd:string">6px</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>border-image-width</key>
-									<value xsi:type="xsd:string">1</value>
 								</entry>
 								<entry>
 									<key>border-left-color</key>
@@ -2029,25 +1412,22 @@
 									<value xsi:type="xsd:string">avoid</value>
 								</entry>
 								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
 									<key>white-space</key>
 									<value xsi:type="xsd:string">nowrap</value>
 								</entry>
 							</attributes>
 						</attributes>
-						<containedComponents>
+						<containedComponents retestId="option">
 							<identifyingAttributes>
 								<attributes>
+									<attribute key="id" xsi:type="stringAttribute">blankOption</attribute>
 									<attribute key="outline" xsi:type="outlineAttribute">
 										<x>321</x>
 										<y>210</y>
 										<height>14</height>
 										<width>88</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[10]/OPTION[1]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[10]/OPTION[1]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
 								</attributes>
@@ -2059,24 +1439,8 @@
 										<value xsi:type="xsd:string">rgb(51, 153, 255)</value>
 									</entry>
 									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
 										<key>border-bottom-color</key>
 										<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
 									</entry>
 									<entry>
 										<key>border-left-color</key>
@@ -2103,18 +1467,6 @@
 										<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
 									</entry>
 									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">17px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">14px</value>
 									</entry>
@@ -2131,10 +1483,6 @@
 										<value xsi:type="xsd:string">5px</value>
 									</entry>
 									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
 										<key>text-align</key>
 										<value xsi:type="xsd:string">left</value>
 									</entry>
@@ -2142,23 +1490,20 @@
 										<key>text-decoration-color</key>
 										<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
 									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">nowrap</value>
-									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="nothing">
 							<identifyingAttributes>
 								<attributes>
+									<attribute key="id" xsi:type="stringAttribute">optionEmptyValueSet</attribute>
 									<attribute key="outline" xsi:type="outlineAttribute">
 										<x>321</x>
 										<y>224</y>
 										<height>17</height>
 										<width>88</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[10]/OPTION[2]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[10]/OPTION[2]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 									<attribute key="text" xsi:type="textAttribute">nothing</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -2166,34 +1511,6 @@
 							</identifyingAttributes>
 							<attributes>
 								<attributes>
-									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">17px</value>
-									</entry>
 									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">14px</value>
@@ -2207,31 +1524,24 @@
 										<value xsi:type="xsd:string">5px</value>
 									</entry>
 									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
 										<key>text-align</key>
 										<value xsi:type="xsd:string">left</value>
-									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">nowrap</value>
 									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="select">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="name" xsi:type="stringAttribute">selectomatic</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>8</x>
 									<y>178</y>
 									<height>31</height>
 									<width>306</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[1]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[1]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 								<attribute key="type" xsi:type="stringAttribute">SELECT</attribute>
 							</attributes>
@@ -2241,10 +1551,6 @@
 								<entry>
 									<key>background-color</key>
 									<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
-								</entry>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
 								</entry>
 								<entry>
 									<key>border-bottom-color</key>
@@ -2257,18 +1563,6 @@
 								<entry>
 									<key>border-bottom-width</key>
 									<value xsi:type="xsd:string">6px</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>border-image-width</key>
-									<value xsi:type="xsd:string">1</value>
 								</entry>
 								<entry>
 									<key>border-left-color</key>
@@ -2343,25 +1637,22 @@
 									<value xsi:type="xsd:string">avoid</value>
 								</entry>
 								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
 									<key>white-space</key>
 									<value xsi:type="xsd:string">nowrap</value>
 								</entry>
 							</attributes>
 						</attributes>
-						<containedComponents>
+						<containedComponents retestId="one">
 							<identifyingAttributes>
 								<attributes>
+									<attribute key="id" xsi:type="stringAttribute">non_multi_option</attribute>
 									<attribute key="outline" xsi:type="outlineAttribute">
 										<x>10</x>
 										<y>179</y>
 										<height>17</height>
 										<width>303</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[1]/OPTION[1]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[1]/OPTION[1]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 									<attribute key="text" xsi:type="textAttribute">One</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -2374,24 +1665,8 @@
 										<value xsi:type="xsd:string">rgb(51, 153, 255)</value>
 									</entry>
 									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
 										<key>border-bottom-color</key>
 										<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
 									</entry>
 									<entry>
 										<key>border-left-color</key>
@@ -2418,18 +1693,6 @@
 										<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
 									</entry>
 									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">17px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">14px</value>
 									</entry>
@@ -2446,10 +1709,6 @@
 										<value xsi:type="xsd:string">5px</value>
 									</entry>
 									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
 										<key>text-align</key>
 										<value xsi:type="xsd:string">left</value>
 									</entry>
@@ -2457,14 +1716,10 @@
 										<key>text-decoration-color</key>
 										<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
 									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">nowrap</value>
-									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="two">
 							<identifyingAttributes>
 								<attributes>
 									<attribute key="outline" xsi:type="outlineAttribute">
@@ -2473,7 +1728,7 @@
 										<height>17</height>
 										<width>303</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[1]/OPTION[2]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[1]/OPTION[2]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 									<attribute key="text" xsi:type="textAttribute">Two</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -2482,34 +1737,6 @@
 							<attributes>
 								<attributes>
 									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">17px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">14px</value>
 									</entry>
@@ -2522,21 +1749,13 @@
 										<value xsi:type="xsd:string">5px</value>
 									</entry>
 									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
 										<key>text-align</key>
 										<value xsi:type="xsd:string">left</value>
-									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">nowrap</value>
 									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="four">
 							<identifyingAttributes>
 								<attributes>
 									<attribute key="outline" xsi:type="outlineAttribute">
@@ -2545,7 +1764,7 @@
 										<height>17</height>
 										<width>303</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[1]/OPTION[3]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[1]/OPTION[3]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">3</attribute>
 									<attribute key="text" xsi:type="textAttribute">Four</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -2554,34 +1773,6 @@
 							<attributes>
 								<attributes>
 									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">17px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">14px</value>
 									</entry>
@@ -2594,21 +1785,13 @@
 										<value xsi:type="xsd:string">5px</value>
 									</entry>
 									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
 										<key>text-align</key>
 										<value xsi:type="xsd:string">left</value>
-									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">nowrap</value>
 									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="still_learning">
 							<identifyingAttributes>
 								<attributes>
 									<attribute key="outline" xsi:type="outlineAttribute">
@@ -2617,7 +1800,7 @@
 										<height>17</height>
 										<width>303</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[1]/OPTION[4]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[1]/OPTION[4]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">4</attribute>
 									<attribute key="text" xsi:type="textAttribute">Still learning how to count, apparently</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -2625,34 +1808,6 @@
 							</identifyingAttributes>
 							<attributes>
 								<attributes>
-									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">17px</value>
-									</entry>
 									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">14px</value>
@@ -2666,31 +1821,25 @@
 										<value xsi:type="xsd:string">5px</value>
 									</entry>
 									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
 										<key>text-align</key>
 										<value xsi:type="xsd:string">left</value>
-									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">nowrap</value>
 									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="select">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">multi</attribute>
+								<attribute key="name" xsi:type="stringAttribute">multi</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>319</x>
 									<y>130</y>
 									<height>72</height>
 									<width>106</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[2]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[2]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 								<attribute key="type" xsi:type="stringAttribute">SELECT</attribute>
 							</attributes>
@@ -2700,10 +1849,6 @@
 								<entry>
 									<key>background-color</key>
 									<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
-								</entry>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
 								</entry>
 								<entry>
 									<key>border-bottom-color</key>
@@ -2716,18 +1861,6 @@
 								<entry>
 									<key>border-bottom-width</key>
 									<value xsi:type="xsd:string">1px</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>border-image-width</key>
-									<value xsi:type="xsd:string">1</value>
 								</entry>
 								<entry>
 									<key>border-left-color</key>
@@ -2826,10 +1959,6 @@
 									<value xsi:type="xsd:string">avoid</value>
 								</entry>
 								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
 									<key>text-decoration-color</key>
 									<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 								</entry>
@@ -2843,7 +1972,7 @@
 								</entry>
 							</attributes>
 						</attributes>
-						<containedComponents>
+						<containedComponents retestId="eggs">
 							<identifyingAttributes>
 								<attributes>
 									<attribute key="outline" xsi:type="outlineAttribute">
@@ -2852,7 +1981,7 @@
 										<height>17</height>
 										<width>94</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[2]/OPTION[1]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[2]/OPTION[1]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 									<attribute key="text" xsi:type="textAttribute">Eggs</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -2865,24 +1994,8 @@
 										<value xsi:type="xsd:string">rgb(51, 153, 255)</value>
 									</entry>
 									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
 										<key>border-bottom-color</key>
 										<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
 									</entry>
 									<entry>
 										<key>border-left-color</key>
@@ -2909,18 +2022,6 @@
 										<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
 									</entry>
 									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">17px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">14px</value>
 									</entry>
@@ -2937,10 +2038,6 @@
 										<value xsi:type="xsd:string">5px</value>
 									</entry>
 									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
 										<key>text-align</key>
 										<value xsi:type="xsd:string">left</value>
 									</entry>
@@ -2948,14 +2045,10 @@
 										<key>text-decoration-color</key>
 										<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
 									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">nowrap</value>
-									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="ham">
 							<identifyingAttributes>
 								<attributes>
 									<attribute key="outline" xsi:type="outlineAttribute">
@@ -2964,7 +2057,7 @@
 										<height>17</height>
 										<width>94</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[2]/OPTION[2]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[2]/OPTION[2]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 									<attribute key="text" xsi:type="textAttribute">Ham</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -2973,24 +2066,8 @@
 							<attributes>
 								<attributes>
 									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
 										<key>border-bottom-color</key>
 										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
 									</entry>
 									<entry>
 										<key>border-left-color</key>
@@ -3005,36 +2082,8 @@
 										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 									</entry>
 									<entry>
-										<key>caret-color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>column-rule-color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">17px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>outline-color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 									</entry>
 									<entry>
 										<key>padding-left</key>
@@ -3045,25 +2094,13 @@
 										<value xsi:type="xsd:string">5px</value>
 									</entry>
 									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
 										<key>text-align</key>
 										<value xsi:type="xsd:string">left</value>
-									</entry>
-									<entry>
-										<key>text-decoration-color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">nowrap</value>
 									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="sausages">
 							<identifyingAttributes>
 								<attributes>
 									<attribute key="outline" xsi:type="outlineAttribute">
@@ -3072,7 +2109,7 @@
 										<height>17</height>
 										<width>94</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[2]/OPTION[3]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[2]/OPTION[3]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">3</attribute>
 									<attribute key="text" xsi:type="textAttribute">Sausages</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -3085,24 +2122,8 @@
 										<value xsi:type="xsd:string">rgb(51, 153, 255)</value>
 									</entry>
 									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
 										<key>border-bottom-color</key>
 										<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
 									</entry>
 									<entry>
 										<key>border-left-color</key>
@@ -3129,18 +2150,6 @@
 										<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
 									</entry>
 									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">17px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">14px</value>
 									</entry>
@@ -3157,10 +2166,6 @@
 										<value xsi:type="xsd:string">5px</value>
 									</entry>
 									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
 										<key>text-align</key>
 										<value xsi:type="xsd:string">left</value>
 									</entry>
@@ -3168,14 +2173,10 @@
 										<key>text-decoration-color</key>
 										<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
 									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">nowrap</value>
-									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="onion_gravy">
 							<identifyingAttributes>
 								<attributes>
 									<attribute key="outline" xsi:type="outlineAttribute">
@@ -3184,7 +2185,7 @@
 										<height>17</height>
 										<width>94</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[2]/OPTION[4]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[2]/OPTION[4]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">4</attribute>
 									<attribute key="text" xsi:type="textAttribute">Onion gravy</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -3193,24 +2194,8 @@
 							<attributes>
 								<attributes>
 									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
 										<key>border-bottom-color</key>
 										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
 									</entry>
 									<entry>
 										<key>border-left-color</key>
@@ -3225,36 +2210,8 @@
 										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 									</entry>
 									<entry>
-										<key>caret-color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>column-rule-color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">17px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>outline-color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 									</entry>
 									<entry>
 										<key>padding-left</key>
@@ -3265,35 +2222,24 @@
 										<value xsi:type="xsd:string">5px</value>
 									</entry>
 									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
 										<key>text-align</key>
 										<value xsi:type="xsd:string">left</value>
-									</entry>
-									<entry>
-										<key>text-decoration-color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">nowrap</value>
 									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="select">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="name" xsi:type="stringAttribute">no-select</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>430</x>
 									<y>178</y>
 									<height>31</height>
 									<width>63</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[3]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[3]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">3</attribute>
 								<attribute key="type" xsi:type="stringAttribute">SELECT</attribute>
 							</attributes>
@@ -3303,10 +2249,6 @@
 								<entry>
 									<key>background-color</key>
 									<value xsi:type="xsd:string">rgb(227, 227, 227)</value>
-								</entry>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
 								</entry>
 								<entry>
 									<key>border-bottom-color</key>
@@ -3319,18 +2261,6 @@
 								<entry>
 									<key>border-bottom-width</key>
 									<value xsi:type="xsd:string">6px</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>border-image-width</key>
-									<value xsi:type="xsd:string">1</value>
 								</entry>
 								<entry>
 									<key>border-left-color</key>
@@ -3421,10 +2351,6 @@
 									<value xsi:type="xsd:string">avoid</value>
 								</entry>
 								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
 									<key>text-decoration-color</key>
 									<value xsi:type="xsd:string">rgb(109, 109, 109)</value>
 								</entry>
@@ -3434,7 +2360,7 @@
 								</entry>
 							</attributes>
 						</attributes>
-						<containedComponents>
+						<containedComponents retestId="foo">
 							<identifyingAttributes>
 								<attributes>
 									<attribute key="outline" xsi:type="outlineAttribute">
@@ -3443,7 +2369,7 @@
 										<height>17</height>
 										<width>60</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[3]/OPTION[1]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[3]/OPTION[1]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 									<attribute key="text" xsi:type="textAttribute">Foo</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -3456,24 +2382,8 @@
 										<value xsi:type="xsd:string">rgb(51, 153, 255)</value>
 									</entry>
 									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
 										<key>border-bottom-color</key>
 										<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
 									</entry>
 									<entry>
 										<key>border-left-color</key>
@@ -3500,18 +2410,6 @@
 										<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
 									</entry>
 									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">17px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">14px</value>
 									</entry>
@@ -3528,10 +2426,6 @@
 										<value xsi:type="xsd:string">5px</value>
 									</entry>
 									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
 										<key>text-align</key>
 										<value xsi:type="xsd:string">left</value>
 									</entry>
@@ -3539,14 +2433,10 @@
 										<key>text-decoration-color</key>
 										<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
 									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">nowrap</value>
-									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="bar">
 							<identifyingAttributes>
 								<attributes>
 									<attribute key="outline" xsi:type="outlineAttribute">
@@ -3555,7 +2445,7 @@
 										<height>17</height>
 										<width>60</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[3]/OPTION[2]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[3]/OPTION[2]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 									<attribute key="text" xsi:type="textAttribute">Bar</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -3564,24 +2454,8 @@
 							<attributes>
 								<attributes>
 									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
 										<key>border-bottom-color</key>
 										<value xsi:type="xsd:string">rgb(109, 109, 109)</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
 									</entry>
 									<entry>
 										<key>border-left-color</key>
@@ -3596,36 +2470,8 @@
 										<value xsi:type="xsd:string">rgb(109, 109, 109)</value>
 									</entry>
 									<entry>
-										<key>caret-color</key>
-										<value xsi:type="xsd:string">rgb(109, 109, 109)</value>
-									</entry>
-									<entry>
-										<key>color</key>
-										<value xsi:type="xsd:string">rgb(109, 109, 109)</value>
-									</entry>
-									<entry>
-										<key>column-rule-color</key>
-										<value xsi:type="xsd:string">rgb(109, 109, 109)</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">17px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>outline-color</key>
-										<value xsi:type="xsd:string">rgb(109, 109, 109)</value>
 									</entry>
 									<entry>
 										<key>padding-left</key>
@@ -3636,35 +2482,24 @@
 										<value xsi:type="xsd:string">5px</value>
 									</entry>
 									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
 										<key>text-align</key>
 										<value xsi:type="xsd:string">left</value>
-									</entry>
-									<entry>
-										<key>text-decoration-color</key>
-										<value xsi:type="xsd:string">rgb(109, 109, 109)</value>
-									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">nowrap</value>
 									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="select">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="name" xsi:type="stringAttribute">select_empty_multiple</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>498</x>
 									<y>130</y>
 									<height>72</height>
 									<width>78</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[4]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[4]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">4</attribute>
 								<attribute key="type" xsi:type="stringAttribute">SELECT</attribute>
 							</attributes>
@@ -3676,10 +2511,6 @@
 									<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
 								</entry>
 								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
 									<key>border-bottom-color</key>
 									<value xsi:type="xsd:string">rgb(227, 227, 227)</value>
 								</entry>
@@ -3690,18 +2521,6 @@
 								<entry>
 									<key>border-bottom-width</key>
 									<value xsi:type="xsd:string">1px</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>border-image-width</key>
-									<value xsi:type="xsd:string">1</value>
 								</entry>
 								<entry>
 									<key>border-left-color</key>
@@ -3800,10 +2619,6 @@
 									<value xsi:type="xsd:string">avoid</value>
 								</entry>
 								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
 									<key>text-decoration-color</key>
 									<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 								</entry>
@@ -3817,16 +2632,17 @@
 								</entry>
 							</attributes>
 						</attributes>
-						<containedComponents>
+						<containedComponents retestId="select_1">
 							<identifyingAttributes>
 								<attributes>
+									<attribute key="id" xsi:type="stringAttribute">multi_1</attribute>
 									<attribute key="outline" xsi:type="outlineAttribute">
 										<x>499</x>
 										<y>132</y>
 										<height>17</height>
 										<width>66</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[4]/OPTION[1]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[4]/OPTION[1]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 									<attribute key="text" xsi:type="textAttribute">select_1</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -3835,24 +2651,8 @@
 							<attributes>
 								<attributes>
 									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
 										<key>border-bottom-color</key>
 										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
 									</entry>
 									<entry>
 										<key>border-left-color</key>
@@ -3867,36 +2667,8 @@
 										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 									</entry>
 									<entry>
-										<key>caret-color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>column-rule-color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">17px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>outline-color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 									</entry>
 									<entry>
 										<key>padding-left</key>
@@ -3907,34 +2679,23 @@
 										<value xsi:type="xsd:string">5px</value>
 									</entry>
 									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
 										<key>text-align</key>
 										<value xsi:type="xsd:string">left</value>
-									</entry>
-									<entry>
-										<key>text-decoration-color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">nowrap</value>
 									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="select_2">
 							<identifyingAttributes>
 								<attributes>
+									<attribute key="id" xsi:type="stringAttribute">multi_2</attribute>
 									<attribute key="outline" xsi:type="outlineAttribute">
 										<x>499</x>
 										<y>149</y>
 										<height>17</height>
 										<width>66</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[4]/OPTION[2]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[4]/OPTION[2]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 									<attribute key="text" xsi:type="textAttribute">select_2</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -3943,24 +2704,8 @@
 							<attributes>
 								<attributes>
 									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
 										<key>border-bottom-color</key>
 										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
 									</entry>
 									<entry>
 										<key>border-left-color</key>
@@ -3975,36 +2720,8 @@
 										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 									</entry>
 									<entry>
-										<key>caret-color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>column-rule-color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">17px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>outline-color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 									</entry>
 									<entry>
 										<key>padding-left</key>
@@ -4015,34 +2732,23 @@
 										<value xsi:type="xsd:string">5px</value>
 									</entry>
 									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
 										<key>text-align</key>
 										<value xsi:type="xsd:string">left</value>
-									</entry>
-									<entry>
-										<key>text-decoration-color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">nowrap</value>
 									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="select_3">
 							<identifyingAttributes>
 								<attributes>
+									<attribute key="id" xsi:type="stringAttribute">multi_3</attribute>
 									<attribute key="outline" xsi:type="outlineAttribute">
 										<x>499</x>
 										<y>166</y>
 										<height>17</height>
 										<width>66</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[4]/OPTION[3]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[4]/OPTION[3]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">3</attribute>
 									<attribute key="text" xsi:type="textAttribute">select_3</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -4051,24 +2757,8 @@
 							<attributes>
 								<attributes>
 									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
 										<key>border-bottom-color</key>
 										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
 									</entry>
 									<entry>
 										<key>border-left-color</key>
@@ -4083,36 +2773,8 @@
 										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 									</entry>
 									<entry>
-										<key>caret-color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>column-rule-color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">17px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>outline-color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 									</entry>
 									<entry>
 										<key>padding-left</key>
@@ -4123,34 +2785,23 @@
 										<value xsi:type="xsd:string">5px</value>
 									</entry>
 									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
 										<key>text-align</key>
 										<value xsi:type="xsd:string">left</value>
-									</entry>
-									<entry>
-										<key>text-decoration-color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">nowrap</value>
 									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="select_4">
 							<identifyingAttributes>
 								<attributes>
+									<attribute key="id" xsi:type="stringAttribute">multi_4</attribute>
 									<attribute key="outline" xsi:type="outlineAttribute">
 										<x>499</x>
 										<y>183</y>
 										<height>17</height>
 										<width>66</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[4]/OPTION[4]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[4]/OPTION[4]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">4</attribute>
 									<attribute key="text" xsi:type="textAttribute">select_4</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -4159,24 +2810,8 @@
 							<attributes>
 								<attributes>
 									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
 										<key>border-bottom-color</key>
 										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
 									</entry>
 									<entry>
 										<key>border-left-color</key>
@@ -4191,36 +2826,8 @@
 										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 									</entry>
 									<entry>
-										<key>caret-color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>column-rule-color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">17px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>outline-color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 									</entry>
 									<entry>
 										<key>padding-left</key>
@@ -4231,35 +2838,24 @@
 										<value xsi:type="xsd:string">5px</value>
 									</entry>
 									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
 										<key>text-align</key>
 										<value xsi:type="xsd:string">left</value>
-									</entry>
-									<entry>
-										<key>text-decoration-color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">nowrap</value>
 									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="select">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="name" xsi:type="stringAttribute">multi_true</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>581</x>
 									<y>130</y>
 									<height>72</height>
 									<width>78</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[5]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[5]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">5</attribute>
 								<attribute key="type" xsi:type="stringAttribute">SELECT</attribute>
 							</attributes>
@@ -4271,10 +2867,6 @@
 									<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
 								</entry>
 								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
 									<key>border-bottom-color</key>
 									<value xsi:type="xsd:string">rgb(227, 227, 227)</value>
 								</entry>
@@ -4285,18 +2877,6 @@
 								<entry>
 									<key>border-bottom-width</key>
 									<value xsi:type="xsd:string">1px</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>border-image-width</key>
-									<value xsi:type="xsd:string">1</value>
 								</entry>
 								<entry>
 									<key>border-left-color</key>
@@ -4395,10 +2975,6 @@
 									<value xsi:type="xsd:string">avoid</value>
 								</entry>
 								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
 									<key>text-decoration-color</key>
 									<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 								</entry>
@@ -4412,16 +2988,17 @@
 								</entry>
 							</attributes>
 						</attributes>
-						<containedComponents>
+						<containedComponents retestId="select_1">
 							<identifyingAttributes>
 								<attributes>
+									<attribute key="id" xsi:type="stringAttribute">multi_true_1</attribute>
 									<attribute key="outline" xsi:type="outlineAttribute">
 										<x>582</x>
 										<y>132</y>
 										<height>17</height>
 										<width>66</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[5]/OPTION[1]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[5]/OPTION[1]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 									<attribute key="text" xsi:type="textAttribute">select_1</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -4430,24 +3007,8 @@
 							<attributes>
 								<attributes>
 									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
 										<key>border-bottom-color</key>
 										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
 									</entry>
 									<entry>
 										<key>border-left-color</key>
@@ -4462,36 +3023,8 @@
 										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 									</entry>
 									<entry>
-										<key>caret-color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>column-rule-color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">17px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>outline-color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 									</entry>
 									<entry>
 										<key>padding-left</key>
@@ -4502,34 +3035,23 @@
 										<value xsi:type="xsd:string">5px</value>
 									</entry>
 									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
 										<key>text-align</key>
 										<value xsi:type="xsd:string">left</value>
-									</entry>
-									<entry>
-										<key>text-decoration-color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">nowrap</value>
 									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="select_2">
 							<identifyingAttributes>
 								<attributes>
+									<attribute key="id" xsi:type="stringAttribute">multi_true_2</attribute>
 									<attribute key="outline" xsi:type="outlineAttribute">
 										<x>582</x>
 										<y>149</y>
 										<height>17</height>
 										<width>66</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[5]/OPTION[2]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[5]/OPTION[2]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 									<attribute key="text" xsi:type="textAttribute">select_2</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -4538,24 +3060,8 @@
 							<attributes>
 								<attributes>
 									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
 										<key>border-bottom-color</key>
 										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
 									</entry>
 									<entry>
 										<key>border-left-color</key>
@@ -4570,36 +3076,8 @@
 										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 									</entry>
 									<entry>
-										<key>caret-color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>column-rule-color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">17px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>outline-color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 									</entry>
 									<entry>
 										<key>padding-left</key>
@@ -4610,35 +3088,24 @@
 										<value xsi:type="xsd:string">5px</value>
 									</entry>
 									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
 										<key>text-align</key>
 										<value xsi:type="xsd:string">left</value>
-									</entry>
-									<entry>
-										<key>text-decoration-color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">nowrap</value>
 									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="select">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="name" xsi:type="stringAttribute">multi_false</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>664</x>
 									<y>130</y>
 									<height>72</height>
 									<width>78</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[6]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[6]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">6</attribute>
 								<attribute key="type" xsi:type="stringAttribute">SELECT</attribute>
 							</attributes>
@@ -4650,10 +3117,6 @@
 									<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
 								</entry>
 								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
 									<key>border-bottom-color</key>
 									<value xsi:type="xsd:string">rgb(227, 227, 227)</value>
 								</entry>
@@ -4664,18 +3127,6 @@
 								<entry>
 									<key>border-bottom-width</key>
 									<value xsi:type="xsd:string">1px</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>border-image-width</key>
-									<value xsi:type="xsd:string">1</value>
 								</entry>
 								<entry>
 									<key>border-left-color</key>
@@ -4774,10 +3225,6 @@
 									<value xsi:type="xsd:string">avoid</value>
 								</entry>
 								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
 									<key>text-decoration-color</key>
 									<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 								</entry>
@@ -4791,16 +3238,17 @@
 								</entry>
 							</attributes>
 						</attributes>
-						<containedComponents>
+						<containedComponents retestId="select_1">
 							<identifyingAttributes>
 								<attributes>
+									<attribute key="id" xsi:type="stringAttribute">multi_false_1</attribute>
 									<attribute key="outline" xsi:type="outlineAttribute">
 										<x>665</x>
 										<y>132</y>
 										<height>17</height>
 										<width>66</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[6]/OPTION[1]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[6]/OPTION[1]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 									<attribute key="text" xsi:type="textAttribute">select_1</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -4809,24 +3257,8 @@
 							<attributes>
 								<attributes>
 									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
 										<key>border-bottom-color</key>
 										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
 									</entry>
 									<entry>
 										<key>border-left-color</key>
@@ -4841,36 +3273,8 @@
 										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 									</entry>
 									<entry>
-										<key>caret-color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>column-rule-color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">17px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>outline-color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 									</entry>
 									<entry>
 										<key>padding-left</key>
@@ -4881,34 +3285,23 @@
 										<value xsi:type="xsd:string">5px</value>
 									</entry>
 									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
 										<key>text-align</key>
 										<value xsi:type="xsd:string">left</value>
-									</entry>
-									<entry>
-										<key>text-decoration-color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">nowrap</value>
 									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="select_2">
 							<identifyingAttributes>
 								<attributes>
+									<attribute key="id" xsi:type="stringAttribute">multi_false_2</attribute>
 									<attribute key="outline" xsi:type="outlineAttribute">
 										<x>665</x>
 										<y>149</y>
 										<height>17</height>
 										<width>66</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[6]/OPTION[2]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[6]/OPTION[2]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 									<attribute key="text" xsi:type="textAttribute">select_2</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -4917,24 +3310,8 @@
 							<attributes>
 								<attributes>
 									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
 										<key>border-bottom-color</key>
 										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
 									</entry>
 									<entry>
 										<key>border-left-color</key>
@@ -4949,36 +3326,8 @@
 										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 									</entry>
 									<entry>
-										<key>caret-color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>column-rule-color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">17px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>outline-color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 									</entry>
 									<entry>
 										<key>padding-left</key>
@@ -4989,35 +3338,24 @@
 										<value xsi:type="xsd:string">5px</value>
 									</entry>
 									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
 										<key>text-align</key>
 										<value xsi:type="xsd:string">left</value>
-									</entry>
-									<entry>
-										<key>text-decoration-color</key>
-										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
-									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">nowrap</value>
 									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="select">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">invisi_select</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>747</x>
 									<y>178</y>
 									<height>31</height>
 									<width>97</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[7]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[7]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">7</attribute>
 								<attribute key="type" xsi:type="stringAttribute">SELECT</attribute>
 							</attributes>
@@ -5027,10 +3365,6 @@
 								<entry>
 									<key>background-color</key>
 									<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
-								</entry>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
 								</entry>
 								<entry>
 									<key>border-bottom-color</key>
@@ -5043,18 +3377,6 @@
 								<entry>
 									<key>border-bottom-width</key>
 									<value xsi:type="xsd:string">6px</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>border-image-width</key>
-									<value xsi:type="xsd:string">1</value>
 								</entry>
 								<entry>
 									<key>border-left-color</key>
@@ -5133,16 +3455,12 @@
 									<value xsi:type="xsd:string">avoid</value>
 								</entry>
 								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
 									<key>white-space</key>
 									<value xsi:type="xsd:string">nowrap</value>
 								</entry>
 							</attributes>
 						</attributes>
-						<containedComponents>
+						<containedComponents retestId="apples">
 							<identifyingAttributes>
 								<attributes>
 									<attribute key="outline" xsi:type="outlineAttribute">
@@ -5151,7 +3469,7 @@
 										<height>17</height>
 										<width>94</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[7]/OPTION[1]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[7]/OPTION[1]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 									<attribute key="text" xsi:type="textAttribute">Apples</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -5164,24 +3482,8 @@
 										<value xsi:type="xsd:string">rgb(51, 153, 255)</value>
 									</entry>
 									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
 										<key>border-bottom-color</key>
 										<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
 									</entry>
 									<entry>
 										<key>border-left-color</key>
@@ -5208,18 +3510,6 @@
 										<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
 									</entry>
 									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">17px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">14px</value>
 									</entry>
@@ -5236,10 +3526,6 @@
 										<value xsi:type="xsd:string">5px</value>
 									</entry>
 									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
 										<key>text-align</key>
 										<value xsi:type="xsd:string">left</value>
 									</entry>
@@ -5247,14 +3533,10 @@
 										<key>text-decoration-color</key>
 										<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
 									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">nowrap</value>
-									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="oranges">
 							<identifyingAttributes>
 								<attributes>
 									<attribute key="outline" xsi:type="outlineAttribute">
@@ -5263,7 +3545,7 @@
 										<height>17</height>
 										<width>94</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[7]/OPTION[2]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[7]/OPTION[2]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 									<attribute key="text" xsi:type="textAttribute">Oranges</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -5271,34 +3553,6 @@
 							</identifyingAttributes>
 							<attributes>
 								<attributes>
-									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">17px</value>
-									</entry>
 									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">14px</value>
@@ -5312,31 +3566,24 @@
 										<value xsi:type="xsd:string">5px</value>
 									</entry>
 									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
 										<key>text-align</key>
 										<value xsi:type="xsd:string">left</value>
-									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">nowrap</value>
 									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="select">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="name" xsi:type="stringAttribute">select-default</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>849</x>
 									<y>178</y>
 									<height>31</height>
 									<width>306</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[8]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[8]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">8</attribute>
 								<attribute key="type" xsi:type="stringAttribute">SELECT</attribute>
 							</attributes>
@@ -5348,10 +3595,6 @@
 									<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
 								</entry>
 								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
 									<key>border-bottom-color</key>
 									<value xsi:type="xsd:string">rgb(227, 227, 227)</value>
 								</entry>
@@ -5362,18 +3605,6 @@
 								<entry>
 									<key>border-bottom-width</key>
 									<value xsi:type="xsd:string">6px</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>border-image-width</key>
-									<value xsi:type="xsd:string">1</value>
 								</entry>
 								<entry>
 									<key>border-left-color</key>
@@ -5448,16 +3679,12 @@
 									<value xsi:type="xsd:string">avoid</value>
 								</entry>
 								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
 									<key>white-space</key>
 									<value xsi:type="xsd:string">nowrap</value>
 								</entry>
 							</attributes>
 						</attributes>
-						<containedComponents>
+						<containedComponents retestId="one">
 							<identifyingAttributes>
 								<attributes>
 									<attribute key="outline" xsi:type="outlineAttribute">
@@ -5466,7 +3693,7 @@
 										<height>17</height>
 										<width>303</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[8]/OPTION[1]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[8]/OPTION[1]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 									<attribute key="text" xsi:type="textAttribute">One</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -5479,24 +3706,8 @@
 										<value xsi:type="xsd:string">rgb(51, 153, 255)</value>
 									</entry>
 									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
 										<key>border-bottom-color</key>
 										<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
 									</entry>
 									<entry>
 										<key>border-left-color</key>
@@ -5523,18 +3734,6 @@
 										<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
 									</entry>
 									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">17px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">14px</value>
 									</entry>
@@ -5551,10 +3750,6 @@
 										<value xsi:type="xsd:string">5px</value>
 									</entry>
 									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
 										<key>text-align</key>
 										<value xsi:type="xsd:string">left</value>
 									</entry>
@@ -5562,14 +3757,10 @@
 										<key>text-decoration-color</key>
 										<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
 									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">nowrap</value>
-									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="two">
 							<identifyingAttributes>
 								<attributes>
 									<attribute key="outline" xsi:type="outlineAttribute">
@@ -5578,7 +3769,7 @@
 										<height>17</height>
 										<width>303</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[8]/OPTION[2]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[8]/OPTION[2]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 									<attribute key="text" xsi:type="textAttribute">Two</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -5587,34 +3778,6 @@
 							<attributes>
 								<attributes>
 									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">17px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">14px</value>
 									</entry>
@@ -5627,21 +3790,13 @@
 										<value xsi:type="xsd:string">5px</value>
 									</entry>
 									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
 										<key>text-align</key>
 										<value xsi:type="xsd:string">left</value>
-									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">nowrap</value>
 									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="four">
 							<identifyingAttributes>
 								<attributes>
 									<attribute key="outline" xsi:type="outlineAttribute">
@@ -5650,7 +3805,7 @@
 										<height>17</height>
 										<width>303</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[8]/OPTION[3]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[8]/OPTION[3]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">3</attribute>
 									<attribute key="text" xsi:type="textAttribute">Four</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -5659,34 +3814,6 @@
 							<attributes>
 								<attributes>
 									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">17px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">14px</value>
 									</entry>
@@ -5699,21 +3826,13 @@
 										<value xsi:type="xsd:string">5px</value>
 									</entry>
 									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
 										<key>text-align</key>
 										<value xsi:type="xsd:string">left</value>
-									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">nowrap</value>
 									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="still_learning">
 							<identifyingAttributes>
 								<attributes>
 									<attribute key="outline" xsi:type="outlineAttribute">
@@ -5722,7 +3841,7 @@
 										<height>17</height>
 										<width>303</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[8]/OPTION[4]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[8]/OPTION[4]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">4</attribute>
 									<attribute key="text" xsi:type="textAttribute">Still learning how to count, apparently</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -5730,34 +3849,6 @@
 							</identifyingAttributes>
 							<attributes>
 								<attributes>
-									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">17px</value>
-									</entry>
 									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">14px</value>
@@ -5771,31 +3862,24 @@
 										<value xsi:type="xsd:string">5px</value>
 									</entry>
 									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
 										<key>text-align</key>
 										<value xsi:type="xsd:string">left</value>
-									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">nowrap</value>
 									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="select">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="name" xsi:type="stringAttribute">select_with_spaces</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>8</x>
 									<y>209</y>
 									<height>31</height>
 									<width>306</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[9]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[9]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">9</attribute>
 								<attribute key="type" xsi:type="stringAttribute">SELECT</attribute>
 							</attributes>
@@ -5807,10 +3891,6 @@
 									<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
 								</entry>
 								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
 									<key>border-bottom-color</key>
 									<value xsi:type="xsd:string">rgb(227, 227, 227)</value>
 								</entry>
@@ -5821,18 +3901,6 @@
 								<entry>
 									<key>border-bottom-width</key>
 									<value xsi:type="xsd:string">6px</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>border-image-width</key>
-									<value xsi:type="xsd:string">1</value>
 								</entry>
 								<entry>
 									<key>border-left-color</key>
@@ -5907,16 +3975,12 @@
 									<value xsi:type="xsd:string">avoid</value>
 								</entry>
 								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
 									<key>white-space</key>
 									<value xsi:type="xsd:string">nowrap</value>
 								</entry>
 							</attributes>
 						</attributes>
-						<containedComponents>
+						<containedComponents retestId="one">
 							<identifyingAttributes>
 								<attributes>
 									<attribute key="outline" xsi:type="outlineAttribute">
@@ -5925,7 +3989,7 @@
 										<height>17</height>
 										<width>303</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[9]/OPTION[1]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[9]/OPTION[1]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 									<attribute key="text" xsi:type="textAttribute">One</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -5938,24 +4002,8 @@
 										<value xsi:type="xsd:string">rgb(51, 153, 255)</value>
 									</entry>
 									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
 										<key>border-bottom-color</key>
 										<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
 									</entry>
 									<entry>
 										<key>border-left-color</key>
@@ -5982,18 +4030,6 @@
 										<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
 									</entry>
 									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">17px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">14px</value>
 									</entry>
@@ -6010,10 +4046,6 @@
 										<value xsi:type="xsd:string">5px</value>
 									</entry>
 									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
 										<key>text-align</key>
 										<value xsi:type="xsd:string">left</value>
 									</entry>
@@ -6021,14 +4053,10 @@
 										<key>text-decoration-color</key>
 										<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
 									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">nowrap</value>
-									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="two">
 							<identifyingAttributes>
 								<attributes>
 									<attribute key="outline" xsi:type="outlineAttribute">
@@ -6037,7 +4065,7 @@
 										<height>17</height>
 										<width>303</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[9]/OPTION[2]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[9]/OPTION[2]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 									<attribute key="text" xsi:type="textAttribute">Two</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -6046,34 +4074,6 @@
 							<attributes>
 								<attributes>
 									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">17px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">14px</value>
 									</entry>
@@ -6086,21 +4086,13 @@
 										<value xsi:type="xsd:string">5px</value>
 									</entry>
 									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
 										<key>text-align</key>
 										<value xsi:type="xsd:string">left</value>
-									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">nowrap</value>
 									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="four">
 							<identifyingAttributes>
 								<attributes>
 									<attribute key="outline" xsi:type="outlineAttribute">
@@ -6109,7 +4101,7 @@
 										<height>17</height>
 										<width>303</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[9]/OPTION[3]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[9]/OPTION[3]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">3</attribute>
 									<attribute key="text" xsi:type="textAttribute">Four</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -6118,34 +4110,6 @@
 							<attributes>
 								<attributes>
 									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">17px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">14px</value>
 									</entry>
@@ -6158,21 +4122,13 @@
 										<value xsi:type="xsd:string">5px</value>
 									</entry>
 									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
 										<key>text-align</key>
 										<value xsi:type="xsd:string">left</value>
-									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">nowrap</value>
 									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="still_learning">
 							<identifyingAttributes>
 								<attributes>
 									<attribute key="outline" xsi:type="outlineAttribute">
@@ -6181,7 +4137,7 @@
 										<height>17</height>
 										<width>303</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[3]/SELECT[9]/OPTION[4]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[3]/SELECT[9]/OPTION[4]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">4</attribute>
 									<attribute key="text" xsi:type="textAttribute">Still learning how to count, apparently</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -6189,34 +4145,6 @@
 							</identifyingAttributes>
 							<attributes>
 								<attributes>
-									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">17px</value>
-									</entry>
 									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">14px</value>
@@ -6230,78 +4158,41 @@
 										<value xsi:type="xsd:string">5px</value>
 									</entry>
 									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
 										<key>text-align</key>
 										<value xsi:type="xsd:string">left</value>
-									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">nowrap</value>
 									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
 					</containedComponents>
 				</containedComponents>
-				<containedComponents>
+				<containedComponents retestId="form">
 					<identifyingAttributes>
 						<attributes>
+							<attribute key="name" xsi:type="stringAttribute">disable</attribute>
 							<attribute key="outline" xsi:type="outlineAttribute">
 								<x>8</x>
 								<y>463</y>
 								<height>95</height>
 								<width>1340</width>
 							</attribute>
-							<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[4]</attribute>
+							<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[4]</attribute>
 							<attribute key="suffix" xsi:type="suffixAttribute">4</attribute>
 							<attribute key="type" xsi:type="stringAttribute">FORM</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">19px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>unicode-bidi</key>
-								<value xsi:type="xsd:string">isolate</value>
-							</entry>
-						</attributes>
-					</attributes>
-					<containedComponents>
+					<attributes/>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">working</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>8</x>
 									<y>529</y>
 									<height>29</height>
 									<width>211</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[4]/INPUT[1]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[4]/INPUT[1]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -6311,10 +4202,6 @@
 								<entry>
 									<key>background-color</key>
 									<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
-								</entry>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
 								</entry>
 								<entry>
 									<key>border-bottom-color</key>
@@ -6327,14 +4214,6 @@
 								<entry>
 									<key>border-bottom-width</key>
 									<value xsi:type="xsd:string">5px</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
 								</entry>
 								<entry>
 									<key>border-left-color</key>
@@ -6405,10 +4284,6 @@
 									<value xsi:type="xsd:string">0px</value>
 								</entry>
 								<entry>
-									<key>margin-top</key>
-									<value xsi:type="xsd:string">0px</value>
-								</entry>
-								<entry>
 									<key>outline-color</key>
 									<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 								</entry>
@@ -6429,26 +4304,23 @@
 									<value xsi:type="xsd:string">1px</value>
 								</entry>
 								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
 									<key>text-decoration-color</key>
 									<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 								</entry>
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">notWorking</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>224</x>
 									<y>529</y>
 									<height>29</height>
 									<width>211</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[4]/INPUT[2]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[4]/INPUT[2]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -6460,10 +4332,6 @@
 									<value xsi:type="xsd:string">rgb(227, 227, 227)</value>
 								</entry>
 								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
 									<key>border-bottom-color</key>
 									<value xsi:type="xsd:string">rgb(227, 227, 227)</value>
 								</entry>
@@ -6474,14 +4342,6 @@
 								<entry>
 									<key>border-bottom-width</key>
 									<value xsi:type="xsd:string">5px</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
 								</entry>
 								<entry>
 									<key>border-left-color</key>
@@ -6552,10 +4412,6 @@
 									<value xsi:type="xsd:string">0px</value>
 								</entry>
 								<entry>
-									<key>margin-top</key>
-									<value xsi:type="xsd:string">0px</value>
-								</entry>
-								<entry>
 									<key>outline-color</key>
 									<value xsi:type="xsd:string">rgb(109, 109, 109)</value>
 								</entry>
@@ -6576,26 +4432,23 @@
 									<value xsi:type="xsd:string">1px</value>
 								</entry>
 								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
 									<key>text-decoration-color</key>
 									<value xsi:type="xsd:string">rgb(109, 109, 109)</value>
 								</entry>
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">inputWithText</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>494</x>
 									<y>529</y>
 									<height>29</height>
 									<width>211</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[4]/INPUT[3]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[4]/INPUT[3]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">3</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -6607,10 +4460,6 @@
 									<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
 								</entry>
 								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
 									<key>border-bottom-color</key>
 									<value xsi:type="xsd:string">rgb(227, 227, 227)</value>
 								</entry>
@@ -6621,14 +4470,6 @@
 								<entry>
 									<key>border-bottom-width</key>
 									<value xsi:type="xsd:string">5px</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
 								</entry>
 								<entry>
 									<key>border-left-color</key>
@@ -6699,10 +4540,6 @@
 									<value xsi:type="xsd:string">0px</value>
 								</entry>
 								<entry>
-									<key>margin-top</key>
-									<value xsi:type="xsd:string">0px</value>
-								</entry>
-								<entry>
 									<key>outline-color</key>
 									<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 								</entry>
@@ -6723,26 +4560,23 @@
 									<value xsi:type="xsd:string">1px</value>
 								</entry>
 								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
 									<key>text-decoration-color</key>
 									<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 								</entry>
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="textarea">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">notWorkingArea</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>440</x>
 									<y>464</y>
 									<height>87</height>
 									<width>49</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[4]/TEXTAREA[1]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[4]/TEXTAREA[1]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 								<attribute key="type" xsi:type="stringAttribute">TEXTAREA</attribute>
 							</attributes>
@@ -6752,10 +4586,6 @@
 								<entry>
 									<key>background-color</key>
 									<value xsi:type="xsd:string">rgb(227, 227, 227)</value>
-								</entry>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
 								</entry>
 								<entry>
 									<key>border-bottom-color</key>
@@ -6768,18 +4598,6 @@
 								<entry>
 									<key>border-bottom-width</key>
 									<value xsi:type="xsd:string">1px</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>border-image-width</key>
-									<value xsi:type="xsd:string">1</value>
 								</entry>
 								<entry>
 									<key>border-left-color</key>
@@ -6870,10 +4688,6 @@
 									<value xsi:type="xsd:string">1px</value>
 								</entry>
 								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
 									<key>resize</key>
 									<value xsi:type="xsd:string">both</value>
 								</entry>
@@ -6896,16 +4710,17 @@
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="example_text">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">withText</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>710</x>
 									<y>464</y>
 									<height>87</height>
 									<width>49</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[4]/TEXTAREA[2]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[4]/TEXTAREA[2]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 								<attribute key="text" xsi:type="textAttribute">Example text</attribute>
 								<attribute key="type" xsi:type="stringAttribute">TEXTAREA</attribute>
@@ -6918,10 +4733,6 @@
 									<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
 								</entry>
 								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
 									<key>border-bottom-color</key>
 									<value xsi:type="xsd:string">rgb(227, 227, 227)</value>
 								</entry>
@@ -6932,18 +4743,6 @@
 								<entry>
 									<key>border-bottom-width</key>
 									<value xsi:type="xsd:string">1px</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>border-image-width</key>
-									<value xsi:type="xsd:string">1</value>
 								</entry>
 								<entry>
 									<key>border-left-color</key>
@@ -7032,10 +4831,6 @@
 								<entry>
 									<key>padding-right</key>
 									<value xsi:type="xsd:string">1px</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
 								</entry>
 								<entry>
 									<key>resize</key>
@@ -7060,16 +4855,17 @@
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="textarea">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">emptyTextArea</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>764</x>
 									<y>464</y>
 									<height>87</height>
 									<width>49</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[4]/TEXTAREA[3]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[4]/TEXTAREA[3]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">3</attribute>
 								<attribute key="type" xsi:type="stringAttribute">TEXTAREA</attribute>
 							</attributes>
@@ -7079,10 +4875,6 @@
 								<entry>
 									<key>background-color</key>
 									<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
-								</entry>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
 								</entry>
 								<entry>
 									<key>border-bottom-color</key>
@@ -7095,18 +4887,6 @@
 								<entry>
 									<key>border-bottom-width</key>
 									<value xsi:type="xsd:string">1px</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>border-image-width</key>
-									<value xsi:type="xsd:string">1</value>
 								</entry>
 								<entry>
 									<key>border-left-color</key>
@@ -7195,10 +4975,6 @@
 								<entry>
 									<key>padding-right</key>
 									<value xsi:type="xsd:string">1px</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
 								</entry>
 								<entry>
 									<key>resize</key>
@@ -7224,7 +5000,7 @@
 						</attributes>
 					</containedComponents>
 				</containedComponents>
-				<containedComponents>
+				<containedComponents retestId="form">
 					<identifyingAttributes>
 						<attributes>
 							<attribute key="outline" xsi:type="outlineAttribute">
@@ -7233,53 +5009,23 @@
 								<height>31</height>
 								<width>1340</width>
 							</attribute>
-							<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[5]</attribute>
+							<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[5]</attribute>
 							<attribute key="suffix" xsi:type="suffixAttribute">5</attribute>
 							<attribute key="type" xsi:type="stringAttribute">FORM</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">19px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>unicode-bidi</key>
-								<value xsi:type="xsd:string">isolate</value>
-							</entry>
-						</attributes>
-					</attributes>
-					<containedComponents>
+					<attributes/>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">no-type</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>79</x>
 									<y>575</y>
 									<height>29</height>
 									<width>211</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[5]/INPUT[1]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[5]/INPUT[1]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -7289,10 +5035,6 @@
 								<entry>
 									<key>background-color</key>
 									<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
-								</entry>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
 								</entry>
 								<entry>
 									<key>border-bottom-color</key>
@@ -7305,14 +5047,6 @@
 								<entry>
 									<key>border-bottom-width</key>
 									<value xsi:type="xsd:string">5px</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
 								</entry>
 								<entry>
 									<key>border-left-color</key>
@@ -7383,10 +5117,6 @@
 									<value xsi:type="xsd:string">0px</value>
 								</entry>
 								<entry>
-									<key>margin-top</key>
-									<value xsi:type="xsd:string">0px</value>
-								</entry>
-								<entry>
 									<key>outline-color</key>
 									<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 								</entry>
@@ -7407,44 +5137,29 @@
 									<value xsi:type="xsd:string">1px</value>
 								</entry>
 								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
 									<key>text-decoration-color</key>
 									<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 								</entry>
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">upload</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>295</x>
 									<y>575</y>
 									<height>29</height>
 									<width>264</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[5]/INPUT[2]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[5]/INPUT[2]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
 						</identifyingAttributes>
 						<attributes>
 							<attributes>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
 								<entry>
 									<key>font-family</key>
 									<value xsi:type="xsd:string">sans-serif</value>
@@ -7462,10 +5177,6 @@
 									<value xsi:type="xsd:string">0px</value>
 								</entry>
 								<entry>
-									<key>margin-top</key>
-									<value xsi:type="xsd:string">0px</value>
-								</entry>
-								<entry>
 									<key>overflow</key>
 									<value xsi:type="xsd:string">hidden</value>
 								</entry>
@@ -7478,17 +5189,13 @@
 									<value xsi:type="xsd:string">hidden</value>
 								</entry>
 								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
 									<key>white-space</key>
 									<value xsi:type="xsd:string">nowrap</value>
 								</entry>
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
 								<attribute key="outline" xsi:type="outlineAttribute">
@@ -7497,7 +5204,7 @@
 									<height>29</height>
 									<width>127</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[5]/INPUT[3]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[5]/INPUT[3]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">3</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -7507,10 +5214,6 @@
 								<entry>
 									<key>background-color</key>
 									<value xsi:type="xsd:string">rgb(240, 240, 240)</value>
-								</entry>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
 								</entry>
 								<entry>
 									<key>border-bottom-color</key>
@@ -7523,14 +5226,6 @@
 								<entry>
 									<key>border-bottom-width</key>
 									<value xsi:type="xsd:string">6px</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
 								</entry>
 								<entry>
 									<key>border-left-color</key>
@@ -7589,20 +5284,12 @@
 									<value xsi:type="xsd:string">0px</value>
 								</entry>
 								<entry>
-									<key>margin-top</key>
-									<value xsi:type="xsd:string">0px</value>
-								</entry>
-								<entry>
 									<key>padding-left</key>
 									<value xsi:type="xsd:string">8px</value>
 								</entry>
 								<entry>
 									<key>padding-right</key>
 									<value xsi:type="xsd:string">8px</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
 								</entry>
 								<entry>
 									<key>text-align</key>
@@ -7615,16 +5302,18 @@
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="select">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">redirect</attribute>
+								<attribute key="name" xsi:type="stringAttribute">redirect</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>8</x>
 									<y>574</y>
 									<height>31</height>
 									<width>66</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[5]/SELECT[1]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[5]/SELECT[1]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 								<attribute key="type" xsi:type="stringAttribute">SELECT</attribute>
 							</attributes>
@@ -7634,10 +5323,6 @@
 								<entry>
 									<key>background-color</key>
 									<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
-								</entry>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
 								</entry>
 								<entry>
 									<key>border-bottom-color</key>
@@ -7650,18 +5335,6 @@
 								<entry>
 									<key>border-bottom-width</key>
 									<value xsi:type="xsd:string">6px</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>border-image-width</key>
-									<value xsi:type="xsd:string">1</value>
 								</entry>
 								<entry>
 									<key>border-left-color</key>
@@ -7736,16 +5409,12 @@
 									<value xsi:type="xsd:string">avoid</value>
 								</entry>
 								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
 									<key>white-space</key>
 									<value xsi:type="xsd:string">nowrap</value>
 								</entry>
 							</attributes>
 						</attributes>
-						<containedComponents>
+						<containedComponents retestId="one">
 							<identifyingAttributes>
 								<attributes>
 									<attribute key="outline" xsi:type="outlineAttribute">
@@ -7754,7 +5423,7 @@
 										<height>17</height>
 										<width>63</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[5]/SELECT[1]/OPTION[1]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[5]/SELECT[1]/OPTION[1]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 									<attribute key="text" xsi:type="textAttribute">One</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -7767,24 +5436,8 @@
 										<value xsi:type="xsd:string">rgb(51, 153, 255)</value>
 									</entry>
 									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
 										<key>border-bottom-color</key>
 										<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
 									</entry>
 									<entry>
 										<key>border-left-color</key>
@@ -7811,18 +5464,6 @@
 										<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
 									</entry>
 									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">17px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">14px</value>
 									</entry>
@@ -7839,10 +5480,6 @@
 										<value xsi:type="xsd:string">5px</value>
 									</entry>
 									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
 										<key>text-align</key>
 										<value xsi:type="xsd:string">left</value>
 									</entry>
@@ -7850,23 +5487,20 @@
 										<key>text-decoration-color</key>
 										<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
 									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">nowrap</value>
-									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="two">
 							<identifyingAttributes>
 								<attributes>
+									<attribute key="id" xsi:type="stringAttribute">changeme</attribute>
 									<attribute key="outline" xsi:type="outlineAttribute">
 										<x>10</x>
 										<y>592</y>
 										<height>17</height>
 										<width>63</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[5]/SELECT[1]/OPTION[2]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[5]/SELECT[1]/OPTION[2]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 									<attribute key="text" xsi:type="textAttribute">Two</attribute>
 									<attribute key="type" xsi:type="stringAttribute">OPTION</attribute>
@@ -7874,34 +5508,6 @@
 							</identifyingAttributes>
 							<attributes>
 								<attributes>
-									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">17px</value>
-									</entry>
 									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">14px</value>
@@ -7915,66 +5521,32 @@
 										<value xsi:type="xsd:string">5px</value>
 									</entry>
 									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
 										<key>text-align</key>
 										<value xsi:type="xsd:string">left</value>
-									</entry>
-									<entry>
-										<key>white-space</key>
-										<value xsi:type="xsd:string">nowrap</value>
 									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="span">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">fileResults</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>564</x>
 									<y>594</y>
 									<height>0</height>
 									<width>0</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[5]/SPAN[1]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[5]/SPAN[1]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 								<attribute key="type" xsi:type="stringAttribute">SPAN</attribute>
 							</attributes>
 						</identifyingAttributes>
-						<attributes>
-							<attributes>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">serif</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">19px</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-							</attributes>
-						</attributes>
+						<attributes/>
 					</containedComponents>
 				</containedComponents>
-				<containedComponents>
+				<containedComponents retestId="form">
 					<identifyingAttributes>
 						<attributes>
 							<attribute key="outline" xsi:type="outlineAttribute">
@@ -7983,53 +5555,23 @@
 								<height>29</height>
 								<width>1340</width>
 							</attribute>
-							<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[6]</attribute>
+							<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[6]</attribute>
 							<attribute key="suffix" xsi:type="suffixAttribute">6</attribute>
 							<attribute key="type" xsi:type="stringAttribute">FORM</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">19px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>unicode-bidi</key>
-								<value xsi:type="xsd:string">isolate</value>
-							</entry>
-						</attributes>
-					</attributes>
-					<containedComponents>
+					<attributes/>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="name" xsi:type="stringAttribute">id-name1</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>8</x>
 									<y>621</y>
 									<height>29</height>
 									<width>211</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[6]/INPUT[1]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[6]/INPUT[1]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -8039,10 +5581,6 @@
 								<entry>
 									<key>background-color</key>
 									<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
-								</entry>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
 								</entry>
 								<entry>
 									<key>border-bottom-color</key>
@@ -8055,14 +5593,6 @@
 								<entry>
 									<key>border-bottom-width</key>
 									<value xsi:type="xsd:string">5px</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
 								</entry>
 								<entry>
 									<key>border-left-color</key>
@@ -8133,10 +5663,6 @@
 									<value xsi:type="xsd:string">0px</value>
 								</entry>
 								<entry>
-									<key>margin-top</key>
-									<value xsi:type="xsd:string">0px</value>
-								</entry>
-								<entry>
 									<key>outline-color</key>
 									<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 								</entry>
@@ -8157,26 +5683,23 @@
 									<value xsi:type="xsd:string">1px</value>
 								</entry>
 								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
 									<key>text-decoration-color</key>
 									<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 								</entry>
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">id-name1</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>224</x>
 									<y>621</y>
 									<height>29</height>
 									<width>211</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[6]/INPUT[2]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[6]/INPUT[2]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -8188,10 +5711,6 @@
 									<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
 								</entry>
 								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
 									<key>border-bottom-color</key>
 									<value xsi:type="xsd:string">rgb(227, 227, 227)</value>
 								</entry>
@@ -8202,14 +5721,6 @@
 								<entry>
 									<key>border-bottom-width</key>
 									<value xsi:type="xsd:string">5px</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
 								</entry>
 								<entry>
 									<key>border-left-color</key>
@@ -8280,10 +5791,6 @@
 									<value xsi:type="xsd:string">0px</value>
 								</entry>
 								<entry>
-									<key>margin-top</key>
-									<value xsi:type="xsd:string">0px</value>
-								</entry>
-								<entry>
 									<key>outline-color</key>
 									<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 								</entry>
@@ -8304,26 +5811,23 @@
 									<value xsi:type="xsd:string">1px</value>
 								</entry>
 								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
 									<key>text-decoration-color</key>
 									<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 								</entry>
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="id" xsi:type="stringAttribute">id-name2</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>440</x>
 									<y>621</y>
 									<height>29</height>
 									<width>211</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[6]/INPUT[3]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[6]/INPUT[3]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">3</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -8335,10 +5839,6 @@
 									<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
 								</entry>
 								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
 									<key>border-bottom-color</key>
 									<value xsi:type="xsd:string">rgb(227, 227, 227)</value>
 								</entry>
@@ -8349,14 +5849,6 @@
 								<entry>
 									<key>border-bottom-width</key>
 									<value xsi:type="xsd:string">5px</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
 								</entry>
 								<entry>
 									<key>border-left-color</key>
@@ -8427,10 +5919,6 @@
 									<value xsi:type="xsd:string">0px</value>
 								</entry>
 								<entry>
-									<key>margin-top</key>
-									<value xsi:type="xsd:string">0px</value>
-								</entry>
-								<entry>
 									<key>outline-color</key>
 									<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 								</entry>
@@ -8451,26 +5939,23 @@
 									<value xsi:type="xsd:string">1px</value>
 								</entry>
 								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
 									<key>text-decoration-color</key>
 									<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 								</entry>
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="name" xsi:type="stringAttribute">id-name2</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>656</x>
 									<y>621</y>
 									<height>29</height>
 									<width>211</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[6]/INPUT[4]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[6]/INPUT[4]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">4</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -8482,10 +5967,6 @@
 									<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
 								</entry>
 								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
 									<key>border-bottom-color</key>
 									<value xsi:type="xsd:string">rgb(227, 227, 227)</value>
 								</entry>
@@ -8496,14 +5977,6 @@
 								<entry>
 									<key>border-bottom-width</key>
 									<value xsi:type="xsd:string">5px</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
 								</entry>
 								<entry>
 									<key>border-left-color</key>
@@ -8574,10 +6047,6 @@
 									<value xsi:type="xsd:string">0px</value>
 								</entry>
 								<entry>
-									<key>margin-top</key>
-									<value xsi:type="xsd:string">0px</value>
-								</entry>
-								<entry>
 									<key>outline-color</key>
 									<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 								</entry>
@@ -8598,26 +6067,23 @@
 									<value xsi:type="xsd:string">1px</value>
 								</entry>
 								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
 									<key>text-decoration-color</key>
 									<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 								</entry>
 							</attributes>
 						</attributes>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
+								<attribute key="name" xsi:type="stringAttribute">readonly</attribute>
 								<attribute key="outline" xsi:type="outlineAttribute">
 									<x>872</x>
 									<y>621</y>
 									<height>29</height>
 									<width>211</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[6]/INPUT[5]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[6]/INPUT[5]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">5</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -8629,10 +6095,6 @@
 									<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
 								</entry>
 								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
 									<key>border-bottom-color</key>
 									<value xsi:type="xsd:string">rgb(227, 227, 227)</value>
 								</entry>
@@ -8643,14 +6105,6 @@
 								<entry>
 									<key>border-bottom-width</key>
 									<value xsi:type="xsd:string">5px</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
 								</entry>
 								<entry>
 									<key>border-left-color</key>
@@ -8721,10 +6175,6 @@
 									<value xsi:type="xsd:string">0px</value>
 								</entry>
 								<entry>
-									<key>margin-top</key>
-									<value xsi:type="xsd:string">0px</value>
-								</entry>
-								<entry>
 									<key>outline-color</key>
 									<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 								</entry>
@@ -8745,10 +6195,6 @@
 									<value xsi:type="xsd:string">1px</value>
 								</entry>
 								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
 									<key>text-decoration-color</key>
 									<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 								</entry>
@@ -8756,53 +6202,23 @@
 						</attributes>
 					</containedComponents>
 				</containedComponents>
-				<containedComponents>
+				<containedComponents retestId="form">
 					<identifyingAttributes>
 						<attributes>
+							<attribute key="id" xsi:type="stringAttribute">nested_form</attribute>
 							<attribute key="outline" xsi:type="outlineAttribute">
 								<x>8</x>
 								<y>666</y>
 								<height>58</height>
 								<width>1340</width>
 							</attribute>
-							<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[7]</attribute>
+							<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[7]</attribute>
 							<attribute key="suffix" xsi:type="suffixAttribute">7</attribute>
 							<attribute key="type" xsi:type="stringAttribute">FORM</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">19px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>unicode-bidi</key>
-								<value xsi:type="xsd:string">isolate</value>
-							</entry>
-						</attributes>
-					</attributes>
-					<containedComponents>
+					<attributes/>
+					<containedComponents retestId="div">
 						<identifyingAttributes>
 							<attributes>
 								<attribute key="outline" xsi:type="outlineAttribute">
@@ -8811,53 +6227,23 @@
 									<height>29</height>
 									<width>1340</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[7]/DIV[1]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[7]/DIV[1]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 								<attribute key="type" xsi:type="stringAttribute">DIV</attribute>
 							</attributes>
 						</identifyingAttributes>
-						<attributes>
-							<attributes>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">serif</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">19px</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
-									<key>unicode-bidi</key>
-									<value xsi:type="xsd:string">isolate</value>
-								</entry>
-							</attributes>
-						</attributes>
-						<containedComponents>
+						<attributes/>
+						<containedComponents retestId="input">
 							<identifyingAttributes>
 								<attributes>
+									<attribute key="name" xsi:type="stringAttribute">x</attribute>
 									<attribute key="outline" xsi:type="outlineAttribute">
 										<x>8</x>
 										<y>666</y>
 										<height>29</height>
 										<width>211</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[7]/DIV[1]/INPUT[1]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[7]/DIV[1]/INPUT[1]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 									<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 								</attributes>
@@ -8867,10 +6253,6 @@
 									<entry>
 										<key>background-color</key>
 										<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
-									</entry>
-									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
 									</entry>
 									<entry>
 										<key>border-bottom-color</key>
@@ -8883,14 +6265,6 @@
 									<entry>
 										<key>border-bottom-width</key>
 										<value xsi:type="xsd:string">5px</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
 									</entry>
 									<entry>
 										<key>border-left-color</key>
@@ -8957,14 +6331,6 @@
 										<value xsi:type="xsd:string">17px</value>
 									</entry>
 									<entry>
-										<key>margin-bottom</key>
-										<value xsi:type="xsd:string">0px</value>
-									</entry>
-									<entry>
-										<key>margin-top</key>
-										<value xsi:type="xsd:string">0px</value>
-									</entry>
-									<entry>
 										<key>outline-color</key>
 										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 									</entry>
@@ -8985,10 +6351,6 @@
 										<value xsi:type="xsd:string">1px</value>
 									</entry>
 									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
 										<key>text-decoration-color</key>
 										<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 									</entry>
@@ -8996,7 +6358,7 @@
 							</attributes>
 						</containedComponents>
 					</containedComponents>
-					<containedComponents>
+					<containedComponents retestId="input">
 						<identifyingAttributes>
 							<attributes>
 								<attribute key="outline" xsi:type="outlineAttribute">
@@ -9005,7 +6367,7 @@
 									<height>29</height>
 									<width>127</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[7]/INPUT[1]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[7]/INPUT[1]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 								<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 							</attributes>
@@ -9015,10 +6377,6 @@
 								<entry>
 									<key>background-color</key>
 									<value xsi:type="xsd:string">rgb(240, 240, 240)</value>
-								</entry>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
 								</entry>
 								<entry>
 									<key>border-bottom-color</key>
@@ -9031,14 +6389,6 @@
 								<entry>
 									<key>border-bottom-width</key>
 									<value xsi:type="xsd:string">6px</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
 								</entry>
 								<entry>
 									<key>border-left-color</key>
@@ -9097,20 +6447,12 @@
 									<value xsi:type="xsd:string">0px</value>
 								</entry>
 								<entry>
-									<key>margin-top</key>
-									<value xsi:type="xsd:string">0px</value>
-								</entry>
-								<entry>
 									<key>padding-left</key>
 									<value xsi:type="xsd:string">8px</value>
 								</entry>
 								<entry>
 									<key>padding-right</key>
 									<value xsi:type="xsd:string">8px</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
 								</entry>
 								<entry>
 									<key>text-align</key>
@@ -9124,7 +6466,7 @@
 						</attributes>
 					</containedComponents>
 				</containedComponents>
-				<containedComponents>
+				<containedComponents retestId="form">
 					<identifyingAttributes>
 						<attributes>
 							<attribute key="outline" xsi:type="outlineAttribute">
@@ -9133,44 +6475,13 @@
 								<height>29</height>
 								<width>1340</width>
 							</attribute>
-							<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[8]</attribute>
+							<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[8]</attribute>
 							<attribute key="suffix" xsi:type="suffixAttribute">8</attribute>
 							<attribute key="type" xsi:type="stringAttribute">FORM</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">19px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>unicode-bidi</key>
-								<value xsi:type="xsd:string">isolate</value>
-							</entry>
-						</attributes>
-					</attributes>
-					<containedComponents>
+					<attributes/>
+					<containedComponents retestId="p">
 						<identifyingAttributes>
 							<attributes>
 								<attribute key="outline" xsi:type="outlineAttribute">
@@ -9179,53 +6490,23 @@
 									<height>29</height>
 									<width>1340</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[8]/P[1]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[8]/P[1]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 								<attribute key="type" xsi:type="stringAttribute">P</attribute>
 							</attributes>
 						</identifyingAttributes>
-						<attributes>
-							<attributes>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">serif</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">19px</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
-									<key>unicode-bidi</key>
-									<value xsi:type="xsd:string">isolate</value>
-								</entry>
-							</attributes>
-						</attributes>
-						<containedComponents>
+						<attributes/>
+						<containedComponents retestId="input">
 							<identifyingAttributes>
 								<attributes>
+									<attribute key="id" xsi:type="stringAttribute">disabledTextElement1</attribute>
 									<attribute key="outline" xsi:type="outlineAttribute">
 										<x>8</x>
 										<y>740</y>
 										<height>29</height>
 										<width>211</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[8]/P[1]/INPUT[1]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[8]/P[1]/INPUT[1]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 									<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 								</attributes>
@@ -9237,10 +6518,6 @@
 										<value xsi:type="xsd:string">rgb(227, 227, 227)</value>
 									</entry>
 									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
 										<key>border-bottom-color</key>
 										<value xsi:type="xsd:string">rgb(227, 227, 227)</value>
 									</entry>
@@ -9251,14 +6528,6 @@
 									<entry>
 										<key>border-bottom-width</key>
 										<value xsi:type="xsd:string">5px</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
 									</entry>
 									<entry>
 										<key>border-left-color</key>
@@ -9353,26 +6622,23 @@
 										<value xsi:type="xsd:string">1px</value>
 									</entry>
 									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
 										<key>text-decoration-color</key>
 										<value xsi:type="xsd:string">rgb(109, 109, 109)</value>
 									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="input">
 							<identifyingAttributes>
 								<attributes>
+									<attribute key="id" xsi:type="stringAttribute">disabledTextElement2</attribute>
 									<attribute key="outline" xsi:type="outlineAttribute">
 										<x>224</x>
 										<y>740</y>
 										<height>29</height>
 										<width>211</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[8]/P[1]/INPUT[2]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[8]/P[1]/INPUT[2]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 									<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 								</attributes>
@@ -9384,10 +6650,6 @@
 										<value xsi:type="xsd:string">rgb(227, 227, 227)</value>
 									</entry>
 									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
 										<key>border-bottom-color</key>
 										<value xsi:type="xsd:string">rgb(227, 227, 227)</value>
 									</entry>
@@ -9398,14 +6660,6 @@
 									<entry>
 										<key>border-bottom-width</key>
 										<value xsi:type="xsd:string">5px</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
 									</entry>
 									<entry>
 										<key>border-left-color</key>
@@ -9500,26 +6754,23 @@
 										<value xsi:type="xsd:string">1px</value>
 									</entry>
 									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
 										<key>text-decoration-color</key>
 										<value xsi:type="xsd:string">rgb(109, 109, 109)</value>
 									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="input">
 							<identifyingAttributes>
 								<attributes>
+									<attribute key="id" xsi:type="stringAttribute">disabledSubmitElement</attribute>
 									<attribute key="outline" xsi:type="outlineAttribute">
 										<x>440</x>
 										<y>740</y>
 										<height>29</height>
 										<width>80</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[8]/P[1]/INPUT[3]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[8]/P[1]/INPUT[3]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">3</attribute>
 									<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 								</attributes>
@@ -9529,10 +6780,6 @@
 									<entry>
 										<key>background-color</key>
 										<value xsi:type="xsd:string">rgb(240, 240, 240)</value>
-									</entry>
-									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
 									</entry>
 									<entry>
 										<key>border-bottom-color</key>
@@ -9545,14 +6792,6 @@
 									<entry>
 										<key>border-bottom-width</key>
 										<value xsi:type="xsd:string">6px</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
 									</entry>
 									<entry>
 										<key>border-left-color</key>
@@ -9637,10 +6876,6 @@
 									<entry>
 										<key>padding-right</key>
 										<value xsi:type="xsd:string">8px</value>
-									</entry>
-									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
 									</entry>
 									<entry>
 										<key>text-align</key>
@@ -9659,7 +6894,7 @@
 						</containedComponents>
 					</containedComponents>
 				</containedComponents>
-				<containedComponents>
+				<containedComponents retestId="form">
 					<identifyingAttributes>
 						<attributes>
 							<attribute key="outline" xsi:type="outlineAttribute">
@@ -9668,44 +6903,13 @@
 								<height>25</height>
 								<width>1340</width>
 							</attribute>
-							<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[9]</attribute>
+							<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[9]</attribute>
 							<attribute key="suffix" xsi:type="suffixAttribute">9</attribute>
 							<attribute key="type" xsi:type="stringAttribute">FORM</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">19px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>unicode-bidi</key>
-								<value xsi:type="xsd:string">isolate</value>
-							</entry>
-						</attributes>
-					</attributes>
-					<containedComponents>
+					<attributes/>
+					<containedComponents retestId="p">
 						<identifyingAttributes>
 							<attributes>
 								<attribute key="outline" xsi:type="outlineAttribute">
@@ -9714,71 +6918,29 @@
 									<height>25</height>
 									<width>1340</width>
 								</attribute>
-								<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[9]/P[1]</attribute>
+								<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[9]/P[1]</attribute>
 								<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 								<attribute key="type" xsi:type="stringAttribute">P</attribute>
 							</attributes>
 						</identifyingAttributes>
-						<attributes>
-							<attributes>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">serif</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">19px</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
-									<key>unicode-bidi</key>
-									<value xsi:type="xsd:string">isolate</value>
-								</entry>
-							</attributes>
-						</attributes>
-						<containedComponents>
+						<attributes/>
+						<containedComponents retestId="input">
 							<identifyingAttributes>
 								<attributes>
+									<attribute key="id" xsi:type="stringAttribute">checkbox-with-label</attribute>
 									<attribute key="outline" xsi:type="outlineAttribute">
 										<x>57</x>
 										<y>833</y>
 										<height>18</height>
 										<width>18</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[9]/P[1]/INPUT[1]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[9]/P[1]/INPUT[1]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 									<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 								</attributes>
 							</identifyingAttributes>
 							<attributes>
 								<attributes>
-									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
 									<entry>
 										<key>font-family</key>
 										<value xsi:type="xsd:string">sans-serif</value>
@@ -9799,69 +6961,40 @@
 										<key>margin-right</key>
 										<value xsi:type="xsd:string">3px</value>
 									</entry>
-									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
-						<containedComponents>
+						<containedComponents retestId="label">
 							<identifyingAttributes>
 								<attributes>
+									<attribute key="id" xsi:type="stringAttribute">label-for-checkbox-with-label</attribute>
 									<attribute key="outline" xsi:type="outlineAttribute">
 										<x>8</x>
 										<y>836</y>
 										<height>19</height>
 										<width>45</width>
 									</attribute>
-									<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/FORM[9]/P[1]/LABEL[1]</attribute>
+									<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/FORM[9]/P[1]/LABEL[1]</attribute>
 									<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 									<attribute key="text" xsi:type="textAttribute">Label</attribute>
 									<attribute key="type" xsi:type="stringAttribute">LABEL</attribute>
 								</attributes>
 							</identifyingAttributes>
-							<attributes>
-								<attributes>
-									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">serif</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">19px</value>
-									</entry>
-									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-								</attributes>
-							</attributes>
+							<attributes/>
 						</containedComponents>
 					</containedComponents>
 				</containedComponents>
-				<containedComponents>
+				<containedComponents retestId="input">
 					<identifyingAttributes>
 						<attributes>
+							<attribute key="id" xsi:type="stringAttribute">killIframe</attribute>
 							<attribute key="outline" xsi:type="outlineAttribute">
 								<x>8</x>
 								<y>785</y>
 								<height>29</height>
 								<width>181</width>
 							</attribute>
-							<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/INPUT[1]</attribute>
+							<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/INPUT[1]</attribute>
 							<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 							<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 						</attributes>
@@ -9871,10 +7004,6 @@
 							<entry>
 								<key>background-color</key>
 								<value xsi:type="xsd:string">rgb(240, 240, 240)</value>
-							</entry>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
 							</entry>
 							<entry>
 								<key>border-bottom-color</key>
@@ -9887,14 +7016,6 @@
 							<entry>
 								<key>border-bottom-width</key>
 								<value xsi:type="xsd:string">6px</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
 							</entry>
 							<entry>
 								<key>border-left-color</key>
@@ -9965,10 +7086,6 @@
 								<value xsi:type="xsd:string">8px</value>
 							</entry>
 							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
 								<key>text-align</key>
 								<value xsi:type="xsd:string">center</value>
 							</entry>
@@ -9979,16 +7096,19 @@
 						</attributes>
 					</attributes>
 				</containedComponents>
-				<containedComponents>
+				<containedComponents retestId="input">
 					<identifyingAttributes>
 						<attributes>
+							<attribute key="class" xsi:type="stringAttribute">inputLabel</attribute>
+							<attribute key="id" xsi:type="stringAttribute">vsearchGadget</attribute>
+							<attribute key="name" xsi:type="stringAttribute">SearchableText</attribute>
 							<attribute key="outline" xsi:type="outlineAttribute">
 								<x>8</x>
 								<y>871</y>
 								<height>29</height>
 								<width>193</width>
 							</attribute>
-							<attribute key="path" xsi:type="pathAttribute">//HTML[1]/BODY[1]/INPUT[2]</attribute>
+							<attribute key="path" xsi:type="pathAttribute">HTML[1]/BODY[1]/INPUT[2]</attribute>
 							<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
 							<attribute key="type" xsi:type="stringAttribute">INPUT</attribute>
 						</attributes>
@@ -9998,10 +7118,6 @@
 							<entry>
 								<key>background-color</key>
 								<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
-							</entry>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
 							</entry>
 							<entry>
 								<key>border-bottom-color</key>
@@ -10014,14 +7130,6 @@
 							<entry>
 								<key>border-bottom-width</key>
 								<value xsi:type="xsd:string">5px</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
 							</entry>
 							<entry>
 								<key>border-left-color</key>
@@ -10116,10 +7224,6 @@
 								<value xsi:type="xsd:string">1px</value>
 							</entry>
 							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
 								<key>text-decoration-color</key>
 								<value xsi:type="xsd:string">rgb(33, 33, 33)</value>
 							</entry>
@@ -10127,7 +7231,7 @@
 					</attributes>
 				</containedComponents>
 			</containedComponents>
-			<containedComponents>
+			<containedComponents retestId="head">
 				<identifyingAttributes>
 					<attributes>
 						<attribute key="outline" xsi:type="outlineAttribute">
@@ -10136,40 +7240,13 @@
 							<height>0</height>
 							<width>0</width>
 						</attribute>
-						<attribute key="path" xsi:type="pathAttribute">//HTML[1]/HEAD[1]</attribute>
+						<attribute key="path" xsi:type="pathAttribute">HTML[1]/HEAD[1]</attribute>
 						<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 						<attribute key="type" xsi:type="stringAttribute">HEAD</attribute>
 					</attributes>
 				</identifyingAttributes>
-				<attributes>
-					<attributes>
-						<entry>
-							<key>background-size</key>
-							<value xsi:type="xsd:string">auto auto</value>
-						</entry>
-						<entry>
-							<key>border-image-outset</key>
-							<value xsi:type="xsd:string">0</value>
-						</entry>
-						<entry>
-							<key>border-image-repeat</key>
-							<value xsi:type="xsd:string">stretch stretch</value>
-						</entry>
-						<entry>
-							<key>font-family</key>
-							<value xsi:type="xsd:string">serif</value>
-						</entry>
-						<entry>
-							<key>line-height</key>
-							<value xsi:type="xsd:string">19px</value>
-						</entry>
-						<entry>
-							<key>quotes</key>
-							<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-						</entry>
-					</attributes>
-				</attributes>
-				<containedComponents>
+				<attributes/>
+				<containedComponents retestId="function_change">
 					<identifyingAttributes>
 						<attributes>
 							<attribute key="outline" xsi:type="outlineAttribute">
@@ -10178,7 +7255,7 @@
 								<height>0</height>
 								<width>0</width>
 							</attribute>
-							<attribute key="path" xsi:type="pathAttribute">//HTML[1]/HEAD[1]/SCRIPT[1]</attribute>
+							<attribute key="path" xsi:type="pathAttribute">HTML[1]/HEAD[1]/SCRIPT[1]</attribute>
 							<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 							<attribute key="text" xsi:type="textAttribute">function changePage() {
             var newLocation = '/common/page/3';
@@ -10187,36 +7264,9 @@
 							<attribute key="type" xsi:type="stringAttribute">SCRIPT</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">19px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
-				<containedComponents>
+				<containedComponents retestId="we_leave_from">
 					<identifyingAttributes>
 						<attributes>
 							<attribute key="outline" xsi:type="outlineAttribute">
@@ -10225,40 +7275,13 @@
 								<height>0</height>
 								<width>0</width>
 							</attribute>
-							<attribute key="path" xsi:type="pathAttribute">//HTML[1]/HEAD[1]/TITLE[1]</attribute>
+							<attribute key="path" xsi:type="pathAttribute">HTML[1]/HEAD[1]/TITLE[1]</attribute>
 							<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 							<attribute key="text" xsi:type="textAttribute">We Leave From Here</attribute>
 							<attribute key="type" xsi:type="stringAttribute">TITLE</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">19px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 			</containedComponents>
 			<screenshot>

--- a/src/test/resources/retest/recheck/de.retest.web.ShowcaseIT/showcase-ChromeDriver.open.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.ShowcaseIT/showcase-ChromeDriver.open.recheck/retest.xml
@@ -65,10 +65,6 @@
 							<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 						</entry>
 						<entry>
-							<key>box-sizing</key>
-							<value xsi:type="xsd:string">border-box</value>
-						</entry>
-						<entry>
 							<key>caret-color</key>
 							<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 						</entry>
@@ -91,22 +87,6 @@
 						<entry>
 							<key>line-height</key>
 							<value xsi:type="xsd:string">30px</value>
-						</entry>
-						<entry>
-							<key>margin-bottom</key>
-							<value xsi:type="xsd:string">0px</value>
-						</entry>
-						<entry>
-							<key>margin-left</key>
-							<value xsi:type="xsd:string">0px</value>
-						</entry>
-						<entry>
-							<key>margin-right</key>
-							<value xsi:type="xsd:string">0px</value>
-						</entry>
-						<entry>
-							<key>margin-top</key>
-							<value xsi:type="xsd:string">0px</value>
 						</entry>
 						<entry>
 							<key>outline-color</key>
@@ -135,68 +115,12 @@
 					<attributes>
 						<attributes>
 							<entry>
-								<key>background-color</key>
-								<value xsi:type="xsd:string">rgb(212, 218, 223)</value>
-							</entry>
-							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
 								<key>font-size</key>
 								<value xsi:type="xsd:string">14px</value>
 							</entry>
 							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
 								<key>padding-top</key>
 								<value xsi:type="xsd:string">66px</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -218,50 +142,6 @@
 						<attributes>
 							<attributes>
 								<entry>
-									<key>border-bottom-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-left-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-right-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-top-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>box-sizing</key>
-									<value xsi:type="xsd:string">border-box</value>
-								</entry>
-								<entry>
-									<key>caret-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>column-rule-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-								</entry>
-								<entry>
-									<key>font-size</key>
-									<value xsi:type="xsd:string">14px</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">30px</value>
-								</entry>
-								<entry>
 									<key>margin-left</key>
 									<value xsi:type="xsd:string">82.5px</value>
 								</entry>
@@ -272,14 +152,6 @@
 								<entry>
 									<key>max-width</key>
 									<value xsi:type="xsd:string">1020px</value>
-								</entry>
-								<entry>
-									<key>outline-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>text-decoration-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 								</entry>
 							</attributes>
 						</attributes>
@@ -301,60 +173,12 @@
 							<attributes>
 								<attributes>
 									<entry>
-										<key>border-bottom-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>border-left-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>border-right-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>border-top-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>box-sizing</key>
-										<value xsi:type="xsd:string">border-box</value>
-									</entry>
-									<entry>
-										<key>caret-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>column-rule-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
 										<key>float</key>
 										<value xsi:type="xsd:string">left</value>
 									</entry>
 									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">30px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">1px</value>
-									</entry>
-									<entry>
-										<key>outline-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 									</entry>
 									<entry>
 										<key>padding-left</key>
@@ -367,10 +191,6 @@
 									<entry>
 										<key>position</key>
 										<value xsi:type="xsd:string">relative</value>
-									</entry>
-									<entry>
-										<key>text-decoration-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 									</entry>
 								</attributes>
 							</attributes>
@@ -392,66 +212,6 @@
 								<attributes>
 									<attributes>
 										<entry>
-											<key>border-bottom-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-image-width</key>
-											<value xsi:type="xsd:string">1</value>
-										</entry>
-										<entry>
-											<key>border-left-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-right-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-top-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>box-sizing</key>
-											<value xsi:type="xsd:string">border-box</value>
-										</entry>
-										<entry>
-											<key>caret-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>column-rule-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>font-family</key>
-											<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-										</entry>
-										<entry>
-											<key>font-size</key>
-											<value xsi:type="xsd:string">14px</value>
-										</entry>
-										<entry>
-											<key>line-height</key>
-											<value xsi:type="xsd:string">30px</value>
-										</entry>
-										<entry>
-											<key>margin-bottom</key>
-											<value xsi:type="xsd:string">0px</value>
-										</entry>
-										<entry>
-											<key>margin-top</key>
-											<value xsi:type="xsd:string">0px</value>
-										</entry>
-										<entry>
-											<key>outline-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
 											<key>padding-left</key>
 											<value xsi:type="xsd:string">0px</value>
 										</entry>
@@ -462,10 +222,6 @@
 										<entry>
 											<key>text-align</key>
 											<value xsi:type="xsd:string">center</value>
-										</entry>
-										<entry>
-											<key>text-decoration-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 										</entry>
 									</attributes>
 								</attributes>
@@ -487,68 +243,12 @@
 									<attributes>
 										<attributes>
 											<entry>
-												<key>border-bottom-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-image-width</key>
-												<value xsi:type="xsd:string">1</value>
-											</entry>
-											<entry>
-												<key>border-left-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-right-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-top-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
-											</entry>
-											<entry>
-												<key>caret-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>column-rule-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
 												<key>display</key>
 												<value xsi:type="xsd:string">inline-block</value>
 											</entry>
 											<entry>
-												<key>font-family</key>
-												<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-											</entry>
-											<entry>
-												<key>font-size</key>
-												<value xsi:type="xsd:string">14px</value>
-											</entry>
-											<entry>
 												<key>line-height</key>
 												<value xsi:type="xsd:string">24px</value>
-											</entry>
-											<entry>
-												<key>outline-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>text-align</key>
-												<value xsi:type="xsd:string">center</value>
-											</entry>
-											<entry>
-												<key>text-decoration-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 											</entry>
 										</attributes>
 									</attributes>
@@ -571,68 +271,12 @@
 									<attributes>
 										<attributes>
 											<entry>
-												<key>border-bottom-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-image-width</key>
-												<value xsi:type="xsd:string">1</value>
-											</entry>
-											<entry>
-												<key>border-left-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-right-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-top-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
-											</entry>
-											<entry>
-												<key>caret-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>column-rule-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
 												<key>display</key>
 												<value xsi:type="xsd:string">inline-block</value>
 											</entry>
 											<entry>
-												<key>font-family</key>
-												<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-											</entry>
-											<entry>
-												<key>font-size</key>
-												<value xsi:type="xsd:string">14px</value>
-											</entry>
-											<entry>
 												<key>line-height</key>
 												<value xsi:type="xsd:string">24px</value>
-											</entry>
-											<entry>
-												<key>outline-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>text-align</key>
-												<value xsi:type="xsd:string">center</value>
-											</entry>
-											<entry>
-												<key>text-decoration-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 											</entry>
 										</attributes>
 									</attributes>
@@ -670,10 +314,6 @@
 													<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 												</entry>
 												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
 													<key>caret-color</key>
 													<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 												</entry>
@@ -686,32 +326,12 @@
 													<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 												</entry>
 												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">14px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">24px</value>
-												</entry>
-												<entry>
 													<key>outline-color</key>
 													<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 												</entry>
 												<entry>
-													<key>text-align</key>
-													<value xsi:type="xsd:string">center</value>
-												</entry>
-												<entry>
 													<key>text-decoration-color</key>
 													<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-												</entry>
-												<entry>
-													<key>text-decoration-line</key>
-													<value xsi:type="xsd:string">none</value>
 												</entry>
 												<entry>
 													<key>transition-duration</key>
@@ -747,70 +367,7 @@
 							<attribute key="type" xsi:type="stringAttribute">HEADER</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-color</key>
-								<value xsi:type="xsd:string">rgb(212, 218, 223)</value>
-							</entry>
-							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">15px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 					<containedComponents retestId="div">
 						<identifyingAttributes>
 							<attributes>
@@ -829,50 +386,6 @@
 						<attributes>
 							<attributes>
 								<entry>
-									<key>border-bottom-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-left-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-right-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-top-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>box-sizing</key>
-									<value xsi:type="xsd:string">border-box</value>
-								</entry>
-								<entry>
-									<key>caret-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>column-rule-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-								</entry>
-								<entry>
-									<key>font-size</key>
-									<value xsi:type="xsd:string">15px</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">30px</value>
-								</entry>
-								<entry>
 									<key>margin-left</key>
 									<value xsi:type="xsd:string">82.5px</value>
 								</entry>
@@ -883,14 +396,6 @@
 								<entry>
 									<key>max-width</key>
 									<value xsi:type="xsd:string">1020px</value>
-								</entry>
-								<entry>
-									<key>outline-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>text-decoration-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 								</entry>
 							</attributes>
 						</attributes>
@@ -912,60 +417,12 @@
 							<attributes>
 								<attributes>
 									<entry>
-										<key>border-bottom-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>border-left-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>border-right-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>border-top-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>box-sizing</key>
-										<value xsi:type="xsd:string">border-box</value>
-									</entry>
-									<entry>
-										<key>caret-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>column-rule-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
 										<key>float</key>
 										<value xsi:type="xsd:string">left</value>
 									</entry>
 									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">15px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">30px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">1px</value>
-									</entry>
-									<entry>
-										<key>outline-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 									</entry>
 									<entry>
 										<key>padding-left</key>
@@ -978,10 +435,6 @@
 									<entry>
 										<key>position</key>
 										<value xsi:type="xsd:string">relative</value>
-									</entry>
-									<entry>
-										<key>text-decoration-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 									</entry>
 								</attributes>
 							</attributes>
@@ -1003,60 +456,12 @@
 								<attributes>
 									<attributes>
 										<entry>
-											<key>border-bottom-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-left-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-right-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-top-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
 											<key>bottom</key>
 											<value xsi:type="xsd:string">50px</value>
 										</entry>
 										<entry>
-											<key>box-sizing</key>
-											<value xsi:type="xsd:string">border-box</value>
-										</entry>
-										<entry>
-											<key>caret-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>column-rule-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>font-family</key>
-											<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-										</entry>
-										<entry>
-											<key>font-size</key>
-											<value xsi:type="xsd:string">15px</value>
-										</entry>
-										<entry>
 											<key>left</key>
 											<value xsi:type="xsd:string">20px</value>
-										</entry>
-										<entry>
-											<key>line-height</key>
-											<value xsi:type="xsd:string">30px</value>
-										</entry>
-										<entry>
-											<key>outline-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 										</entry>
 										<entry>
 											<key>position</key>
@@ -1065,10 +470,6 @@
 										<entry>
 											<key>right</key>
 											<value xsi:type="xsd:string">820px</value>
-										</entry>
-										<entry>
-											<key>text-decoration-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 										</entry>
 										<entry>
 											<key>top</key>
@@ -1109,10 +510,6 @@
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 											</entry>
 											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
-											</entry>
-											<entry>
 												<key>caret-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 											</entry>
@@ -1125,32 +522,12 @@
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 											</entry>
 											<entry>
-												<key>display</key>
-												<value xsi:type="xsd:string">block</value>
-											</entry>
-											<entry>
-												<key>font-family</key>
-												<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-											</entry>
-											<entry>
-												<key>font-size</key>
-												<value xsi:type="xsd:string">15px</value>
-											</entry>
-											<entry>
-												<key>line-height</key>
-												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
 												<key>outline-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 											</entry>
 											<entry>
 												<key>text-decoration-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-											</entry>
-											<entry>
-												<key>text-decoration-line</key>
-												<value xsi:type="xsd:string">none</value>
 											</entry>
 											<entry>
 												<key>transition-duration</key>
@@ -1183,10 +560,6 @@
 										<attributes>
 											<attributes>
 												<entry>
-													<key>border-bottom-color</key>
-													<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-												</entry>
-												<entry>
 													<key>border-bottom-left-radius</key>
 													<value xsi:type="xsd:string">3px</value>
 												</entry>
@@ -1195,20 +568,8 @@
 													<value xsi:type="xsd:string">3px</value>
 												</entry>
 												<entry>
-													<key>border-left-color</key>
-													<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-												</entry>
-												<entry>
 													<key>border-radius</key>
 													<value xsi:type="xsd:string">3px</value>
-												</entry>
-												<entry>
-													<key>border-right-color</key>
-													<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-												</entry>
-												<entry>
-													<key>border-top-color</key>
-													<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 												</entry>
 												<entry>
 													<key>border-top-left-radius</key>
@@ -1219,44 +580,8 @@
 													<value xsi:type="xsd:string">3px</value>
 												</entry>
 												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
-													<key>caret-color</key>
-													<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-												</entry>
-												<entry>
-													<key>color</key>
-													<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-												</entry>
-												<entry>
-													<key>column-rule-color</key>
-													<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-												</entry>
-												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">15px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">30px</value>
-												</entry>
-												<entry>
 													<key>max-width</key>
 													<value xsi:type="xsd:string">100%</value>
-												</entry>
-												<entry>
-													<key>outline-color</key>
-													<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-												</entry>
-												<entry>
-													<key>text-decoration-color</key>
-													<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -1281,42 +606,6 @@
 								<attributes>
 									<attributes>
 										<entry>
-											<key>border-bottom-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-image-width</key>
-											<value xsi:type="xsd:string">1</value>
-										</entry>
-										<entry>
-											<key>border-left-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-right-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-top-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>box-sizing</key>
-											<value xsi:type="xsd:string">border-box</value>
-										</entry>
-										<entry>
-											<key>caret-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>column-rule-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
 											<key>float</key>
 											<value xsi:type="xsd:string">right</value>
 										</entry>
@@ -1335,18 +624,6 @@
 										<entry>
 											<key>margin-top</key>
 											<value xsi:type="xsd:string">36px</value>
-										</entry>
-										<entry>
-											<key>outline-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>position</key>
-											<value xsi:type="xsd:string">relative</value>
-										</entry>
-										<entry>
-											<key>text-decoration-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 										</entry>
 										<entry>
 											<key>z-index</key>
@@ -1409,10 +686,6 @@
 												<value xsi:type="xsd:string">3px</value>
 											</entry>
 											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
-											</entry>
-											<entry>
 												<key>caret-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 											</entry>
@@ -1429,24 +702,12 @@
 												<value xsi:type="xsd:string">none</value>
 											</entry>
 											<entry>
-												<key>font-family</key>
-												<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-											</entry>
-											<entry>
-												<key>font-size</key>
-												<value xsi:type="xsd:string">14px</value>
-											</entry>
-											<entry>
 												<key>outline-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 											</entry>
 											<entry>
 												<key>text-decoration-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-											</entry>
-											<entry>
-												<key>text-decoration-line</key>
-												<value xsi:type="xsd:string">none</value>
 											</entry>
 											<entry>
 												<key>transition-duration</key>
@@ -1518,10 +779,6 @@
 												<value xsi:type="xsd:string">3px</value>
 											</entry>
 											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
-											</entry>
-											<entry>
 												<key>caret-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 											</entry>
@@ -1538,24 +795,12 @@
 												<value xsi:type="xsd:string">none</value>
 											</entry>
 											<entry>
-												<key>font-family</key>
-												<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-											</entry>
-											<entry>
-												<key>font-size</key>
-												<value xsi:type="xsd:string">14px</value>
-											</entry>
-											<entry>
 												<key>outline-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 											</entry>
 											<entry>
 												<key>text-decoration-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-											</entry>
-											<entry>
-												<key>text-decoration-line</key>
-												<value xsi:type="xsd:string">none</value>
 											</entry>
 											<entry>
 												<key>transition-duration</key>
@@ -1591,56 +836,8 @@
 									<attributes>
 										<attributes>
 											<entry>
-												<key>border-bottom-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-image-width</key>
-												<value xsi:type="xsd:string">1</value>
-											</entry>
-											<entry>
-												<key>border-left-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-right-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-top-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
-											</entry>
-											<entry>
-												<key>caret-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>column-rule-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
 												<key>display</key>
 												<value xsi:type="xsd:string">inline</value>
-											</entry>
-											<entry>
-												<key>font-family</key>
-												<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-											</entry>
-											<entry>
-												<key>font-size</key>
-												<value xsi:type="xsd:string">14px</value>
-											</entry>
-											<entry>
-												<key>margin-bottom</key>
-												<value xsi:type="xsd:string">0px</value>
 											</entry>
 											<entry>
 												<key>margin-top</key>
@@ -1651,20 +848,8 @@
 												<value xsi:type="xsd:string">48px</value>
 											</entry>
 											<entry>
-												<key>outline-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>padding-left</key>
-												<value xsi:type="xsd:string">0px</value>
-											</entry>
-											<entry>
 												<key>text-align</key>
 												<value xsi:type="xsd:string">left</value>
-											</entry>
-											<entry>
-												<key>text-decoration-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 											</entry>
 										</attributes>
 									</attributes>
@@ -1685,72 +870,16 @@
 										<attributes>
 											<attributes>
 												<entry>
-													<key>border-bottom-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-image-width</key>
-													<value xsi:type="xsd:string">1</value>
-												</entry>
-												<entry>
-													<key>border-left-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-right-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-top-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
-													<key>caret-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>column-rule-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>display</key>
 													<value xsi:type="xsd:string">inline-block</value>
-												</entry>
-												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">14px</value>
 												</entry>
 												<entry>
 													<key>list-style-type</key>
 													<value xsi:type="xsd:string">none</value>
 												</entry>
 												<entry>
-													<key>outline-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>position</key>
 													<value xsi:type="xsd:string">relative</value>
-												</entry>
-												<entry>
-													<key>text-align</key>
-													<value xsi:type="xsd:string">left</value>
-												</entry>
-												<entry>
-													<key>text-decoration-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -1768,66 +897,7 @@
 													<attribute key="type" xsi:type="stringAttribute">SPAN</attribute>
 												</attributes>
 											</identifyingAttributes>
-											<attributes>
-												<attributes>
-													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">14px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-												</attributes>
-											</attributes>
+											<attributes/>
 											<containedComponents retestId="for_testers">
 												<identifyingAttributes>
 													<attributes>
@@ -1862,10 +932,6 @@
 															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 														</entry>
@@ -1882,20 +948,8 @@
 															<value xsi:type="xsd:string">inline-block</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
 															<key>line-height</key>
 															<value xsi:type="xsd:string">32px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
 														</entry>
 														<entry>
 															<key>outline-color</key>
@@ -1918,16 +972,8 @@
 															<value xsi:type="xsd:string">8px</value>
 														</entry>
 														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
 															<key>text-decoration-color</key>
 															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>text-decoration-line</key>
-															<value xsi:type="xsd:string">none</value>
 														</entry>
 														<entry>
 															<key>transition-duration</key>
@@ -1966,10 +1012,6 @@
 														<value xsi:type="xsd:string">rgb(212, 218, 223)</value>
 													</entry>
 													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>border-bottom-left-radius</key>
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
@@ -1978,60 +1020,12 @@
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
 													<entry>
-														<key>border-image-width</key>
-														<value xsi:type="xsd:string">1</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>border-radius</key>
 														<value xsi:type="xsd:string">0px 0px 3px 3px</value>
 													</entry>
 													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">14px</value>
-													</entry>
-													<entry>
 														<key>list-style-type</key>
 														<value xsi:type="xsd:string">circle</value>
-													</entry>
-													<entry>
-														<key>margin-bottom</key>
-														<value xsi:type="xsd:string">0px</value>
-													</entry>
-													<entry>
-														<key>margin-top</key>
-														<value xsi:type="xsd:string">0px</value>
 													</entry>
 													<entry>
 														<key>min-width</key>
@@ -2042,28 +1036,12 @@
 														<value xsi:type="xsd:string">0</value>
 													</entry>
 													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>padding-left</key>
-														<value xsi:type="xsd:string">0px</value>
-													</entry>
-													<entry>
 														<key>position</key>
 														<value xsi:type="xsd:string">absolute</value>
 													</entry>
 													<entry>
 														<key>right</key>
 														<value xsi:type="xsd:string">-122.188px</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 													</entry>
 													<entry>
 														<key>top</key>
@@ -2104,60 +1082,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
 															<key>list-style-type</key>
 															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
 															<key>overflow</key>
@@ -2174,22 +1100,6 @@
 														<entry>
 															<key>position</key>
 															<value xsi:type="xsd:string">relative</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
 														</entry>
 														<entry>
 															<key>transition-property</key>
@@ -2231,10 +1141,6 @@
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
@@ -2251,20 +1157,12 @@
 																<value xsi:type="xsd:string">inline-block</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
 																<key>font-size</key>
 																<value xsi:type="xsd:string">13px</value>
 															</entry>
 															<entry>
 																<key>line-height</key>
 																<value xsi:type="xsd:string">32px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>outline-color</key>
@@ -2287,16 +1185,8 @@
 																<value xsi:type="xsd:string">6px</value>
 															</entry>
 															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
 																<key>text-decoration-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>text-decoration-line</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>transition-duration</key>
@@ -2335,60 +1225,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
 															<key>list-style-type</key>
 															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
 															<key>overflow</key>
@@ -2405,22 +1243,6 @@
 														<entry>
 															<key>position</key>
 															<value xsi:type="xsd:string">relative</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
 														</entry>
 														<entry>
 															<key>transition-property</key>
@@ -2462,10 +1284,6 @@
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
@@ -2482,20 +1300,12 @@
 																<value xsi:type="xsd:string">inline-block</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
 																<key>font-size</key>
 																<value xsi:type="xsd:string">13px</value>
 															</entry>
 															<entry>
 																<key>line-height</key>
 																<value xsi:type="xsd:string">32px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>outline-color</key>
@@ -2518,16 +1328,8 @@
 																<value xsi:type="xsd:string">6px</value>
 															</entry>
 															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
 																<key>text-decoration-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>text-decoration-line</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>transition-duration</key>
@@ -2566,60 +1368,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
 															<key>list-style-type</key>
 															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
 															<key>overflow</key>
@@ -2636,22 +1386,6 @@
 														<entry>
 															<key>position</key>
 															<value xsi:type="xsd:string">relative</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
 														</entry>
 														<entry>
 															<key>transition-property</key>
@@ -2693,10 +1427,6 @@
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
@@ -2713,20 +1443,12 @@
 																<value xsi:type="xsd:string">inline-block</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
 																<key>font-size</key>
 																<value xsi:type="xsd:string">13px</value>
 															</entry>
 															<entry>
 																<key>line-height</key>
 																<value xsi:type="xsd:string">32px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>outline-color</key>
@@ -2749,16 +1471,8 @@
 																<value xsi:type="xsd:string">6px</value>
 															</entry>
 															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
 																<key>text-decoration-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>text-decoration-line</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>transition-duration</key>
@@ -2797,60 +1511,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
 															<key>list-style-type</key>
 															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
 															<key>overflow</key>
@@ -2867,22 +1529,6 @@
 														<entry>
 															<key>position</key>
 															<value xsi:type="xsd:string">relative</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
 														</entry>
 														<entry>
 															<key>transition-property</key>
@@ -2924,10 +1570,6 @@
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
@@ -2944,20 +1586,12 @@
 																<value xsi:type="xsd:string">inline-block</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
 																<key>font-size</key>
 																<value xsi:type="xsd:string">13px</value>
 															</entry>
 															<entry>
 																<key>line-height</key>
 																<value xsi:type="xsd:string">32px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>outline-color</key>
@@ -2980,16 +1614,8 @@
 																<value xsi:type="xsd:string">6px</value>
 															</entry>
 															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
 																<key>text-decoration-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>text-decoration-line</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>transition-duration</key>
@@ -3030,72 +1656,16 @@
 										<attributes>
 											<attributes>
 												<entry>
-													<key>border-bottom-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-image-width</key>
-													<value xsi:type="xsd:string">1</value>
-												</entry>
-												<entry>
-													<key>border-left-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-right-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-top-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
-													<key>caret-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>column-rule-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>display</key>
 													<value xsi:type="xsd:string">inline-block</value>
-												</entry>
-												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">14px</value>
 												</entry>
 												<entry>
 													<key>list-style-type</key>
 													<value xsi:type="xsd:string">none</value>
 												</entry>
 												<entry>
-													<key>outline-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>position</key>
 													<value xsi:type="xsd:string">relative</value>
-												</entry>
-												<entry>
-													<key>text-align</key>
-													<value xsi:type="xsd:string">left</value>
-												</entry>
-												<entry>
-													<key>text-decoration-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -3113,66 +1683,7 @@
 													<attribute key="type" xsi:type="stringAttribute">SPAN</attribute>
 												</attributes>
 											</identifyingAttributes>
-											<attributes>
-												<attributes>
-													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">14px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-												</attributes>
-											</attributes>
+											<attributes/>
 											<containedComponents retestId="for_developers">
 												<identifyingAttributes>
 													<attributes>
@@ -3207,10 +1718,6 @@
 															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 														</entry>
@@ -3227,20 +1734,8 @@
 															<value xsi:type="xsd:string">inline-block</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
 															<key>line-height</key>
 															<value xsi:type="xsd:string">32px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
 														</entry>
 														<entry>
 															<key>outline-color</key>
@@ -3263,16 +1758,8 @@
 															<value xsi:type="xsd:string">8px</value>
 														</entry>
 														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
 															<key>text-decoration-color</key>
 															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>text-decoration-line</key>
-															<value xsi:type="xsd:string">none</value>
 														</entry>
 														<entry>
 															<key>transition-duration</key>
@@ -3311,10 +1798,6 @@
 														<value xsi:type="xsd:string">rgb(212, 218, 223)</value>
 													</entry>
 													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>border-bottom-left-radius</key>
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
@@ -3323,60 +1806,12 @@
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
 													<entry>
-														<key>border-image-width</key>
-														<value xsi:type="xsd:string">1</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>border-radius</key>
 														<value xsi:type="xsd:string">0px 0px 3px 3px</value>
 													</entry>
 													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">14px</value>
-													</entry>
-													<entry>
 														<key>list-style-type</key>
 														<value xsi:type="xsd:string">circle</value>
-													</entry>
-													<entry>
-														<key>margin-bottom</key>
-														<value xsi:type="xsd:string">0px</value>
-													</entry>
-													<entry>
-														<key>margin-top</key>
-														<value xsi:type="xsd:string">0px</value>
 													</entry>
 													<entry>
 														<key>min-width</key>
@@ -3387,24 +1822,8 @@
 														<value xsi:type="xsd:string">0</value>
 													</entry>
 													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>padding-left</key>
-														<value xsi:type="xsd:string">0px</value>
-													</entry>
-													<entry>
 														<key>position</key>
 														<value xsi:type="xsd:string">absolute</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 													</entry>
 													<entry>
 														<key>top</key>
@@ -3445,60 +1864,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
 															<key>list-style-type</key>
 															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
 															<key>overflow</key>
@@ -3515,22 +1882,6 @@
 														<entry>
 															<key>position</key>
 															<value xsi:type="xsd:string">relative</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
 														</entry>
 														<entry>
 															<key>transition-property</key>
@@ -3572,10 +1923,6 @@
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
@@ -3592,20 +1939,12 @@
 																<value xsi:type="xsd:string">inline-block</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
 																<key>font-size</key>
 																<value xsi:type="xsd:string">13px</value>
 															</entry>
 															<entry>
 																<key>line-height</key>
 																<value xsi:type="xsd:string">32px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>outline-color</key>
@@ -3628,16 +1967,8 @@
 																<value xsi:type="xsd:string">6px</value>
 															</entry>
 															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
 																<key>text-decoration-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>text-decoration-line</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>transition-duration</key>
@@ -3676,60 +2007,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
 															<key>list-style-type</key>
 															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
 															<key>overflow</key>
@@ -3746,22 +2025,6 @@
 														<entry>
 															<key>position</key>
 															<value xsi:type="xsd:string">relative</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
 														</entry>
 														<entry>
 															<key>transition-property</key>
@@ -3803,10 +2066,6 @@
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
@@ -3823,20 +2082,12 @@
 																<value xsi:type="xsd:string">inline-block</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
 																<key>font-size</key>
 																<value xsi:type="xsd:string">13px</value>
 															</entry>
 															<entry>
 																<key>line-height</key>
 																<value xsi:type="xsd:string">32px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>outline-color</key>
@@ -3859,16 +2110,8 @@
 																<value xsi:type="xsd:string">6px</value>
 															</entry>
 															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
 																<key>text-decoration-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>text-decoration-line</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>transition-duration</key>
@@ -3907,60 +2150,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
 															<key>list-style-type</key>
 															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
 															<key>overflow</key>
@@ -3977,22 +2168,6 @@
 														<entry>
 															<key>position</key>
 															<value xsi:type="xsd:string">relative</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
 														</entry>
 														<entry>
 															<key>transition-property</key>
@@ -4034,10 +2209,6 @@
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
@@ -4054,20 +2225,12 @@
 																<value xsi:type="xsd:string">inline-block</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
 																<key>font-size</key>
 																<value xsi:type="xsd:string">13px</value>
 															</entry>
 															<entry>
 																<key>line-height</key>
 																<value xsi:type="xsd:string">32px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>outline-color</key>
@@ -4090,16 +2253,8 @@
 																<value xsi:type="xsd:string">6px</value>
 															</entry>
 															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
 																<key>text-decoration-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>text-decoration-line</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>transition-duration</key>
@@ -4140,72 +2295,16 @@
 										<attributes>
 											<attributes>
 												<entry>
-													<key>border-bottom-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-image-width</key>
-													<value xsi:type="xsd:string">1</value>
-												</entry>
-												<entry>
-													<key>border-left-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-right-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-top-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
-													<key>caret-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>column-rule-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>display</key>
 													<value xsi:type="xsd:string">inline-block</value>
-												</entry>
-												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">14px</value>
 												</entry>
 												<entry>
 													<key>list-style-type</key>
 													<value xsi:type="xsd:string">none</value>
 												</entry>
 												<entry>
-													<key>outline-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>position</key>
 													<value xsi:type="xsd:string">relative</value>
-												</entry>
-												<entry>
-													<key>text-align</key>
-													<value xsi:type="xsd:string">left</value>
-												</entry>
-												<entry>
-													<key>text-decoration-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -4223,66 +2322,7 @@
 													<attribute key="type" xsi:type="stringAttribute">SPAN</attribute>
 												</attributes>
 											</identifyingAttributes>
-											<attributes>
-												<attributes>
-													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">14px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-												</attributes>
-											</attributes>
+											<attributes/>
 											<containedComponents retestId="for_managers">
 												<identifyingAttributes>
 													<attributes>
@@ -4317,10 +2357,6 @@
 															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 														</entry>
@@ -4337,20 +2373,8 @@
 															<value xsi:type="xsd:string">inline-block</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
 															<key>line-height</key>
 															<value xsi:type="xsd:string">32px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
 														</entry>
 														<entry>
 															<key>outline-color</key>
@@ -4373,16 +2397,8 @@
 															<value xsi:type="xsd:string">8px</value>
 														</entry>
 														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
 															<key>text-decoration-color</key>
 															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>text-decoration-line</key>
-															<value xsi:type="xsd:string">none</value>
 														</entry>
 														<entry>
 															<key>transition-duration</key>
@@ -4421,10 +2437,6 @@
 														<value xsi:type="xsd:string">rgb(212, 218, 223)</value>
 													</entry>
 													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>border-bottom-left-radius</key>
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
@@ -4433,60 +2445,12 @@
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
 													<entry>
-														<key>border-image-width</key>
-														<value xsi:type="xsd:string">1</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>border-radius</key>
 														<value xsi:type="xsd:string">0px 0px 3px 3px</value>
 													</entry>
 													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">14px</value>
-													</entry>
-													<entry>
 														<key>list-style-type</key>
 														<value xsi:type="xsd:string">circle</value>
-													</entry>
-													<entry>
-														<key>margin-bottom</key>
-														<value xsi:type="xsd:string">0px</value>
-													</entry>
-													<entry>
-														<key>margin-top</key>
-														<value xsi:type="xsd:string">0px</value>
 													</entry>
 													<entry>
 														<key>min-width</key>
@@ -4497,28 +2461,12 @@
 														<value xsi:type="xsd:string">0</value>
 													</entry>
 													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>padding-left</key>
-														<value xsi:type="xsd:string">0px</value>
-													</entry>
-													<entry>
 														<key>position</key>
 														<value xsi:type="xsd:string">absolute</value>
 													</entry>
 													<entry>
 														<key>right</key>
 														<value xsi:type="xsd:string">-78.7812px</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 													</entry>
 													<entry>
 														<key>top</key>
@@ -4559,60 +2507,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
 															<key>list-style-type</key>
 															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
 															<key>overflow</key>
@@ -4629,22 +2525,6 @@
 														<entry>
 															<key>position</key>
 															<value xsi:type="xsd:string">relative</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
 														</entry>
 														<entry>
 															<key>transition-property</key>
@@ -4686,10 +2566,6 @@
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
@@ -4706,20 +2582,12 @@
 																<value xsi:type="xsd:string">inline-block</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
 																<key>font-size</key>
 																<value xsi:type="xsd:string">13px</value>
 															</entry>
 															<entry>
 																<key>line-height</key>
 																<value xsi:type="xsd:string">32px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>outline-color</key>
@@ -4742,16 +2610,8 @@
 																<value xsi:type="xsd:string">6px</value>
 															</entry>
 															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
 																<key>text-decoration-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>text-decoration-line</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>transition-duration</key>
@@ -4790,60 +2650,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
 															<key>list-style-type</key>
 															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
 															<key>overflow</key>
@@ -4860,22 +2668,6 @@
 														<entry>
 															<key>position</key>
 															<value xsi:type="xsd:string">relative</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
 														</entry>
 														<entry>
 															<key>transition-property</key>
@@ -4917,10 +2709,6 @@
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
@@ -4937,20 +2725,12 @@
 																<value xsi:type="xsd:string">inline-block</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
 																<key>font-size</key>
 																<value xsi:type="xsd:string">13px</value>
 															</entry>
 															<entry>
 																<key>line-height</key>
 																<value xsi:type="xsd:string">32px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>outline-color</key>
@@ -4973,16 +2753,8 @@
 																<value xsi:type="xsd:string">6px</value>
 															</entry>
 															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
 																<key>text-decoration-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>text-decoration-line</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>transition-duration</key>
@@ -5021,60 +2793,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
 															<key>list-style-type</key>
 															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
 															<key>overflow</key>
@@ -5091,22 +2811,6 @@
 														<entry>
 															<key>position</key>
 															<value xsi:type="xsd:string">relative</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
 														</entry>
 														<entry>
 															<key>transition-property</key>
@@ -5148,10 +2852,6 @@
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
@@ -5168,20 +2868,12 @@
 																<value xsi:type="xsd:string">inline-block</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
 																<key>font-size</key>
 																<value xsi:type="xsd:string">13px</value>
 															</entry>
 															<entry>
 																<key>line-height</key>
 																<value xsi:type="xsd:string">32px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>outline-color</key>
@@ -5204,16 +2896,8 @@
 																<value xsi:type="xsd:string">6px</value>
 															</entry>
 															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
 																<key>text-decoration-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>text-decoration-line</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>transition-duration</key>
@@ -5254,72 +2938,16 @@
 										<attributes>
 											<attributes>
 												<entry>
-													<key>border-bottom-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-image-width</key>
-													<value xsi:type="xsd:string">1</value>
-												</entry>
-												<entry>
-													<key>border-left-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-right-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-top-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
-													<key>caret-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>column-rule-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>display</key>
 													<value xsi:type="xsd:string">inline-block</value>
-												</entry>
-												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">14px</value>
 												</entry>
 												<entry>
 													<key>list-style-type</key>
 													<value xsi:type="xsd:string">none</value>
 												</entry>
 												<entry>
-													<key>outline-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>position</key>
 													<value xsi:type="xsd:string">relative</value>
-												</entry>
-												<entry>
-													<key>text-align</key>
-													<value xsi:type="xsd:string">left</value>
-												</entry>
-												<entry>
-													<key>text-decoration-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -5337,66 +2965,7 @@
 													<attribute key="type" xsi:type="stringAttribute">SPAN</attribute>
 												</attributes>
 											</identifyingAttributes>
-											<attributes>
-												<attributes>
-													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">14px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-												</attributes>
-											</attributes>
+											<attributes/>
 											<containedComponents retestId="about">
 												<identifyingAttributes>
 													<attributes>
@@ -5431,10 +3000,6 @@
 															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 														</entry>
@@ -5451,20 +3016,8 @@
 															<value xsi:type="xsd:string">inline-block</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
 															<key>line-height</key>
 															<value xsi:type="xsd:string">32px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
 														</entry>
 														<entry>
 															<key>outline-color</key>
@@ -5487,16 +3040,8 @@
 															<value xsi:type="xsd:string">8px</value>
 														</entry>
 														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
 															<key>text-decoration-color</key>
 															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>text-decoration-line</key>
-															<value xsi:type="xsd:string">none</value>
 														</entry>
 														<entry>
 															<key>transition-duration</key>
@@ -5535,10 +3080,6 @@
 														<value xsi:type="xsd:string">rgb(212, 218, 223)</value>
 													</entry>
 													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>border-bottom-left-radius</key>
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
@@ -5547,60 +3088,12 @@
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
 													<entry>
-														<key>border-image-width</key>
-														<value xsi:type="xsd:string">1</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>border-radius</key>
 														<value xsi:type="xsd:string">0px 0px 3px 3px</value>
 													</entry>
 													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">14px</value>
-													</entry>
-													<entry>
 														<key>list-style-type</key>
 														<value xsi:type="xsd:string">circle</value>
-													</entry>
-													<entry>
-														<key>margin-bottom</key>
-														<value xsi:type="xsd:string">0px</value>
-													</entry>
-													<entry>
-														<key>margin-top</key>
-														<value xsi:type="xsd:string">0px</value>
 													</entry>
 													<entry>
 														<key>min-width</key>
@@ -5611,28 +3104,12 @@
 														<value xsi:type="xsd:string">0</value>
 													</entry>
 													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>padding-left</key>
-														<value xsi:type="xsd:string">0px</value>
-													</entry>
-													<entry>
 														<key>position</key>
 														<value xsi:type="xsd:string">absolute</value>
 													</entry>
 													<entry>
 														<key>right</key>
 														<value xsi:type="xsd:string">-50.8594px</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 													</entry>
 													<entry>
 														<key>top</key>
@@ -5673,60 +3150,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
 															<key>list-style-type</key>
 															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
 															<key>overflow</key>
@@ -5743,22 +3168,6 @@
 														<entry>
 															<key>position</key>
 															<value xsi:type="xsd:string">relative</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
 														</entry>
 														<entry>
 															<key>transition-property</key>
@@ -5800,10 +3209,6 @@
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
@@ -5820,20 +3225,12 @@
 																<value xsi:type="xsd:string">inline-block</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
 																<key>font-size</key>
 																<value xsi:type="xsd:string">13px</value>
 															</entry>
 															<entry>
 																<key>line-height</key>
 																<value xsi:type="xsd:string">32px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>outline-color</key>
@@ -5856,16 +3253,8 @@
 																<value xsi:type="xsd:string">6px</value>
 															</entry>
 															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
 																<key>text-decoration-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>text-decoration-line</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>transition-duration</key>
@@ -5904,60 +3293,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
 															<key>list-style-type</key>
 															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
 															<key>overflow</key>
@@ -5974,22 +3311,6 @@
 														<entry>
 															<key>position</key>
 															<value xsi:type="xsd:string">relative</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
 														</entry>
 														<entry>
 															<key>transition-property</key>
@@ -6031,10 +3352,6 @@
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
@@ -6051,20 +3368,12 @@
 																<value xsi:type="xsd:string">inline-block</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
 																<key>font-size</key>
 																<value xsi:type="xsd:string">13px</value>
 															</entry>
 															<entry>
 																<key>line-height</key>
 																<value xsi:type="xsd:string">32px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>outline-color</key>
@@ -6087,16 +3396,8 @@
 																<value xsi:type="xsd:string">6px</value>
 															</entry>
 															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
 																<key>text-decoration-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>text-decoration-line</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>transition-duration</key>
@@ -6135,60 +3436,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
 															<key>list-style-type</key>
 															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
 															<key>overflow</key>
@@ -6205,22 +3454,6 @@
 														<entry>
 															<key>position</key>
 															<value xsi:type="xsd:string">relative</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
 														</entry>
 														<entry>
 															<key>transition-property</key>
@@ -6262,10 +3495,6 @@
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
@@ -6282,20 +3511,12 @@
 																<value xsi:type="xsd:string">inline-block</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
 																<key>font-size</key>
 																<value xsi:type="xsd:string">13px</value>
 															</entry>
 															<entry>
 																<key>line-height</key>
 																<value xsi:type="xsd:string">32px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>outline-color</key>
@@ -6318,16 +3539,8 @@
 																<value xsi:type="xsd:string">6px</value>
 															</entry>
 															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
 																<key>text-decoration-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>text-decoration-line</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>transition-duration</key>
@@ -6369,72 +3582,16 @@
 										<attributes>
 											<attributes>
 												<entry>
-													<key>border-bottom-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-image-width</key>
-													<value xsi:type="xsd:string">1</value>
-												</entry>
-												<entry>
-													<key>border-left-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-right-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-top-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
-													<key>caret-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>column-rule-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>display</key>
 													<value xsi:type="xsd:string">inline-block</value>
-												</entry>
-												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">14px</value>
 												</entry>
 												<entry>
 													<key>list-style-type</key>
 													<value xsi:type="xsd:string">none</value>
 												</entry>
 												<entry>
-													<key>outline-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>position</key>
 													<value xsi:type="xsd:string">relative</value>
-												</entry>
-												<entry>
-													<key>text-align</key>
-													<value xsi:type="xsd:string">left</value>
-												</entry>
-												<entry>
-													<key>text-decoration-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -6472,10 +3629,6 @@
 														<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 													</entry>
 													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
 														<key>caret-color</key>
 														<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 													</entry>
@@ -6488,24 +3641,8 @@
 														<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 													</entry>
 													<entry>
-														<key>display</key>
-														<value xsi:type="xsd:string">inline-block</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">14px</value>
-													</entry>
-													<entry>
 														<key>line-height</key>
 														<value xsi:type="xsd:string">32px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
 													</entry>
 													<entry>
 														<key>outline-color</key>
@@ -6528,16 +3665,8 @@
 														<value xsi:type="xsd:string">8px</value>
 													</entry>
 													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
 														<key>text-decoration-color</key>
 														<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-													</entry>
-													<entry>
-														<key>text-decoration-line</key>
-														<value xsi:type="xsd:string">none</value>
 													</entry>
 													<entry>
 														<key>transition-duration</key>
@@ -6571,76 +3700,12 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
 															<key>display</key>
 															<value xsi:type="xsd:string">inline</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">32px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>margin-right</key>
 															<value xsi:type="xsd:string">5px</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 														</entry>
 													</attributes>
 												</attributes>
@@ -6660,70 +3725,7 @@
 														<attribute key="type" xsi:type="stringAttribute">SPAN</attribute>
 													</attributes>
 												</identifyingAttributes>
-												<attributes>
-													<attributes>
-														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">32px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-													</attributes>
-												</attributes>
+												<attributes/>
 											</containedComponents>
 										</containedComponents>
 										<containedComponents retestId="ul">
@@ -6767,10 +3769,6 @@
 													<entry>
 														<key>border-bottom-width</key>
 														<value xsi:type="xsd:string">1px</value>
-													</entry>
-													<entry>
-														<key>border-image-width</key>
-														<value xsi:type="xsd:string">1</value>
 													</entry>
 													<entry>
 														<key>border-left-color</key>
@@ -6829,36 +3827,8 @@
 														<value xsi:type="xsd:string">rgba(0, 0, 0, 0.176) 0px 6px 12px 0px</value>
 													</entry>
 													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-													</entry>
-													<entry>
 														<key>left</key>
 														<value xsi:type="xsd:string">-125px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
-														<key>margin-bottom</key>
-														<value xsi:type="xsd:string">0px</value>
 													</entry>
 													<entry>
 														<key>margin-top</key>
@@ -6873,16 +3843,8 @@
 														<value xsi:type="xsd:string">0</value>
 													</entry>
 													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>padding-bottom</key>
 														<value xsi:type="xsd:string">5px</value>
-													</entry>
-													<entry>
-														<key>padding-left</key>
-														<value xsi:type="xsd:string">0px</value>
 													</entry>
 													<entry>
 														<key>padding-top</key>
@@ -6891,14 +3853,6 @@
 													<entry>
 														<key>position</key>
 														<value xsi:type="xsd:string">absolute</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 													</entry>
 													<entry>
 														<key>top</key>
@@ -6943,10 +3897,6 @@
 															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
 															<key>border-left-color</key>
 															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
@@ -6956,38 +3906,6 @@
 														</entry>
 														<entry>
 															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
@@ -7005,22 +3923,6 @@
 														<entry>
 															<key>position</key>
 															<value xsi:type="xsd:string">relative</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
 														</entry>
 														<entry>
 															<key>transition-property</key>
@@ -7061,10 +3963,6 @@
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
@@ -7081,20 +3979,12 @@
 																<value xsi:type="xsd:string">inline-block</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
 																<key>font-size</key>
 																<value xsi:type="xsd:string">15px</value>
 															</entry>
 															<entry>
 																<key>line-height</key>
 																<value xsi:type="xsd:string">32px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>outline-color</key>
@@ -7117,16 +4007,8 @@
 																<value xsi:type="xsd:string">5px</value>
 															</entry>
 															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
 																<key>text-decoration-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>text-decoration-line</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>transition-duration</key>
@@ -7164,10 +4046,6 @@
 														<attributes>
 															<attributes>
 																<entry>
-																	<key>border-bottom-color</key>
-																	<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-																</entry>
-																<entry>
 																	<key>border-bottom-left-radius</key>
 																	<value xsi:type="xsd:string">3px</value>
 																</entry>
@@ -7176,20 +4054,8 @@
 																	<value xsi:type="xsd:string">3px</value>
 																</entry>
 																<entry>
-																	<key>border-left-color</key>
-																	<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-																</entry>
-																<entry>
 																	<key>border-radius</key>
 																	<value xsi:type="xsd:string">3px</value>
-																</entry>
-																<entry>
-																	<key>border-right-color</key>
-																	<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-																</entry>
-																<entry>
-																	<key>border-top-color</key>
-																	<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 																</entry>
 																<entry>
 																	<key>border-top-left-radius</key>
@@ -7200,60 +4066,12 @@
 																	<value xsi:type="xsd:string">3px</value>
 																</entry>
 																<entry>
-																	<key>box-sizing</key>
-																	<value xsi:type="xsd:string">border-box</value>
-																</entry>
-																<entry>
-																	<key>caret-color</key>
-																	<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-																</entry>
-																<entry>
-																	<key>color</key>
-																	<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-																</entry>
-																<entry>
-																	<key>column-rule-color</key>
-																	<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-																</entry>
-																<entry>
-																	<key>font-family</key>
-																	<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-																</entry>
-																<entry>
-																	<key>font-size</key>
-																	<value xsi:type="xsd:string">15px</value>
-																</entry>
-																<entry>
-																	<key>line-height</key>
-																	<value xsi:type="xsd:string">32px</value>
-																</entry>
-																<entry>
-																	<key>list-style-type</key>
-																	<value xsi:type="xsd:string">none</value>
-																</entry>
-																<entry>
 																	<key>margin-right</key>
 																	<value xsi:type="xsd:string">8px</value>
 																</entry>
 																<entry>
 																	<key>max-width</key>
 																	<value xsi:type="xsd:string">100%</value>
-																</entry>
-																<entry>
-																	<key>outline-color</key>
-																	<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-																</entry>
-																<entry>
-																	<key>text-align</key>
-																	<value xsi:type="xsd:string">left</value>
-																</entry>
-																<entry>
-																	<key>text-decoration-color</key>
-																	<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-																</entry>
-																<entry>
-																	<key>white-space</key>
-																	<value xsi:type="xsd:string">nowrap</value>
 																</entry>
 															</attributes>
 														</attributes>
@@ -7286,18 +4104,6 @@
 															<value xsi:type="xsd:string">rgb(229, 229, 229)</value>
 														</entry>
 														<entry>
-															<key>border-bottom-style</key>
-															<value xsi:type="xsd:string">solid</value>
-														</entry>
-														<entry>
-															<key>border-bottom-width</key>
-															<value xsi:type="xsd:string">1px</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
 															<key>border-left-color</key>
 															<value xsi:type="xsd:string">rgb(63, 60, 57)</value>
 														</entry>
@@ -7322,10 +4128,6 @@
 															<value xsi:type="xsd:string">rgba(0, 0, 0, 0.03) 0px -2px 1px 0px inset</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(63, 60, 57)</value>
 														</entry>
@@ -7342,24 +4144,8 @@
 															<value xsi:type="xsd:string">rgb(63, 60, 57)</value>
 														</entry>
 														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
 															<key>font-size</key>
 															<value xsi:type="xsd:string">15px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>margin-top</key>
-															<value xsi:type="xsd:string">-5px</value>
 														</entry>
 														<entry>
 															<key>outline-color</key>
@@ -7398,20 +4184,8 @@
 															<value xsi:type="xsd:string">relative</value>
 														</entry>
 														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
 															<key>text-decoration-color</key>
 															<value xsi:type="xsd:string">rgb(63, 60, 57)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
 														</entry>
 														<entry>
 															<key>transition-property</key>
@@ -7453,20 +4227,8 @@
 																<value xsi:type="xsd:string">3px</value>
 															</entry>
 															<entry>
-																<key>border-left-color</key>
-																<value xsi:type="xsd:string">rgb(63, 60, 57)</value>
-															</entry>
-															<entry>
 																<key>border-radius</key>
 																<value xsi:type="xsd:string">3px</value>
-															</entry>
-															<entry>
-																<key>border-right-color</key>
-																<value xsi:type="xsd:string">rgb(63, 60, 57)</value>
-															</entry>
-															<entry>
-																<key>border-top-color</key>
-																<value xsi:type="xsd:string">rgb(63, 60, 57)</value>
 															</entry>
 															<entry>
 																<key>border-top-left-radius</key>
@@ -7477,56 +4239,12 @@
 																<value xsi:type="xsd:string">3px</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
-																<key>caret-color</key>
-																<value xsi:type="xsd:string">rgb(63, 60, 57)</value>
-															</entry>
-															<entry>
-																<key>color</key>
-																<value xsi:type="xsd:string">rgb(63, 60, 57)</value>
-															</entry>
-															<entry>
-																<key>column-rule-color</key>
-																<value xsi:type="xsd:string">rgb(63, 60, 57)</value>
-															</entry>
-															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
-																<key>font-size</key>
-																<value xsi:type="xsd:string">15px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
-															</entry>
-															<entry>
 																<key>margin-right</key>
 																<value xsi:type="xsd:string">8px</value>
 															</entry>
 															<entry>
 																<key>max-width</key>
 																<value xsi:type="xsd:string">100%</value>
-															</entry>
-															<entry>
-																<key>outline-color</key>
-																<value xsi:type="xsd:string">rgb(63, 60, 57)</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
-																<key>text-decoration-color</key>
-																<value xsi:type="xsd:string">rgb(63, 60, 57)</value>
-															</entry>
-															<entry>
-																<key>white-space</key>
-																<value xsi:type="xsd:string">nowrap</value>
 															</entry>
 														</attributes>
 													</attributes>
@@ -7553,62 +4271,7 @@
 							<attribute key="type" xsi:type="stringAttribute">SCRIPT</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">15px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="consolelogretest">
 					<identifyingAttributes>
@@ -7627,62 +4290,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">SCRIPT</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">15px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="script">
 					<identifyingAttributes>
@@ -7698,62 +4306,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">SCRIPT</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">15px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="windowjquery">
 					<identifyingAttributes>
@@ -7770,62 +4323,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">SCRIPT</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">15px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="script">
 					<identifyingAttributes>
@@ -7841,62 +4339,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">SCRIPT</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">15px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="script">
 					<identifyingAttributes>
@@ -7912,62 +4355,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">SCRIPT</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">15px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="script">
 					<identifyingAttributes>
@@ -7983,62 +4371,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">SCRIPT</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">15px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="script">
 					<identifyingAttributes>
@@ -8054,62 +4387,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">SCRIPT</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">15px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="script">
 					<identifyingAttributes>
@@ -8125,62 +4403,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">SCRIPT</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">15px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="script">
 					<identifyingAttributes>
@@ -8196,62 +4419,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">SCRIPT</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">15px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="script">
 					<identifyingAttributes>
@@ -8267,62 +4435,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">SCRIPT</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">15px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="section">
 					<identifyingAttributes>
@@ -8345,62 +4458,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<key>background-color</key>
 								<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
 							</entry>
-							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">15px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
 						</attributes>
 					</attributes>
 					<containedComponents retestId="div">
@@ -8422,60 +4479,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 						<attributes>
 							<attributes>
 								<entry>
-									<key>border-bottom-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-left-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-right-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-top-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
 									<key>bottom</key>
 									<value xsi:type="xsd:string">694px</value>
 								</entry>
 								<entry>
-									<key>box-sizing</key>
-									<value xsi:type="xsd:string">border-box</value>
-								</entry>
-								<entry>
-									<key>caret-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>column-rule-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-								</entry>
-								<entry>
-									<key>font-size</key>
-									<value xsi:type="xsd:string">15px</value>
-								</entry>
-								<entry>
 									<key>left</key>
 									<value xsi:type="xsd:string">875px</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">30px</value>
-								</entry>
-								<entry>
-									<key>outline-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 								</entry>
 								<entry>
 									<key>position</key>
@@ -8484,10 +4493,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<entry>
 									<key>right</key>
 									<value xsi:type="xsd:string">10px</value>
-								</entry>
-								<entry>
-									<key>text-decoration-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 								</entry>
 								<entry>
 									<key>top</key>
@@ -8515,62 +4520,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<attribute key="type" xsi:type="stringAttribute">DIV</attribute>
 							</attributes>
 						</identifyingAttributes>
-						<attributes>
-							<attributes>
-								<entry>
-									<key>border-bottom-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-left-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-right-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-top-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>box-sizing</key>
-									<value xsi:type="xsd:string">border-box</value>
-								</entry>
-								<entry>
-									<key>caret-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>column-rule-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-								</entry>
-								<entry>
-									<key>font-size</key>
-									<value xsi:type="xsd:string">15px</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">30px</value>
-								</entry>
-								<entry>
-									<key>outline-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>text-decoration-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-							</attributes>
-						</attributes>
+						<attributes/>
 						<containedComponents retestId="ul">
 							<identifyingAttributes>
 								<attributes>
@@ -8589,68 +4539,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attributes>
 								<attributes>
 									<entry>
-										<key>border-bottom-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>border-left-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>border-right-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>border-top-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>box-sizing</key>
-										<value xsi:type="xsd:string">border-box</value>
-									</entry>
-									<entry>
-										<key>caret-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>column-rule-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">15px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">30px</value>
-									</entry>
-									<entry>
 										<key>list-style-type</key>
 										<value xsi:type="xsd:string">none</value>
-									</entry>
-									<entry>
-										<key>margin-bottom</key>
-										<value xsi:type="xsd:string">0px</value>
-									</entry>
-									<entry>
-										<key>margin-top</key>
-										<value xsi:type="xsd:string">0px</value>
-									</entry>
-									<entry>
-										<key>outline-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 									</entry>
 									<entry>
 										<key>overflow</key>
@@ -8665,16 +4555,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 										<value xsi:type="xsd:string">hidden</value>
 									</entry>
 									<entry>
-										<key>padding-left</key>
-										<value xsi:type="xsd:string">0px</value>
-									</entry>
-									<entry>
 										<key>position</key>
 										<value xsi:type="xsd:string">relative</value>
-									</entry>
-									<entry>
-										<key>text-decoration-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 									</entry>
 								</attributes>
 							</attributes>
@@ -8695,68 +4577,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<attributes>
 									<attributes>
 										<entry>
-											<key>border-bottom-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-image-width</key>
-											<value xsi:type="xsd:string">1</value>
-										</entry>
-										<entry>
-											<key>border-left-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-right-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-top-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>box-sizing</key>
-											<value xsi:type="xsd:string">border-box</value>
-										</entry>
-										<entry>
-											<key>caret-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>column-rule-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>font-family</key>
-											<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-										</entry>
-										<entry>
-											<key>font-size</key>
-											<value xsi:type="xsd:string">15px</value>
-										</entry>
-										<entry>
-											<key>line-height</key>
-											<value xsi:type="xsd:string">30px</value>
-										</entry>
-										<entry>
-											<key>list-style-type</key>
-											<value xsi:type="xsd:string">none</value>
-										</entry>
-										<entry>
-											<key>outline-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
 											<key>text-align</key>
 											<value xsi:type="xsd:string">left</value>
-										</entry>
-										<entry>
-											<key>text-decoration-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 										</entry>
 									</attributes>
 								</attributes>
@@ -8790,56 +4612,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<value xsi:type="xsd:string">1px</value>
 											</entry>
 											<entry>
-												<key>border-left-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-right-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
 												<key>border-style</key>
 												<value xsi:type="xsd:string">none none solid</value>
 											</entry>
 											<entry>
-												<key>border-top-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
 												<key>border-width</key>
 												<value xsi:type="xsd:string">0px 0px 1px</value>
-											</entry>
-											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
-											</entry>
-											<entry>
-												<key>caret-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>column-rule-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>font-family</key>
-												<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-											</entry>
-											<entry>
-												<key>font-size</key>
-												<value xsi:type="xsd:string">15px</value>
-											</entry>
-											<entry>
-												<key>line-height</key>
-												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
-												<key>list-style-type</key>
-												<value xsi:type="xsd:string">none</value>
 											</entry>
 											<entry>
 												<key>margin-left</key>
@@ -8854,20 +4632,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<value xsi:type="xsd:string">1020px</value>
 											</entry>
 											<entry>
-												<key>outline-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
 												<key>padding-bottom</key>
 												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
-												<key>text-align</key>
-												<value xsi:type="xsd:string">left</value>
-											</entry>
-											<entry>
-												<key>text-decoration-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 											</entry>
 										</attributes>
 									</attributes>
@@ -8905,10 +4671,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 												</entry>
 												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
 													<key>caret-color</key>
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 												</entry>
@@ -8919,22 +4681,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<entry>
 													<key>column-rule-color</key>
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-												</entry>
-												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">15px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">30px</value>
-												</entry>
-												<entry>
-													<key>list-style-type</key>
-													<value xsi:type="xsd:string">none</value>
 												</entry>
 												<entry>
 													<key>margin-bottom</key>
@@ -9000,10 +4746,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 													</entry>
 													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
 														<key>caret-color</key>
 														<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 													</entry>
@@ -9024,14 +4766,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">40px</value>
 													</entry>
 													<entry>
-														<key>font-weight</key>
-														<value xsi:type="xsd:string">400</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
 														<key>margin-bottom</key>
 														<value xsi:type="xsd:string">18px</value>
 													</entry>
@@ -9044,16 +4778,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 													</entry>
 													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">center</value>
-													</entry>
-													<entry>
 														<key>text-decoration-color</key>
 														<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 													</entry>
 												</attributes>
 											</attributes>
-											<containedComponents retestId="4ad85b32-6e78-4ade-81ae-8b7eb1e4caa0">
+											<containedComponents retestId="2e0c1542-5725-47a4-a57d-6bf990936566">
 												<identifyingAttributes>
 													<attributes>
 														<attribute key="outline" xsi:type="outlineAttribute">
@@ -9087,10 +4817,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
@@ -9103,24 +4829,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">&quot;Gill Sans MT&quot;, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">40px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">center</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -9163,10 +4873,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
@@ -9179,24 +4885,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">&quot;Gill Sans MT&quot;, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">40px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">center</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -9239,10 +4929,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
@@ -9255,24 +4941,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">&quot;Gill Sans MT&quot;, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">40px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">center</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -9315,10 +4985,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
@@ -9331,24 +4997,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">&quot;Gill Sans MT&quot;, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">40px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">center</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -9357,7 +5007,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													</attributes>
 												</attributes>
 											</containedComponents>
-											<containedComponents retestId="94bdebff-b46f-4789-a23f-e87eff871e9f">
+											<containedComponents retestId="132f6ab6-4f20-41c7-a22f-25ecc7e54cb7">
 												<identifyingAttributes>
 													<attributes>
 														<attribute key="outline" xsi:type="outlineAttribute">
@@ -9391,10 +5041,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
@@ -9407,24 +5053,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">&quot;Gill Sans MT&quot;, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">40px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">center</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -9457,60 +5087,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 												<entry>
-													<key>border-left-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-right-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-top-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
-													<key>caret-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>column-rule-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>float</key>
 													<value xsi:type="xsd:string">right</value>
 												</entry>
 												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">15px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">30px</value>
-												</entry>
-												<entry>
-													<key>list-style-type</key>
-													<value xsi:type="xsd:string">none</value>
-												</entry>
-												<entry>
 													<key>min-height</key>
 													<value xsi:type="xsd:string">1px</value>
-												</entry>
-												<entry>
-													<key>outline-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 												<entry>
 													<key>padding-left</key>
@@ -9523,14 +5105,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<entry>
 													<key>position</key>
 													<value xsi:type="xsd:string">relative</value>
-												</entry>
-												<entry>
-													<key>text-align</key>
-													<value xsi:type="xsd:string">left</value>
-												</entry>
-												<entry>
-													<key>text-decoration-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -9548,70 +5122,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 												</attributes>
 											</identifyingAttributes>
-											<attributes>
-												<attributes>
-													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-												</attributes>
-											</attributes>
+											<attributes/>
 										</containedComponents>
 										<containedComponents retestId="br">
 											<identifyingAttributes>
@@ -9627,70 +5138,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 												</attributes>
 											</identifyingAttributes>
-											<attributes>
-												<attributes>
-													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-												</attributes>
-											</attributes>
+											<attributes/>
 										</containedComponents>
 										<containedComponents retestId="br">
 											<identifyingAttributes>
@@ -9706,70 +5154,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 												</attributes>
 											</identifyingAttributes>
-											<attributes>
-												<attributes>
-													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-												</attributes>
-											</attributes>
+											<attributes/>
 										</containedComponents>
 										<containedComponents retestId="iframe">
 											<identifyingAttributes>
@@ -9789,72 +5174,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 											<attributes>
 												<attributes>
 													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-image-width</key>
-														<value xsi:type="xsd:string">1</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>display</key>
 														<value xsi:type="xsd:string">inline</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 													</entry>
 												</attributes>
 											</attributes>
@@ -9894,10 +5215,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 												</entry>
 												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
 													<key>caret-color</key>
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 												</entry>
@@ -9912,22 +5229,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<entry>
 													<key>float</key>
 													<value xsi:type="xsd:string">right</value>
-												</entry>
-												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">15px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">30px</value>
-												</entry>
-												<entry>
-													<key>list-style-type</key>
-													<value xsi:type="xsd:string">none</value>
 												</entry>
 												<entry>
 													<key>margin-bottom</key>
@@ -9980,52 +5281,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 											<attributes>
 												<attributes>
 													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
 														<key>font-size</key>
 														<value xsi:type="xsd:string">17px</value>
 													</entry>
 													<entry>
 														<key>line-height</key>
 														<value xsi:type="xsd:string">36px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
 													</entry>
 													<entry>
 														<key>margin-bottom</key>
@@ -10043,18 +5304,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<key>margin-top</key>
 														<value xsi:type="xsd:string">12px</value>
 													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">right</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-													</entry>
 												</attributes>
 											</attributes>
 											<containedComponents retestId="br">
@@ -10071,70 +5320,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 													</attributes>
 												</identifyingAttributes>
-												<attributes>
-													<attributes>
-														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">17px</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">36px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">right</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-													</attributes>
-												</attributes>
+												<attributes/>
 											</containedComponents>
 											<containedComponents retestId="br">
 												<identifyingAttributes>
@@ -10150,70 +5336,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 													</attributes>
 												</identifyingAttributes>
-												<attributes>
-													<attributes>
-														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">17px</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">36px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">right</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-													</attributes>
-												</attributes>
+												<attributes/>
 											</containedComponents>
 											<containedComponents retestId="have_you_had">
 												<identifyingAttributes>
@@ -10249,10 +5372,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 														</entry>
@@ -10265,32 +5384,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">17px</value>
-														</entry>
-														<entry>
-															<key>font-style</key>
-															<value xsi:type="xsd:string">normal</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">36px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">right</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -10312,70 +5407,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 														</attributes>
 													</identifyingAttributes>
-													<attributes>
-														<attributes>
-															<entry>
-																<key>border-bottom-color</key>
-																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-															</entry>
-															<entry>
-																<key>border-left-color</key>
-																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-															</entry>
-															<entry>
-																<key>border-right-color</key>
-																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-															</entry>
-															<entry>
-																<key>border-top-color</key>
-																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-															</entry>
-															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
-																<key>caret-color</key>
-																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-															</entry>
-															<entry>
-																<key>color</key>
-																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-															</entry>
-															<entry>
-																<key>column-rule-color</key>
-																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-															</entry>
-															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-															</entry>
-															<entry>
-																<key>font-size</key>
-																<value xsi:type="xsd:string">17px</value>
-															</entry>
-															<entry>
-																<key>line-height</key>
-																<value xsi:type="xsd:string">36px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
-															</entry>
-															<entry>
-																<key>outline-color</key>
-																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">right</value>
-															</entry>
-															<entry>
-																<key>text-decoration-color</key>
-																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-															</entry>
-														</attributes>
-													</attributes>
+													<attributes/>
 												</containedComponents>
 											</containedComponents>
 											<containedComponents retestId="use_an_artifici">
@@ -10412,10 +5444,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 														</entry>
@@ -10428,32 +5456,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">17px</value>
-														</entry>
-														<entry>
-															<key>font-style</key>
-															<value xsi:type="xsd:string">normal</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">36px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">right</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -10496,10 +5500,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 														</entry>
@@ -10512,32 +5512,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">17px</value>
-														</entry>
-														<entry>
-															<key>font-style</key>
-															<value xsi:type="xsd:string">normal</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">36px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">right</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -10546,7 +5522,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													</attributes>
 												</attributes>
 											</containedComponents>
-											<containedComponents retestId="af39aba3-c5d3-4cbe-87a2-0a92087112dc">
+											<containedComponents retestId="2abc0c3e-1953-4bd0-b12d-e8a900594be3">
 												<identifyingAttributes>
 													<attributes>
 														<attribute key="outline" xsi:type="outlineAttribute">
@@ -10580,10 +5556,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
@@ -10596,28 +5568,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">17px</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">36px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">right</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -10660,10 +5612,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
@@ -10676,28 +5624,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">17px</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">36px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">right</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -10727,68 +5655,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<attributes>
 									<attributes>
 										<entry>
-											<key>border-bottom-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-image-width</key>
-											<value xsi:type="xsd:string">1</value>
-										</entry>
-										<entry>
-											<key>border-left-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-right-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-top-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>box-sizing</key>
-											<value xsi:type="xsd:string">border-box</value>
-										</entry>
-										<entry>
-											<key>caret-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>column-rule-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>font-family</key>
-											<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-										</entry>
-										<entry>
-											<key>font-size</key>
-											<value xsi:type="xsd:string">15px</value>
-										</entry>
-										<entry>
-											<key>line-height</key>
-											<value xsi:type="xsd:string">30px</value>
-										</entry>
-										<entry>
-											<key>list-style-type</key>
-											<value xsi:type="xsd:string">none</value>
-										</entry>
-										<entry>
-											<key>outline-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
 											<key>text-align</key>
 											<value xsi:type="xsd:string">left</value>
-										</entry>
-										<entry>
-											<key>text-decoration-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 										</entry>
 									</attributes>
 								</attributes>
@@ -10822,56 +5690,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<value xsi:type="xsd:string">1px</value>
 											</entry>
 											<entry>
-												<key>border-left-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-right-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
 												<key>border-style</key>
 												<value xsi:type="xsd:string">none none solid</value>
 											</entry>
 											<entry>
-												<key>border-top-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
 												<key>border-width</key>
 												<value xsi:type="xsd:string">0px 0px 1px</value>
-											</entry>
-											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
-											</entry>
-											<entry>
-												<key>caret-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>column-rule-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>font-family</key>
-												<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-											</entry>
-											<entry>
-												<key>font-size</key>
-												<value xsi:type="xsd:string">15px</value>
-											</entry>
-											<entry>
-												<key>line-height</key>
-												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
-												<key>list-style-type</key>
-												<value xsi:type="xsd:string">none</value>
 											</entry>
 											<entry>
 												<key>margin-left</key>
@@ -10886,20 +5710,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<value xsi:type="xsd:string">1020px</value>
 											</entry>
 											<entry>
-												<key>outline-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
 												<key>padding-bottom</key>
 												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
-												<key>text-align</key>
-												<value xsi:type="xsd:string">left</value>
-											</entry>
-											<entry>
-												<key>text-decoration-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 											</entry>
 										</attributes>
 									</attributes>
@@ -10937,10 +5749,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 												</entry>
 												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
 													<key>caret-color</key>
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 												</entry>
@@ -10951,22 +5759,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<entry>
 													<key>column-rule-color</key>
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-												</entry>
-												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">15px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">30px</value>
-												</entry>
-												<entry>
-													<key>list-style-type</key>
-													<value xsi:type="xsd:string">none</value>
 												</entry>
 												<entry>
 													<key>margin-bottom</key>
@@ -11019,10 +5811,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
 													</entry>
 													<entry>
-														<key>border-image-width</key>
-														<value xsi:type="xsd:string">1</value>
-													</entry>
-													<entry>
 														<key>border-left-color</key>
 														<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
 													</entry>
@@ -11033,10 +5821,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<entry>
 														<key>border-top-color</key>
 														<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
 													</entry>
 													<entry>
 														<key>caret-color</key>
@@ -11067,10 +5851,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">42px</value>
 													</entry>
 													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
 														<key>margin-bottom</key>
 														<value xsi:type="xsd:string">6px</value>
 													</entry>
@@ -11081,10 +5861,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<entry>
 														<key>outline-color</key>
 														<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">center</value>
 													</entry>
 													<entry>
 														<key>text-decoration-color</key>
@@ -11110,10 +5886,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<attributes>
 													<attributes>
 														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
 															<key>border-bottom-left-radius</key>
 															<value xsi:type="xsd:string">3px</value>
 														</entry>
@@ -11122,20 +5894,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">3px</value>
 														</entry>
 														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
 															<key>border-radius</key>
 															<value xsi:type="xsd:string">3px</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
 														</entry>
 														<entry>
 															<key>border-top-left-radius</key>
@@ -11146,60 +5906,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">3px</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">30px</value>
-														</entry>
-														<entry>
-															<key>font-weight</key>
-															<value xsi:type="xsd:string">700</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">42px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>margin-right</key>
 															<value xsi:type="xsd:string">-30px</value>
 														</entry>
 														<entry>
 															<key>max-width</key>
 															<value xsi:type="xsd:string">100%</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">center</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
 														</entry>
 														<entry>
 															<key>vertical-align</key>
@@ -11242,10 +5954,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
@@ -11258,32 +5966,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">30px</value>
-														</entry>
-														<entry>
-															<key>font-weight</key>
-															<value xsi:type="xsd:string">700</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">42px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">center</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -11292,7 +5976,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													</attributes>
 												</attributes>
 											</containedComponents>
-											<containedComponents retestId="682ccbd9-fd8a-463e-8345-625f8745e0f8">
+											<containedComponents retestId="f4cd3a52-3edf-4808-8cc3-8eefcdc6faf5">
 												<identifyingAttributes>
 													<attributes>
 														<attribute key="outline" xsi:type="outlineAttribute">
@@ -11326,10 +6010,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
@@ -11342,32 +6022,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">30px</value>
-														</entry>
-														<entry>
-															<key>font-weight</key>
-															<value xsi:type="xsd:string">700</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">42px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">center</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -11400,60 +6056,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 												<entry>
-													<key>border-left-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-right-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-top-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
-													<key>caret-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>column-rule-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>float</key>
 													<value xsi:type="xsd:string">left</value>
 												</entry>
 												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">15px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">30px</value>
-												</entry>
-												<entry>
-													<key>list-style-type</key>
-													<value xsi:type="xsd:string">none</value>
-												</entry>
-												<entry>
 													<key>min-height</key>
 													<value xsi:type="xsd:string">1px</value>
-												</entry>
-												<entry>
-													<key>outline-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 												<entry>
 													<key>padding-left</key>
@@ -11466,14 +6074,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<entry>
 													<key>position</key>
 													<value xsi:type="xsd:string">relative</value>
-												</entry>
-												<entry>
-													<key>text-align</key>
-													<value xsi:type="xsd:string">left</value>
-												</entry>
-												<entry>
-													<key>text-decoration-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -11494,10 +6094,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 											<attributes>
 												<attributes>
 													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>border-bottom-left-radius</key>
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
@@ -11506,20 +6102,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
 													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>border-radius</key>
 														<value xsi:type="xsd:string">3px</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 													</entry>
 													<entry>
 														<key>border-top-left-radius</key>
@@ -11530,60 +6114,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
 													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>display</key>
-														<value xsi:type="xsd:string">block</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
 														<key>max-height</key>
 														<value xsi:type="xsd:string">430px</value>
 													</entry>
 													<entry>
 														<key>max-width</key>
 														<value xsi:type="xsd:string">100%</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 													</entry>
 													<entry>
 														<key>vertical-align</key>
@@ -11615,60 +6151,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 												<entry>
-													<key>border-left-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-right-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-top-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
-													<key>caret-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>column-rule-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>float</key>
 													<value xsi:type="xsd:string">right</value>
 												</entry>
 												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">15px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">30px</value>
-												</entry>
-												<entry>
-													<key>list-style-type</key>
-													<value xsi:type="xsd:string">none</value>
-												</entry>
-												<entry>
 													<key>min-height</key>
 													<value xsi:type="xsd:string">1px</value>
-												</entry>
-												<entry>
-													<key>outline-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 												<entry>
 													<key>padding-left</key>
@@ -11681,14 +6169,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<entry>
 													<key>position</key>
 													<value xsi:type="xsd:string">relative</value>
-												</entry>
-												<entry>
-													<key>text-align</key>
-													<value xsi:type="xsd:string">left</value>
-												</entry>
-												<entry>
-													<key>text-decoration-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -11726,10 +6206,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 													</entry>
 													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
 														<key>caret-color</key>
 														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 													</entry>
@@ -11742,28 +6218,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 													</entry>
 													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
 														<key>outline-color</key>
 														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
 													</entry>
 													<entry>
 														<key>text-decoration-color</key>
@@ -11788,56 +6244,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<attributes>
 													<attributes>
 														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-														</entry>
-														<entry>
 															<key>font-size</key>
 															<value xsi:type="xsd:string">17px</value>
 														</entry>
 														<entry>
 															<key>line-height</key>
 															<value xsi:type="xsd:string">36px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>margin-bottom</key>
-															<value xsi:type="xsd:string">0px</value>
 														</entry>
 														<entry>
 															<key>margin-left</key>
@@ -11850,18 +6262,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<entry>
 															<key>margin-top</key>
 															<value xsi:type="xsd:string">12px</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 														</entry>
 													</attributes>
 												</attributes>
@@ -11879,70 +6279,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 														</attributes>
 													</identifyingAttributes>
-													<attributes>
-														<attributes>
-															<entry>
-																<key>border-bottom-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>border-left-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>border-right-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>border-top-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
-																<key>caret-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>column-rule-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-															</entry>
-															<entry>
-																<key>font-size</key>
-																<value xsi:type="xsd:string">17px</value>
-															</entry>
-															<entry>
-																<key>line-height</key>
-																<value xsi:type="xsd:string">36px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
-															</entry>
-															<entry>
-																<key>outline-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
-																<key>text-decoration-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-														</attributes>
-													</attributes>
+													<attributes/>
 												</containedComponents>
 												<containedComponents retestId="no_need_to_crea">
 													<identifyingAttributes>
@@ -11978,10 +6315,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 															</entry>
@@ -11994,32 +6327,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-															</entry>
-															<entry>
-																<key>font-size</key>
-																<value xsi:type="xsd:string">17px</value>
-															</entry>
-															<entry>
-																<key>font-style</key>
-																<value xsi:type="xsd:string">normal</value>
-															</entry>
-															<entry>
-																<key>line-height</key>
-																<value xsi:type="xsd:string">36px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
-															</entry>
-															<entry>
 																<key>outline-color</key>
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
 															</entry>
 															<entry>
 																<key>text-decoration-color</key>
@@ -12028,7 +6337,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														</attributes>
 													</attributes>
 												</containedComponents>
-												<containedComponents retestId="4aa19ebf-8861-404a-a227-0570d20febad">
+												<containedComponents retestId="1058a2bd-8d49-4c23-b559-1d2c4d99607f">
 													<identifyingAttributes>
 														<attributes>
 															<attribute key="outline" xsi:type="outlineAttribute">
@@ -12062,10 +6371,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 															</entry>
@@ -12078,28 +6383,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-															</entry>
-															<entry>
-																<key>font-size</key>
-																<value xsi:type="xsd:string">17px</value>
-															</entry>
-															<entry>
-																<key>line-height</key>
-																<value xsi:type="xsd:string">36px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
-															</entry>
-															<entry>
 																<key>outline-color</key>
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
 															</entry>
 															<entry>
 																<key>text-decoration-color</key>
@@ -12142,10 +6427,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 															</entry>
@@ -12158,28 +6439,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-															</entry>
-															<entry>
-																<key>font-size</key>
-																<value xsi:type="xsd:string">17px</value>
-															</entry>
-															<entry>
-																<key>line-height</key>
-																<value xsi:type="xsd:string">36px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
-															</entry>
-															<entry>
 																<key>outline-color</key>
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
 															</entry>
 															<entry>
 																<key>text-decoration-color</key>
@@ -12222,10 +6483,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 															</entry>
@@ -12238,28 +6495,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-															</entry>
-															<entry>
-																<key>font-size</key>
-																<value xsi:type="xsd:string">17px</value>
-															</entry>
-															<entry>
-																<key>line-height</key>
-																<value xsi:type="xsd:string">36px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
-															</entry>
-															<entry>
 																<key>outline-color</key>
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
 															</entry>
 															<entry>
 																<key>text-decoration-color</key>
@@ -12290,68 +6527,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<attributes>
 									<attributes>
 										<entry>
-											<key>border-bottom-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-image-width</key>
-											<value xsi:type="xsd:string">1</value>
-										</entry>
-										<entry>
-											<key>border-left-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-right-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-top-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>box-sizing</key>
-											<value xsi:type="xsd:string">border-box</value>
-										</entry>
-										<entry>
-											<key>caret-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>column-rule-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>font-family</key>
-											<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-										</entry>
-										<entry>
-											<key>font-size</key>
-											<value xsi:type="xsd:string">15px</value>
-										</entry>
-										<entry>
-											<key>line-height</key>
-											<value xsi:type="xsd:string">30px</value>
-										</entry>
-										<entry>
-											<key>list-style-type</key>
-											<value xsi:type="xsd:string">none</value>
-										</entry>
-										<entry>
-											<key>outline-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
 											<key>text-align</key>
 											<value xsi:type="xsd:string">left</value>
-										</entry>
-										<entry>
-											<key>text-decoration-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 										</entry>
 									</attributes>
 								</attributes>
@@ -12385,56 +6562,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<value xsi:type="xsd:string">1px</value>
 											</entry>
 											<entry>
-												<key>border-left-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-right-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
 												<key>border-style</key>
 												<value xsi:type="xsd:string">none none solid</value>
 											</entry>
 											<entry>
-												<key>border-top-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
 												<key>border-width</key>
 												<value xsi:type="xsd:string">0px 0px 1px</value>
-											</entry>
-											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
-											</entry>
-											<entry>
-												<key>caret-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>column-rule-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>font-family</key>
-												<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-											</entry>
-											<entry>
-												<key>font-size</key>
-												<value xsi:type="xsd:string">15px</value>
-											</entry>
-											<entry>
-												<key>line-height</key>
-												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
-												<key>list-style-type</key>
-												<value xsi:type="xsd:string">none</value>
 											</entry>
 											<entry>
 												<key>margin-left</key>
@@ -12449,20 +6582,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<value xsi:type="xsd:string">1020px</value>
 											</entry>
 											<entry>
-												<key>outline-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
 												<key>padding-bottom</key>
 												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
-												<key>text-align</key>
-												<value xsi:type="xsd:string">left</value>
-											</entry>
-											<entry>
-												<key>text-decoration-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 											</entry>
 										</attributes>
 									</attributes>
@@ -12500,10 +6621,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 												</entry>
 												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
 													<key>caret-color</key>
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 												</entry>
@@ -12514,22 +6631,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<entry>
 													<key>column-rule-color</key>
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-												</entry>
-												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">15px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">30px</value>
-												</entry>
-												<entry>
-													<key>list-style-type</key>
-													<value xsi:type="xsd:string">none</value>
 												</entry>
 												<entry>
 													<key>margin-bottom</key>
@@ -12582,10 +6683,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
 													</entry>
 													<entry>
-														<key>border-image-width</key>
-														<value xsi:type="xsd:string">1</value>
-													</entry>
-													<entry>
 														<key>border-left-color</key>
 														<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
 													</entry>
@@ -12596,10 +6693,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<entry>
 														<key>border-top-color</key>
 														<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
 													</entry>
 													<entry>
 														<key>caret-color</key>
@@ -12630,10 +6723,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">42px</value>
 													</entry>
 													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
 														<key>margin-bottom</key>
 														<value xsi:type="xsd:string">6px</value>
 													</entry>
@@ -12644,10 +6733,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<entry>
 														<key>outline-color</key>
 														<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">center</value>
 													</entry>
 													<entry>
 														<key>text-decoration-color</key>
@@ -12673,10 +6758,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<attributes>
 													<attributes>
 														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
 															<key>border-bottom-left-radius</key>
 															<value xsi:type="xsd:string">3px</value>
 														</entry>
@@ -12685,20 +6766,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">3px</value>
 														</entry>
 														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
 															<key>border-radius</key>
 															<value xsi:type="xsd:string">3px</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
 														</entry>
 														<entry>
 															<key>border-top-left-radius</key>
@@ -12709,60 +6778,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">3px</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">30px</value>
-														</entry>
-														<entry>
-															<key>font-weight</key>
-															<value xsi:type="xsd:string">700</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">42px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>margin-right</key>
 															<value xsi:type="xsd:string">-30px</value>
 														</entry>
 														<entry>
 															<key>max-width</key>
 															<value xsi:type="xsd:string">100%</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">center</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
 														</entry>
 														<entry>
 															<key>vertical-align</key>
@@ -12805,10 +6826,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
@@ -12821,32 +6838,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">30px</value>
-														</entry>
-														<entry>
-															<key>font-weight</key>
-															<value xsi:type="xsd:string">700</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">42px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">center</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -12855,7 +6848,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													</attributes>
 												</attributes>
 											</containedComponents>
-											<containedComponents retestId="97b367eb-db76-4201-aa79-390b0dba9ef5">
+											<containedComponents retestId="2e888efd-b5d5-4ff8-821b-424400c3b73c">
 												<identifyingAttributes>
 													<attributes>
 														<attribute key="outline" xsi:type="outlineAttribute">
@@ -12889,10 +6882,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
@@ -12905,32 +6894,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">30px</value>
-														</entry>
-														<entry>
-															<key>font-weight</key>
-															<value xsi:type="xsd:string">700</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">42px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">center</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -12963,60 +6928,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 												<entry>
-													<key>border-left-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-right-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-top-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
-													<key>caret-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>column-rule-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>float</key>
 													<value xsi:type="xsd:string">left</value>
 												</entry>
 												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">15px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">30px</value>
-												</entry>
-												<entry>
-													<key>list-style-type</key>
-													<value xsi:type="xsd:string">none</value>
-												</entry>
-												<entry>
 													<key>min-height</key>
 													<value xsi:type="xsd:string">1px</value>
-												</entry>
-												<entry>
-													<key>outline-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 												<entry>
 													<key>padding-left</key>
@@ -13029,14 +6946,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<entry>
 													<key>position</key>
 													<value xsi:type="xsd:string">relative</value>
-												</entry>
-												<entry>
-													<key>text-align</key>
-													<value xsi:type="xsd:string">left</value>
-												</entry>
-												<entry>
-													<key>text-decoration-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -13074,10 +6983,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 													</entry>
 													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
 														<key>caret-color</key>
 														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 													</entry>
@@ -13088,22 +6993,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<entry>
 														<key>column-rule-color</key>
 														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
 													</entry>
 													<entry>
 														<key>outline-color</key>
@@ -13142,56 +7031,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<attributes>
 													<attributes>
 														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-														</entry>
-														<entry>
 															<key>font-size</key>
 															<value xsi:type="xsd:string">17px</value>
 														</entry>
 														<entry>
 															<key>line-height</key>
 															<value xsi:type="xsd:string">36px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>margin-bottom</key>
-															<value xsi:type="xsd:string">0px</value>
 														</entry>
 														<entry>
 															<key>margin-left</key>
@@ -13204,18 +7049,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<entry>
 															<key>margin-top</key>
 															<value xsi:type="xsd:string">12px</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">right</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 														</entry>
 													</attributes>
 												</attributes>
@@ -13233,70 +7066,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 														</attributes>
 													</identifyingAttributes>
-													<attributes>
-														<attributes>
-															<entry>
-																<key>border-bottom-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>border-left-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>border-right-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>border-top-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
-																<key>caret-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>column-rule-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-															</entry>
-															<entry>
-																<key>font-size</key>
-																<value xsi:type="xsd:string">17px</value>
-															</entry>
-															<entry>
-																<key>line-height</key>
-																<value xsi:type="xsd:string">36px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
-															</entry>
-															<entry>
-																<key>outline-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">right</value>
-															</entry>
-															<entry>
-																<key>text-decoration-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-														</attributes>
-													</attributes>
+													<attributes/>
 												</containedComponents>
 												<containedComponents retestId="retest_compares">
 													<identifyingAttributes>
@@ -13332,10 +7102,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 															</entry>
@@ -13348,32 +7114,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-															</entry>
-															<entry>
-																<key>font-size</key>
-																<value xsi:type="xsd:string">17px</value>
-															</entry>
-															<entry>
-																<key>font-style</key>
-																<value xsi:type="xsd:string">normal</value>
-															</entry>
-															<entry>
-																<key>line-height</key>
-																<value xsi:type="xsd:string">36px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
-															</entry>
-															<entry>
 																<key>outline-color</key>
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">right</value>
 															</entry>
 															<entry>
 																<key>text-decoration-color</key>
@@ -13407,60 +7149,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 												<entry>
-													<key>border-left-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-right-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-top-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
-													<key>caret-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>column-rule-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>float</key>
 													<value xsi:type="xsd:string">right</value>
 												</entry>
 												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">15px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">30px</value>
-												</entry>
-												<entry>
-													<key>list-style-type</key>
-													<value xsi:type="xsd:string">none</value>
-												</entry>
-												<entry>
 													<key>min-height</key>
 													<value xsi:type="xsd:string">1px</value>
-												</entry>
-												<entry>
-													<key>outline-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 												<entry>
 													<key>padding-left</key>
@@ -13473,14 +7167,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<entry>
 													<key>position</key>
 													<value xsi:type="xsd:string">relative</value>
-												</entry>
-												<entry>
-													<key>text-align</key>
-													<value xsi:type="xsd:string">left</value>
-												</entry>
-												<entry>
-													<key>text-decoration-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -13498,70 +7184,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 												</attributes>
 											</identifyingAttributes>
-											<attributes>
-												<attributes>
-													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-												</attributes>
-											</attributes>
+											<attributes/>
 										</containedComponents>
 										<containedComponents retestId="img">
 											<identifyingAttributes>
@@ -13580,10 +7203,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 											<attributes>
 												<attributes>
 													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>border-bottom-left-radius</key>
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
@@ -13592,20 +7211,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
 													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>border-radius</key>
 														<value xsi:type="xsd:string">3px</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 													</entry>
 													<entry>
 														<key>border-top-left-radius</key>
@@ -13616,60 +7223,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
 													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>display</key>
-														<value xsi:type="xsd:string">block</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
 														<key>max-height</key>
 														<value xsi:type="xsd:string">200px</value>
 													</entry>
 													<entry>
 														<key>max-width</key>
 														<value xsi:type="xsd:string">100%</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 													</entry>
 													<entry>
 														<key>vertical-align</key>
@@ -13695,10 +7254,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 											<attributes>
 												<attributes>
 													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>border-bottom-left-radius</key>
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
@@ -13707,20 +7262,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
 													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>border-radius</key>
 														<value xsi:type="xsd:string">3px</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 													</entry>
 													<entry>
 														<key>border-top-left-radius</key>
@@ -13731,60 +7274,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
 													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>display</key>
-														<value xsi:type="xsd:string">block</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
 														<key>max-height</key>
 														<value xsi:type="xsd:string">200px</value>
 													</entry>
 													<entry>
 														<key>max-width</key>
 														<value xsi:type="xsd:string">100%</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 													</entry>
 													<entry>
 														<key>vertical-align</key>
@@ -13813,68 +7308,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<attributes>
 									<attributes>
 										<entry>
-											<key>border-bottom-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-image-width</key>
-											<value xsi:type="xsd:string">1</value>
-										</entry>
-										<entry>
-											<key>border-left-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-right-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-top-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>box-sizing</key>
-											<value xsi:type="xsd:string">border-box</value>
-										</entry>
-										<entry>
-											<key>caret-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>column-rule-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>font-family</key>
-											<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-										</entry>
-										<entry>
-											<key>font-size</key>
-											<value xsi:type="xsd:string">15px</value>
-										</entry>
-										<entry>
-											<key>line-height</key>
-											<value xsi:type="xsd:string">30px</value>
-										</entry>
-										<entry>
-											<key>list-style-type</key>
-											<value xsi:type="xsd:string">none</value>
-										</entry>
-										<entry>
-											<key>outline-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
 											<key>text-align</key>
 											<value xsi:type="xsd:string">left</value>
-										</entry>
-										<entry>
-											<key>text-decoration-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 										</entry>
 									</attributes>
 								</attributes>
@@ -13908,56 +7343,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<value xsi:type="xsd:string">1px</value>
 											</entry>
 											<entry>
-												<key>border-left-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-right-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
 												<key>border-style</key>
 												<value xsi:type="xsd:string">none none solid</value>
 											</entry>
 											<entry>
-												<key>border-top-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
 												<key>border-width</key>
 												<value xsi:type="xsd:string">0px 0px 1px</value>
-											</entry>
-											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
-											</entry>
-											<entry>
-												<key>caret-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>column-rule-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>font-family</key>
-												<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-											</entry>
-											<entry>
-												<key>font-size</key>
-												<value xsi:type="xsd:string">15px</value>
-											</entry>
-											<entry>
-												<key>line-height</key>
-												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
-												<key>list-style-type</key>
-												<value xsi:type="xsd:string">none</value>
 											</entry>
 											<entry>
 												<key>margin-left</key>
@@ -13972,20 +7363,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<value xsi:type="xsd:string">1020px</value>
 											</entry>
 											<entry>
-												<key>outline-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
 												<key>padding-bottom</key>
 												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
-												<key>text-align</key>
-												<value xsi:type="xsd:string">left</value>
-											</entry>
-											<entry>
-												<key>text-decoration-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 											</entry>
 										</attributes>
 									</attributes>
@@ -14023,10 +7402,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 												</entry>
 												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
 													<key>caret-color</key>
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 												</entry>
@@ -14037,22 +7412,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<entry>
 													<key>column-rule-color</key>
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-												</entry>
-												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">15px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">30px</value>
-												</entry>
-												<entry>
-													<key>list-style-type</key>
-													<value xsi:type="xsd:string">none</value>
 												</entry>
 												<entry>
 													<key>margin-bottom</key>
@@ -14105,10 +7464,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
 													</entry>
 													<entry>
-														<key>border-image-width</key>
-														<value xsi:type="xsd:string">1</value>
-													</entry>
-													<entry>
 														<key>border-left-color</key>
 														<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
 													</entry>
@@ -14119,10 +7474,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<entry>
 														<key>border-top-color</key>
 														<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
 													</entry>
 													<entry>
 														<key>caret-color</key>
@@ -14153,10 +7504,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">42px</value>
 													</entry>
 													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
 														<key>margin-bottom</key>
 														<value xsi:type="xsd:string">6px</value>
 													</entry>
@@ -14167,10 +7514,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<entry>
 														<key>outline-color</key>
 														<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">center</value>
 													</entry>
 													<entry>
 														<key>text-decoration-color</key>
@@ -14196,10 +7539,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<attributes>
 													<attributes>
 														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
 															<key>border-bottom-left-radius</key>
 															<value xsi:type="xsd:string">3px</value>
 														</entry>
@@ -14208,20 +7547,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">3px</value>
 														</entry>
 														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
 															<key>border-radius</key>
 															<value xsi:type="xsd:string">3px</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
 														</entry>
 														<entry>
 															<key>border-top-left-radius</key>
@@ -14232,60 +7559,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">3px</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">30px</value>
-														</entry>
-														<entry>
-															<key>font-weight</key>
-															<value xsi:type="xsd:string">700</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">42px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>margin-right</key>
 															<value xsi:type="xsd:string">-30px</value>
 														</entry>
 														<entry>
 															<key>max-width</key>
 															<value xsi:type="xsd:string">100%</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">center</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
 														</entry>
 														<entry>
 															<key>vertical-align</key>
@@ -14328,10 +7607,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
@@ -14344,32 +7619,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">30px</value>
-														</entry>
-														<entry>
-															<key>font-weight</key>
-															<value xsi:type="xsd:string">700</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">42px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">center</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -14378,7 +7629,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													</attributes>
 												</attributes>
 											</containedComponents>
-											<containedComponents retestId="0b53fae7-7989-4c90-bbcb-6f1254e22731">
+											<containedComponents retestId="707a9099-ac76-474f-bfb1-a39b1ed3b837">
 												<identifyingAttributes>
 													<attributes>
 														<attribute key="outline" xsi:type="outlineAttribute">
@@ -14412,10 +7663,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
@@ -14428,32 +7675,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">30px</value>
-														</entry>
-														<entry>
-															<key>font-weight</key>
-															<value xsi:type="xsd:string">700</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">42px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">center</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -14486,60 +7709,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 												<entry>
-													<key>border-left-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-right-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-top-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
-													<key>caret-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>column-rule-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>float</key>
 													<value xsi:type="xsd:string">left</value>
 												</entry>
 												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">15px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">30px</value>
-												</entry>
-												<entry>
-													<key>list-style-type</key>
-													<value xsi:type="xsd:string">none</value>
-												</entry>
-												<entry>
 													<key>min-height</key>
 													<value xsi:type="xsd:string">1px</value>
-												</entry>
-												<entry>
-													<key>outline-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 												<entry>
 													<key>padding-left</key>
@@ -14552,14 +7727,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<entry>
 													<key>position</key>
 													<value xsi:type="xsd:string">relative</value>
-												</entry>
-												<entry>
-													<key>text-align</key>
-													<value xsi:type="xsd:string">left</value>
-												</entry>
-												<entry>
-													<key>text-decoration-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -14577,70 +7744,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 												</attributes>
 											</identifyingAttributes>
-											<attributes>
-												<attributes>
-													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-												</attributes>
-											</attributes>
+											<attributes/>
 										</containedComponents>
 										<containedComponents retestId="br">
 											<identifyingAttributes>
@@ -14656,70 +7760,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 												</attributes>
 											</identifyingAttributes>
-											<attributes>
-												<attributes>
-													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-												</attributes>
-											</attributes>
+											<attributes/>
 										</containedComponents>
 										<containedComponents retestId="br">
 											<identifyingAttributes>
@@ -14735,70 +7776,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 												</attributes>
 											</identifyingAttributes>
-											<attributes>
-												<attributes>
-													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-												</attributes>
-											</attributes>
+											<attributes/>
 										</containedComponents>
 										<containedComponents retestId="img">
 											<identifyingAttributes>
@@ -14817,10 +7795,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 											<attributes>
 												<attributes>
 													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>border-bottom-left-radius</key>
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
@@ -14829,20 +7803,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
 													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>border-radius</key>
 														<value xsi:type="xsd:string">3px</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 													</entry>
 													<entry>
 														<key>border-top-left-radius</key>
@@ -14853,60 +7815,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
 													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>display</key>
-														<value xsi:type="xsd:string">block</value>
-													</entry>
-													<entry>
 														<key>float</key>
 														<value xsi:type="xsd:string">right</value>
 													</entry>
 													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
 														<key>max-width</key>
 														<value xsi:type="xsd:string">400px</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 													</entry>
 													<entry>
 														<key>vertical-align</key>
@@ -14938,60 +7852,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 												<entry>
-													<key>border-left-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-right-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-top-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
-													<key>caret-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>column-rule-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>float</key>
 													<value xsi:type="xsd:string">right</value>
 												</entry>
 												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">15px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">30px</value>
-												</entry>
-												<entry>
-													<key>list-style-type</key>
-													<value xsi:type="xsd:string">none</value>
-												</entry>
-												<entry>
 													<key>min-height</key>
 													<value xsi:type="xsd:string">1px</value>
-												</entry>
-												<entry>
-													<key>outline-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 												<entry>
 													<key>padding-left</key>
@@ -15004,14 +7870,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<entry>
 													<key>position</key>
 													<value xsi:type="xsd:string">relative</value>
-												</entry>
-												<entry>
-													<key>text-align</key>
-													<value xsi:type="xsd:string">left</value>
-												</entry>
-												<entry>
-													<key>text-decoration-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -15049,10 +7907,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 													</entry>
 													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
 														<key>caret-color</key>
 														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 													</entry>
@@ -15065,28 +7919,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 													</entry>
 													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
 														<key>outline-color</key>
 														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
 													</entry>
 													<entry>
 														<key>text-decoration-color</key>
@@ -15111,56 +7945,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<attributes>
 													<attributes>
 														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-														</entry>
-														<entry>
 															<key>font-size</key>
 															<value xsi:type="xsd:string">17px</value>
 														</entry>
 														<entry>
 															<key>line-height</key>
 															<value xsi:type="xsd:string">36px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>margin-bottom</key>
-															<value xsi:type="xsd:string">0px</value>
 														</entry>
 														<entry>
 															<key>margin-left</key>
@@ -15173,18 +7963,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<entry>
 															<key>margin-top</key>
 															<value xsi:type="xsd:string">12px</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 														</entry>
 													</attributes>
 												</attributes>
@@ -15202,70 +7980,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 														</attributes>
 													</identifyingAttributes>
-													<attributes>
-														<attributes>
-															<entry>
-																<key>border-bottom-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>border-left-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>border-right-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>border-top-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
-																<key>caret-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>column-rule-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-															</entry>
-															<entry>
-																<key>font-size</key>
-																<value xsi:type="xsd:string">17px</value>
-															</entry>
-															<entry>
-																<key>line-height</key>
-																<value xsi:type="xsd:string">36px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
-															</entry>
-															<entry>
-																<key>outline-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
-																<key>text-decoration-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-														</attributes>
-													</attributes>
+													<attributes/>
 												</containedComponents>
 												<containedComponents retestId="br">
 													<identifyingAttributes>
@@ -15281,70 +7996,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 														</attributes>
 													</identifyingAttributes>
-													<attributes>
-														<attributes>
-															<entry>
-																<key>border-bottom-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>border-left-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>border-right-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>border-top-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
-																<key>caret-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>column-rule-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-															</entry>
-															<entry>
-																<key>font-size</key>
-																<value xsi:type="xsd:string">17px</value>
-															</entry>
-															<entry>
-																<key>line-height</key>
-																<value xsi:type="xsd:string">36px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
-															</entry>
-															<entry>
-																<key>outline-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
-																<key>text-decoration-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-														</attributes>
-													</attributes>
+													<attributes/>
 												</containedComponents>
 												<containedComponents retestId="the_future_of">
 													<identifyingAttributes>
@@ -15380,10 +8032,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 															</entry>
@@ -15396,32 +8044,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-															</entry>
-															<entry>
-																<key>font-size</key>
-																<value xsi:type="xsd:string">17px</value>
-															</entry>
-															<entry>
-																<key>font-style</key>
-																<value xsi:type="xsd:string">normal</value>
-															</entry>
-															<entry>
-																<key>line-height</key>
-																<value xsi:type="xsd:string">36px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
-															</entry>
-															<entry>
 																<key>outline-color</key>
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
 															</entry>
 															<entry>
 																<key>text-decoration-color</key>
@@ -15464,10 +8088,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 															</entry>
@@ -15480,32 +8100,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-															</entry>
-															<entry>
-																<key>font-size</key>
-																<value xsi:type="xsd:string">17px</value>
-															</entry>
-															<entry>
-																<key>font-style</key>
-																<value xsi:type="xsd:string">normal</value>
-															</entry>
-															<entry>
-																<key>line-height</key>
-																<value xsi:type="xsd:string">36px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
-															</entry>
-															<entry>
 																<key>outline-color</key>
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
 															</entry>
 															<entry>
 																<key>text-decoration-color</key>
@@ -15514,7 +8110,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														</attributes>
 													</attributes>
 												</containedComponents>
-												<containedComponents retestId="0818e190-44ab-4a14-a32d-3eb0bb9dd19b">
+												<containedComponents retestId="d8e36cb0-dfc8-4318-8815-a9e651025ad6">
 													<identifyingAttributes>
 														<attributes>
 															<attribute key="outline" xsi:type="outlineAttribute">
@@ -15548,10 +8144,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 															</entry>
@@ -15564,28 +8156,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-															</entry>
-															<entry>
-																<key>font-size</key>
-																<value xsi:type="xsd:string">17px</value>
-															</entry>
-															<entry>
-																<key>line-height</key>
-																<value xsi:type="xsd:string">36px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
-															</entry>
-															<entry>
 																<key>outline-color</key>
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
 															</entry>
 															<entry>
 																<key>text-decoration-color</key>
@@ -15608,7 +8180,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="id" xsi:type="stringAttribute">info</attribute>
 							<attribute key="outline" xsi:type="outlineAttribute">
 								<x>0</x>
-								<y>2558</y>
+								<y>2601</y>
 								<height>408</height>
 								<width>1200</width>
 							</attribute>
@@ -15624,68 +8196,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
 							</entry>
 							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">15px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
 								<key>padding-bottom</key>
 								<value xsi:type="xsd:string">42px</value>
 							</entry>
 							<entry>
 								<key>padding-top</key>
 								<value xsi:type="xsd:string">60px</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -15707,50 +8223,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 						<attributes>
 							<attributes>
 								<entry>
-									<key>border-bottom-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-left-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-right-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-top-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>box-sizing</key>
-									<value xsi:type="xsd:string">border-box</value>
-								</entry>
-								<entry>
-									<key>caret-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>column-rule-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-								</entry>
-								<entry>
-									<key>font-size</key>
-									<value xsi:type="xsd:string">15px</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">30px</value>
-								</entry>
-								<entry>
 									<key>margin-left</key>
 									<value xsi:type="xsd:string">82.5px</value>
 								</entry>
@@ -15761,14 +8233,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<entry>
 									<key>max-width</key>
 									<value xsi:type="xsd:string">1020px</value>
-								</entry>
-								<entry>
-									<key>outline-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>text-decoration-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 								</entry>
 							</attributes>
 						</attributes>
@@ -15787,62 +8251,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 									<attribute key="type" xsi:type="stringAttribute">DIV</attribute>
 								</attributes>
 							</identifyingAttributes>
-							<attributes>
-								<attributes>
-									<entry>
-										<key>border-bottom-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>border-left-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>border-right-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>border-top-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>box-sizing</key>
-										<value xsi:type="xsd:string">border-box</value>
-									</entry>
-									<entry>
-										<key>caret-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>column-rule-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">15px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">30px</value>
-									</entry>
-									<entry>
-										<key>outline-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>text-decoration-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-								</attributes>
-							</attributes>
+							<attributes/>
 							<containedComponents retestId="div">
 								<identifyingAttributes>
 									<attributes>
@@ -15861,60 +8270,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<attributes>
 									<attributes>
 										<entry>
-											<key>border-bottom-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-left-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-right-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-top-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>box-sizing</key>
-											<value xsi:type="xsd:string">border-box</value>
-										</entry>
-										<entry>
-											<key>caret-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>column-rule-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
 											<key>float</key>
 											<value xsi:type="xsd:string">left</value>
 										</entry>
 										<entry>
-											<key>font-family</key>
-											<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-										</entry>
-										<entry>
-											<key>font-size</key>
-											<value xsi:type="xsd:string">15px</value>
-										</entry>
-										<entry>
-											<key>line-height</key>
-											<value xsi:type="xsd:string">30px</value>
-										</entry>
-										<entry>
 											<key>min-height</key>
 											<value xsi:type="xsd:string">1px</value>
-										</entry>
-										<entry>
-											<key>outline-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 										</entry>
 										<entry>
 											<key>padding-left</key>
@@ -15927,10 +8288,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 										<entry>
 											<key>position</key>
 											<value xsi:type="xsd:string">relative</value>
-										</entry>
-										<entry>
-											<key>text-decoration-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 										</entry>
 									</attributes>
 								</attributes>
@@ -15956,10 +8313,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 											</entry>
 											<entry>
-												<key>border-image-width</key>
-												<value xsi:type="xsd:string">1</value>
-											</entry>
-											<entry>
 												<key>border-left-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 											</entry>
@@ -15970,10 +8323,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 											<entry>
 												<key>border-top-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-											</entry>
-											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
 											</entry>
 											<entry>
 												<key>caret-color</key>
@@ -15996,20 +8345,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<value xsi:type="xsd:string">18px</value>
 											</entry>
 											<entry>
-												<key>font-weight</key>
-												<value xsi:type="xsd:string">400</value>
-											</entry>
-											<entry>
-												<key>line-height</key>
-												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
 												<key>margin-bottom</key>
 												<value xsi:type="xsd:string">6px</value>
-											</entry>
-											<entry>
-												<key>margin-top</key>
-												<value xsi:type="xsd:string">0px</value>
 											</entry>
 											<entry>
 												<key>outline-color</key>
@@ -16041,64 +8378,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 									<attributes>
 										<attributes>
 											<entry>
-												<key>border-bottom-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-left-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-right-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-top-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
-											</entry>
-											<entry>
-												<key>caret-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>column-rule-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>font-family</key>
-												<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-											</entry>
-											<entry>
-												<key>font-size</key>
-												<value xsi:type="xsd:string">15px</value>
-											</entry>
-											<entry>
-												<key>line-height</key>
-												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
 												<key>margin-bottom</key>
 												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
-												<key>margin-top</key>
-												<value xsi:type="xsd:string">0px</value>
-											</entry>
-											<entry>
-												<key>outline-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>text-decoration-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 											</entry>
 										</attributes>
 									</attributes>
@@ -16116,62 +8397,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 											</attributes>
 										</identifyingAttributes>
-										<attributes>
-											<attributes>
-												<entry>
-													<key>border-bottom-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-left-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-right-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-top-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
-													<key>caret-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>column-rule-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">15px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">30px</value>
-												</entry>
-												<entry>
-													<key>outline-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>text-decoration-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-											</attributes>
-										</attributes>
+										<attributes/>
 									</containedComponents>
 								</containedComponents>
 							</containedComponents>
@@ -16193,60 +8419,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<attributes>
 									<attributes>
 										<entry>
-											<key>border-bottom-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-left-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-right-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-top-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>box-sizing</key>
-											<value xsi:type="xsd:string">border-box</value>
-										</entry>
-										<entry>
-											<key>caret-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>column-rule-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
 											<key>float</key>
 											<value xsi:type="xsd:string">left</value>
 										</entry>
 										<entry>
-											<key>font-family</key>
-											<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-										</entry>
-										<entry>
-											<key>font-size</key>
-											<value xsi:type="xsd:string">15px</value>
-										</entry>
-										<entry>
-											<key>line-height</key>
-											<value xsi:type="xsd:string">30px</value>
-										</entry>
-										<entry>
 											<key>min-height</key>
 											<value xsi:type="xsd:string">1px</value>
-										</entry>
-										<entry>
-											<key>outline-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 										</entry>
 										<entry>
 											<key>padding-left</key>
@@ -16259,10 +8437,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 										<entry>
 											<key>position</key>
 											<value xsi:type="xsd:string">relative</value>
-										</entry>
-										<entry>
-											<key>text-decoration-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 										</entry>
 									</attributes>
 								</attributes>
@@ -16288,10 +8462,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 											</entry>
 											<entry>
-												<key>border-image-width</key>
-												<value xsi:type="xsd:string">1</value>
-											</entry>
-											<entry>
 												<key>border-left-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 											</entry>
@@ -16302,10 +8472,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 											<entry>
 												<key>border-top-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-											</entry>
-											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
 											</entry>
 											<entry>
 												<key>caret-color</key>
@@ -16328,20 +8494,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<value xsi:type="xsd:string">18px</value>
 											</entry>
 											<entry>
-												<key>font-weight</key>
-												<value xsi:type="xsd:string">400</value>
-											</entry>
-											<entry>
-												<key>line-height</key>
-												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
 												<key>margin-bottom</key>
 												<value xsi:type="xsd:string">6px</value>
-											</entry>
-											<entry>
-												<key>margin-top</key>
-												<value xsi:type="xsd:string">0px</value>
 											</entry>
 											<entry>
 												<key>outline-color</key>
@@ -16374,64 +8528,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 									<attributes>
 										<attributes>
 											<entry>
-												<key>border-bottom-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-left-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-right-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-top-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
-											</entry>
-											<entry>
-												<key>caret-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>column-rule-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>font-family</key>
-												<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-											</entry>
-											<entry>
-												<key>font-size</key>
-												<value xsi:type="xsd:string">15px</value>
-											</entry>
-											<entry>
-												<key>line-height</key>
-												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
 												<key>margin-bottom</key>
 												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
-												<key>margin-top</key>
-												<value xsi:type="xsd:string">0px</value>
-											</entry>
-											<entry>
-												<key>outline-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>text-decoration-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 											</entry>
 										</attributes>
 									</attributes>
@@ -16455,60 +8553,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<attributes>
 									<attributes>
 										<entry>
-											<key>border-bottom-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-left-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-right-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-top-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>box-sizing</key>
-											<value xsi:type="xsd:string">border-box</value>
-										</entry>
-										<entry>
-											<key>caret-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>column-rule-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
 											<key>float</key>
 											<value xsi:type="xsd:string">left</value>
 										</entry>
 										<entry>
-											<key>font-family</key>
-											<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-										</entry>
-										<entry>
-											<key>font-size</key>
-											<value xsi:type="xsd:string">15px</value>
-										</entry>
-										<entry>
-											<key>line-height</key>
-											<value xsi:type="xsd:string">30px</value>
-										</entry>
-										<entry>
 											<key>min-height</key>
 											<value xsi:type="xsd:string">1px</value>
-										</entry>
-										<entry>
-											<key>outline-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 										</entry>
 										<entry>
 											<key>padding-left</key>
@@ -16521,10 +8571,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 										<entry>
 											<key>position</key>
 											<value xsi:type="xsd:string">relative</value>
-										</entry>
-										<entry>
-											<key>text-decoration-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 										</entry>
 									</attributes>
 								</attributes>
@@ -16550,10 +8596,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 											</entry>
 											<entry>
-												<key>border-image-width</key>
-												<value xsi:type="xsd:string">1</value>
-											</entry>
-											<entry>
 												<key>border-left-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 											</entry>
@@ -16564,10 +8606,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 											<entry>
 												<key>border-top-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-											</entry>
-											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
 											</entry>
 											<entry>
 												<key>caret-color</key>
@@ -16590,20 +8628,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<value xsi:type="xsd:string">18px</value>
 											</entry>
 											<entry>
-												<key>font-weight</key>
-												<value xsi:type="xsd:string">400</value>
-											</entry>
-											<entry>
-												<key>line-height</key>
-												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
 												<key>margin-bottom</key>
 												<value xsi:type="xsd:string">6px</value>
-											</entry>
-											<entry>
-												<key>margin-top</key>
-												<value xsi:type="xsd:string">0px</value>
 											</entry>
 											<entry>
 												<key>outline-color</key>
@@ -16638,64 +8664,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 									<attributes>
 										<attributes>
 											<entry>
-												<key>border-bottom-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-left-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-right-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-top-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
-											</entry>
-											<entry>
-												<key>caret-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>column-rule-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>font-family</key>
-												<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-											</entry>
-											<entry>
-												<key>font-size</key>
-												<value xsi:type="xsd:string">15px</value>
-											</entry>
-											<entry>
-												<key>line-height</key>
-												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
 												<key>margin-bottom</key>
 												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
-												<key>margin-top</key>
-												<value xsi:type="xsd:string">0px</value>
-											</entry>
-											<entry>
-												<key>outline-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>text-decoration-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 											</entry>
 										</attributes>
 									</attributes>
@@ -16719,18 +8689,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 						<attribute key="type" xsi:type="stringAttribute">HEAD</attribute>
 					</attributes>
 				</identifyingAttributes>
-				<attributes>
-					<attributes>
-						<entry>
-							<key>box-sizing</key>
-							<value xsi:type="xsd:string">border-box</value>
-						</entry>
-						<entry>
-							<key>font-size</key>
-							<value xsi:type="xsd:string">10px</value>
-						</entry>
-					</attributes>
-				</attributes>
+				<attributes/>
 				<containedComponents retestId="link">
 					<identifyingAttributes>
 						<attributes>
@@ -16745,22 +8704,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">LINK</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="link">
 					<identifyingAttributes>
@@ -16776,22 +8720,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">LINK</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="link">
 					<identifyingAttributes>
@@ -16807,22 +8736,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">LINK</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="link">
 					<identifyingAttributes>
@@ -16838,22 +8752,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">LINK</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="link">
 					<identifyingAttributes>
@@ -16869,22 +8768,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">LINK</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="link">
 					<identifyingAttributes>
@@ -16900,22 +8784,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">LINK</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="link">
 					<identifyingAttributes>
@@ -16931,22 +8800,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">LINK</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="link">
 					<identifyingAttributes>
@@ -16962,22 +8816,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">LINK</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="meta">
 					<identifyingAttributes>
@@ -16997,24 +8836,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">Initial informations about retest</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -17037,24 +8860,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">2018</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -17077,24 +8884,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">© 2018 Jeremias Rößler</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -17116,24 +8907,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">retest</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -17155,24 +8930,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">website</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -17194,24 +8953,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">https://www.retest.de</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -17233,24 +8976,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">https://www.retest.de/images/logo.png</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -17273,24 +9000,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">width=device-width, initial-scale=1, maximum-scale=1</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -17312,24 +9023,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">text/html; charset=UTF-8</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -17352,24 +9047,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">retest - Java Swing GUI Testing. An innovative approach with artificially intelligent monkey testing.</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -17392,24 +9071,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">Jeremias Rößler</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -17432,24 +9095,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">index, follow</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -17471,24 +9118,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">no-cache</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -17510,24 +9141,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">3600</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -17549,24 +9164,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">3600</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -17588,24 +9187,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">de_DE</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -17628,24 +9211,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">Jeremias Rößler</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -17665,22 +9232,11 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">TITLE</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 			</containedComponents>
 			<screenshot>
-				<persistenceId>window_19cf859b40f9dceebddb552b51356ded4d4b19cf028a06ade9d3f73b7be9e032</persistenceId>
+				<persistenceId>window_5ee1030821dade4a983a310f0f2183ff9d5a90e740386ce1afdac047459ec50c</persistenceId>
 				<type>PNG</type>
 			</screenshot>
 		</descriptors>

--- a/src/test/resources/retest/recheck/de.retest.web.ShowcaseIT/showcase-FirefoxDriver.open.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.ShowcaseIT/showcase-FirefoxDriver.open.recheck/retest.xml
@@ -77,20 +77,8 @@
 							<value xsi:type="xsd:string">rgb(212, 218, 223)</value>
 						</entry>
 						<entry>
-							<key>background-size</key>
-							<value xsi:type="xsd:string">auto auto</value>
-						</entry>
-						<entry>
 							<key>border-bottom-color</key>
 							<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-						</entry>
-						<entry>
-							<key>border-image-outset</key>
-							<value xsi:type="xsd:string">0</value>
-						</entry>
-						<entry>
-							<key>border-image-repeat</key>
-							<value xsi:type="xsd:string">stretch stretch</value>
 						</entry>
 						<entry>
 							<key>border-left-color</key>
@@ -103,10 +91,6 @@
 						<entry>
 							<key>border-top-color</key>
 							<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-						</entry>
-						<entry>
-							<key>box-sizing</key>
-							<value xsi:type="xsd:string">border-box</value>
 						</entry>
 						<entry>
 							<key>caret-color</key>
@@ -133,36 +117,12 @@
 							<value xsi:type="xsd:string">30px</value>
 						</entry>
 						<entry>
-							<key>margin-bottom</key>
-							<value xsi:type="xsd:string">0px</value>
-						</entry>
-						<entry>
-							<key>margin-left</key>
-							<value xsi:type="xsd:string">0px</value>
-						</entry>
-						<entry>
-							<key>margin-right</key>
-							<value xsi:type="xsd:string">0px</value>
-						</entry>
-						<entry>
-							<key>margin-top</key>
-							<value xsi:type="xsd:string">0px</value>
-						</entry>
-						<entry>
 							<key>outline-color</key>
 							<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 						</entry>
 						<entry>
-							<key>quotes</key>
-							<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-						</entry>
-						<entry>
 							<key>text-decoration-color</key>
 							<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-						</entry>
-						<entry>
-							<key>unicode-bidi</key>
-							<value xsi:type="xsd:string">isolate</value>
 						</entry>
 					</attributes>
 				</attributes>
@@ -183,88 +143,12 @@
 					<attributes>
 						<attributes>
 							<entry>
-								<key>background-color</key>
-								<value xsi:type="xsd:string">rgb(212, 218, 223)</value>
-							</entry>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
 								<key>font-size</key>
 								<value xsi:type="xsd:string">14px</value>
 							</entry>
 							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
 								<key>padding-top</key>
 								<value xsi:type="xsd:string">66px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>unicode-bidi</key>
-								<value xsi:type="xsd:string">isolate</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -286,62 +170,6 @@
 						<attributes>
 							<attributes>
 								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-bottom-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>border-left-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-right-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-top-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>box-sizing</key>
-									<value xsi:type="xsd:string">border-box</value>
-								</entry>
-								<entry>
-									<key>caret-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>column-rule-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-								</entry>
-								<entry>
-									<key>font-size</key>
-									<value xsi:type="xsd:string">14px</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">30px</value>
-								</entry>
-								<entry>
 									<key>margin-left</key>
 									<value xsi:type="xsd:string">168px</value>
 								</entry>
@@ -352,22 +180,6 @@
 								<entry>
 									<key>max-width</key>
 									<value xsi:type="xsd:string">1020px</value>
-								</entry>
-								<entry>
-									<key>outline-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
-									<key>text-decoration-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>unicode-bidi</key>
-									<value xsi:type="xsd:string">isolate</value>
 								</entry>
 							</attributes>
 						</attributes>
@@ -389,72 +201,12 @@
 							<attributes>
 								<attributes>
 									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
-										<key>border-bottom-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>border-left-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>border-right-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>border-top-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>box-sizing</key>
-										<value xsi:type="xsd:string">border-box</value>
-									</entry>
-									<entry>
-										<key>caret-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>column-rule-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
 										<key>float</key>
 										<value xsi:type="xsd:string">left</value>
 									</entry>
 									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">30px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">1px</value>
-									</entry>
-									<entry>
-										<key>outline-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 									</entry>
 									<entry>
 										<key>padding-left</key>
@@ -467,18 +219,6 @@
 									<entry>
 										<key>position</key>
 										<value xsi:type="xsd:string">relative</value>
-									</entry>
-									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
-										<key>text-decoration-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>unicode-bidi</key>
-										<value xsi:type="xsd:string">isolate</value>
 									</entry>
 								</attributes>
 							</attributes>
@@ -500,78 +240,6 @@
 								<attributes>
 									<attributes>
 										<entry>
-											<key>background-size</key>
-											<value xsi:type="xsd:string">auto auto</value>
-										</entry>
-										<entry>
-											<key>border-bottom-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-image-outset</key>
-											<value xsi:type="xsd:string">0</value>
-										</entry>
-										<entry>
-											<key>border-image-repeat</key>
-											<value xsi:type="xsd:string">stretch stretch</value>
-										</entry>
-										<entry>
-											<key>border-image-width</key>
-											<value xsi:type="xsd:string">1</value>
-										</entry>
-										<entry>
-											<key>border-left-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-right-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-top-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>box-sizing</key>
-											<value xsi:type="xsd:string">border-box</value>
-										</entry>
-										<entry>
-											<key>caret-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>column-rule-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>font-family</key>
-											<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-										</entry>
-										<entry>
-											<key>font-size</key>
-											<value xsi:type="xsd:string">14px</value>
-										</entry>
-										<entry>
-											<key>line-height</key>
-											<value xsi:type="xsd:string">30px</value>
-										</entry>
-										<entry>
-											<key>margin-bottom</key>
-											<value xsi:type="xsd:string">0px</value>
-										</entry>
-										<entry>
-											<key>margin-top</key>
-											<value xsi:type="xsd:string">0px</value>
-										</entry>
-										<entry>
-											<key>outline-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
 											<key>padding-left</key>
 											<value xsi:type="xsd:string">0px</value>
 										</entry>
@@ -580,20 +248,8 @@
 											<value xsi:type="xsd:string">12px</value>
 										</entry>
 										<entry>
-											<key>quotes</key>
-											<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-										</entry>
-										<entry>
 											<key>text-align</key>
 											<value xsi:type="xsd:string">center</value>
-										</entry>
-										<entry>
-											<key>text-decoration-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>unicode-bidi</key>
-											<value xsi:type="xsd:string">isolate</value>
 										</entry>
 									</attributes>
 								</attributes>
@@ -615,88 +271,12 @@
 									<attributes>
 										<attributes>
 											<entry>
-												<key>background-size</key>
-												<value xsi:type="xsd:string">auto auto</value>
-											</entry>
-											<entry>
-												<key>border-bottom-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-image-outset</key>
-												<value xsi:type="xsd:string">0</value>
-											</entry>
-											<entry>
-												<key>border-image-repeat</key>
-												<value xsi:type="xsd:string">stretch stretch</value>
-											</entry>
-											<entry>
-												<key>border-image-width</key>
-												<value xsi:type="xsd:string">1</value>
-											</entry>
-											<entry>
-												<key>border-left-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-right-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-top-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
-											</entry>
-											<entry>
-												<key>caret-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>column-rule-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
 												<key>display</key>
 												<value xsi:type="xsd:string">inline-block</value>
 											</entry>
 											<entry>
-												<key>font-family</key>
-												<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-											</entry>
-											<entry>
-												<key>font-size</key>
-												<value xsi:type="xsd:string">14px</value>
-											</entry>
-											<entry>
 												<key>line-height</key>
 												<value xsi:type="xsd:string">24px</value>
-											</entry>
-											<entry>
-												<key>outline-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>quotes</key>
-												<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-											</entry>
-											<entry>
-												<key>text-align</key>
-												<value xsi:type="xsd:string">center</value>
-											</entry>
-											<entry>
-												<key>text-decoration-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>unicode-bidi</key>
-												<value xsi:type="xsd:string">isolate</value>
 											</entry>
 										</attributes>
 									</attributes>
@@ -719,88 +299,12 @@
 									<attributes>
 										<attributes>
 											<entry>
-												<key>background-size</key>
-												<value xsi:type="xsd:string">auto auto</value>
-											</entry>
-											<entry>
-												<key>border-bottom-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-image-outset</key>
-												<value xsi:type="xsd:string">0</value>
-											</entry>
-											<entry>
-												<key>border-image-repeat</key>
-												<value xsi:type="xsd:string">stretch stretch</value>
-											</entry>
-											<entry>
-												<key>border-image-width</key>
-												<value xsi:type="xsd:string">1</value>
-											</entry>
-											<entry>
-												<key>border-left-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-right-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-top-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
-											</entry>
-											<entry>
-												<key>caret-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>column-rule-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
 												<key>display</key>
 												<value xsi:type="xsd:string">inline-block</value>
 											</entry>
 											<entry>
-												<key>font-family</key>
-												<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-											</entry>
-											<entry>
-												<key>font-size</key>
-												<value xsi:type="xsd:string">14px</value>
-											</entry>
-											<entry>
 												<key>line-height</key>
 												<value xsi:type="xsd:string">24px</value>
-											</entry>
-											<entry>
-												<key>outline-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>quotes</key>
-												<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-											</entry>
-											<entry>
-												<key>text-align</key>
-												<value xsi:type="xsd:string">center</value>
-											</entry>
-											<entry>
-												<key>text-decoration-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>unicode-bidi</key>
-												<value xsi:type="xsd:string">isolate</value>
 											</entry>
 										</attributes>
 									</attributes>
@@ -822,20 +326,8 @@
 										<attributes>
 											<attributes>
 												<entry>
-													<key>background-size</key>
-													<value xsi:type="xsd:string">auto auto</value>
-												</entry>
-												<entry>
 													<key>border-bottom-color</key>
 													<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-												</entry>
-												<entry>
-													<key>border-image-outset</key>
-													<value xsi:type="xsd:string">0</value>
-												</entry>
-												<entry>
-													<key>border-image-repeat</key>
-													<value xsi:type="xsd:string">stretch stretch</value>
 												</entry>
 												<entry>
 													<key>border-left-color</key>
@@ -850,10 +342,6 @@
 													<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 												</entry>
 												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
 													<key>caret-color</key>
 													<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 												</entry>
@@ -866,36 +354,12 @@
 													<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 												</entry>
 												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">14px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">24px</value>
-												</entry>
-												<entry>
 													<key>outline-color</key>
 													<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 												</entry>
 												<entry>
-													<key>quotes</key>
-													<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-												</entry>
-												<entry>
-													<key>text-align</key>
-													<value xsi:type="xsd:string">center</value>
-												</entry>
-												<entry>
 													<key>text-decoration-color</key>
 													<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-												</entry>
-												<entry>
-													<key>text-decoration-line</key>
-													<value xsi:type="xsd:string">none</value>
 												</entry>
 												<entry>
 													<key>transition-duration</key>
@@ -931,90 +395,7 @@
 							<attribute key="type" xsi:type="stringAttribute">HEADER</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-color</key>
-								<value xsi:type="xsd:string">rgb(212, 218, 223)</value>
-							</entry>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">15px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>unicode-bidi</key>
-								<value xsi:type="xsd:string">isolate</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 					<containedComponents retestId="div">
 						<identifyingAttributes>
 							<attributes>
@@ -1033,62 +414,6 @@
 						<attributes>
 							<attributes>
 								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-bottom-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>border-left-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-right-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-top-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>box-sizing</key>
-									<value xsi:type="xsd:string">border-box</value>
-								</entry>
-								<entry>
-									<key>caret-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>column-rule-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-								</entry>
-								<entry>
-									<key>font-size</key>
-									<value xsi:type="xsd:string">15px</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">30px</value>
-								</entry>
-								<entry>
 									<key>margin-left</key>
 									<value xsi:type="xsd:string">168px</value>
 								</entry>
@@ -1099,22 +424,6 @@
 								<entry>
 									<key>max-width</key>
 									<value xsi:type="xsd:string">1020px</value>
-								</entry>
-								<entry>
-									<key>outline-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
-									<key>text-decoration-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>unicode-bidi</key>
-									<value xsi:type="xsd:string">isolate</value>
 								</entry>
 							</attributes>
 						</attributes>
@@ -1136,72 +445,12 @@
 							<attributes>
 								<attributes>
 									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
-										<key>border-bottom-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>border-left-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>border-right-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>border-top-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>box-sizing</key>
-										<value xsi:type="xsd:string">border-box</value>
-									</entry>
-									<entry>
-										<key>caret-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>column-rule-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
 										<key>float</key>
 										<value xsi:type="xsd:string">left</value>
 									</entry>
 									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">15px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">30px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">1px</value>
-									</entry>
-									<entry>
-										<key>outline-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 									</entry>
 									<entry>
 										<key>padding-left</key>
@@ -1214,18 +463,6 @@
 									<entry>
 										<key>position</key>
 										<value xsi:type="xsd:string">relative</value>
-									</entry>
-									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
-										<key>text-decoration-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>unicode-bidi</key>
-										<value xsi:type="xsd:string">isolate</value>
 									</entry>
 								</attributes>
 							</attributes>
@@ -1247,96 +484,24 @@
 								<attributes>
 									<attributes>
 										<entry>
-											<key>background-size</key>
-											<value xsi:type="xsd:string">auto auto</value>
-										</entry>
-										<entry>
-											<key>border-bottom-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-image-outset</key>
-											<value xsi:type="xsd:string">0</value>
-										</entry>
-										<entry>
-											<key>border-image-repeat</key>
-											<value xsi:type="xsd:string">stretch stretch</value>
-										</entry>
-										<entry>
-											<key>border-left-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-right-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-top-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
 											<key>bottom</key>
 											<value xsi:type="xsd:string">50px</value>
-										</entry>
-										<entry>
-											<key>box-sizing</key>
-											<value xsi:type="xsd:string">border-box</value>
-										</entry>
-										<entry>
-											<key>caret-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>column-rule-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>font-family</key>
-											<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-										</entry>
-										<entry>
-											<key>font-size</key>
-											<value xsi:type="xsd:string">15px</value>
 										</entry>
 										<entry>
 											<key>left</key>
 											<value xsi:type="xsd:string">20px</value>
 										</entry>
 										<entry>
-											<key>line-height</key>
-											<value xsi:type="xsd:string">30px</value>
-										</entry>
-										<entry>
-											<key>outline-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
 											<key>position</key>
 											<value xsi:type="xsd:string">absolute</value>
-										</entry>
-										<entry>
-											<key>quotes</key>
-											<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
 										</entry>
 										<entry>
 											<key>right</key>
 											<value xsi:type="xsd:string">820px</value>
 										</entry>
 										<entry>
-											<key>text-decoration-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
 											<key>top</key>
 											<value xsi:type="xsd:string">10px</value>
-										</entry>
-										<entry>
-											<key>unicode-bidi</key>
-											<value xsi:type="xsd:string">isolate</value>
 										</entry>
 									</attributes>
 								</attributes>
@@ -1357,20 +522,8 @@
 									<attributes>
 										<attributes>
 											<entry>
-												<key>background-size</key>
-												<value xsi:type="xsd:string">auto auto</value>
-											</entry>
-											<entry>
 												<key>border-bottom-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-											</entry>
-											<entry>
-												<key>border-image-outset</key>
-												<value xsi:type="xsd:string">0</value>
-											</entry>
-											<entry>
-												<key>border-image-repeat</key>
-												<value xsi:type="xsd:string">stretch stretch</value>
 											</entry>
 											<entry>
 												<key>border-left-color</key>
@@ -1385,10 +538,6 @@
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 											</entry>
 											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
-											</entry>
-											<entry>
 												<key>caret-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 											</entry>
@@ -1401,36 +550,12 @@
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 											</entry>
 											<entry>
-												<key>display</key>
-												<value xsi:type="xsd:string">block</value>
-											</entry>
-											<entry>
-												<key>font-family</key>
-												<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-											</entry>
-											<entry>
-												<key>font-size</key>
-												<value xsi:type="xsd:string">15px</value>
-											</entry>
-											<entry>
-												<key>line-height</key>
-												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
 												<key>outline-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 											</entry>
 											<entry>
-												<key>quotes</key>
-												<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-											</entry>
-											<entry>
 												<key>text-decoration-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-											</entry>
-											<entry>
-												<key>text-decoration-line</key>
-												<value xsi:type="xsd:string">none</value>
 											</entry>
 											<entry>
 												<key>transition-duration</key>
@@ -1463,40 +588,12 @@
 										<attributes>
 											<attributes>
 												<entry>
-													<key>background-size</key>
-													<value xsi:type="xsd:string">auto auto</value>
-												</entry>
-												<entry>
-													<key>border-bottom-color</key>
-													<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-												</entry>
-												<entry>
 													<key>border-bottom-left-radius</key>
 													<value xsi:type="xsd:string">3px</value>
 												</entry>
 												<entry>
 													<key>border-bottom-right-radius</key>
 													<value xsi:type="xsd:string">3px</value>
-												</entry>
-												<entry>
-													<key>border-image-outset</key>
-													<value xsi:type="xsd:string">0</value>
-												</entry>
-												<entry>
-													<key>border-image-repeat</key>
-													<value xsi:type="xsd:string">stretch stretch</value>
-												</entry>
-												<entry>
-													<key>border-left-color</key>
-													<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-												</entry>
-												<entry>
-													<key>border-right-color</key>
-													<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-												</entry>
-												<entry>
-													<key>border-top-color</key>
-													<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 												</entry>
 												<entry>
 													<key>border-top-left-radius</key>
@@ -1507,48 +604,8 @@
 													<value xsi:type="xsd:string">3px</value>
 												</entry>
 												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
-													<key>caret-color</key>
-													<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-												</entry>
-												<entry>
-													<key>color</key>
-													<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-												</entry>
-												<entry>
-													<key>column-rule-color</key>
-													<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-												</entry>
-												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">15px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">30px</value>
-												</entry>
-												<entry>
 													<key>max-width</key>
 													<value xsi:type="xsd:string">100%</value>
-												</entry>
-												<entry>
-													<key>outline-color</key>
-													<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-												</entry>
-												<entry>
-													<key>quotes</key>
-													<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-												</entry>
-												<entry>
-													<key>text-decoration-color</key>
-													<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -1573,54 +630,6 @@
 								<attributes>
 									<attributes>
 										<entry>
-											<key>background-size</key>
-											<value xsi:type="xsd:string">auto auto</value>
-										</entry>
-										<entry>
-											<key>border-bottom-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-image-outset</key>
-											<value xsi:type="xsd:string">0</value>
-										</entry>
-										<entry>
-											<key>border-image-repeat</key>
-											<value xsi:type="xsd:string">stretch stretch</value>
-										</entry>
-										<entry>
-											<key>border-image-width</key>
-											<value xsi:type="xsd:string">1</value>
-										</entry>
-										<entry>
-											<key>border-left-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-right-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-top-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>box-sizing</key>
-											<value xsi:type="xsd:string">border-box</value>
-										</entry>
-										<entry>
-											<key>caret-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>column-rule-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
 											<key>float</key>
 											<value xsi:type="xsd:string">right</value>
 										</entry>
@@ -1643,26 +652,6 @@
 										<entry>
 											<key>margin-top</key>
 											<value xsi:type="xsd:string">36px</value>
-										</entry>
-										<entry>
-											<key>outline-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>position</key>
-											<value xsi:type="xsd:string">relative</value>
-										</entry>
-										<entry>
-											<key>quotes</key>
-											<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-										</entry>
-										<entry>
-											<key>text-decoration-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>unicode-bidi</key>
-											<value xsi:type="xsd:string">isolate</value>
 										</entry>
 										<entry>
 											<key>z-index</key>
@@ -1689,10 +678,6 @@
 									<attributes>
 										<attributes>
 											<entry>
-												<key>background-size</key>
-												<value xsi:type="xsd:string">auto auto</value>
-											</entry>
-											<entry>
 												<key>border-bottom-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 											</entry>
@@ -1703,14 +688,6 @@
 											<entry>
 												<key>border-bottom-right-radius</key>
 												<value xsi:type="xsd:string">3px</value>
-											</entry>
-											<entry>
-												<key>border-image-outset</key>
-												<value xsi:type="xsd:string">0</value>
-											</entry>
-											<entry>
-												<key>border-image-repeat</key>
-												<value xsi:type="xsd:string">stretch stretch</value>
 											</entry>
 											<entry>
 												<key>border-left-color</key>
@@ -1733,10 +710,6 @@
 												<value xsi:type="xsd:string">3px</value>
 											</entry>
 											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
-											</entry>
-											<entry>
 												<key>caret-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 											</entry>
@@ -1753,32 +726,12 @@
 												<value xsi:type="xsd:string">none</value>
 											</entry>
 											<entry>
-												<key>font-family</key>
-												<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-											</entry>
-											<entry>
-												<key>font-size</key>
-												<value xsi:type="xsd:string">14px</value>
-											</entry>
-											<entry>
-												<key>line-height</key>
-												<value xsi:type="xsd:string">17px</value>
-											</entry>
-											<entry>
 												<key>outline-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 											</entry>
 											<entry>
-												<key>quotes</key>
-												<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-											</entry>
-											<entry>
 												<key>text-decoration-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-											</entry>
-											<entry>
-												<key>text-decoration-line</key>
-												<value xsi:type="xsd:string">none</value>
 											</entry>
 											<entry>
 												<key>transition-duration</key>
@@ -1814,10 +767,6 @@
 									<attributes>
 										<attributes>
 											<entry>
-												<key>background-size</key>
-												<value xsi:type="xsd:string">auto auto</value>
-											</entry>
-											<entry>
 												<key>border-bottom-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 											</entry>
@@ -1828,14 +777,6 @@
 											<entry>
 												<key>border-bottom-right-radius</key>
 												<value xsi:type="xsd:string">3px</value>
-											</entry>
-											<entry>
-												<key>border-image-outset</key>
-												<value xsi:type="xsd:string">0</value>
-											</entry>
-											<entry>
-												<key>border-image-repeat</key>
-												<value xsi:type="xsd:string">stretch stretch</value>
 											</entry>
 											<entry>
 												<key>border-left-color</key>
@@ -1858,10 +799,6 @@
 												<value xsi:type="xsd:string">3px</value>
 											</entry>
 											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
-											</entry>
-											<entry>
 												<key>caret-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 											</entry>
@@ -1878,32 +815,12 @@
 												<value xsi:type="xsd:string">none</value>
 											</entry>
 											<entry>
-												<key>font-family</key>
-												<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-											</entry>
-											<entry>
-												<key>font-size</key>
-												<value xsi:type="xsd:string">14px</value>
-											</entry>
-											<entry>
-												<key>line-height</key>
-												<value xsi:type="xsd:string">17px</value>
-											</entry>
-											<entry>
 												<key>outline-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 											</entry>
 											<entry>
-												<key>quotes</key>
-												<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-											</entry>
-											<entry>
 												<key>text-decoration-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-											</entry>
-											<entry>
-												<key>text-decoration-line</key>
-												<value xsi:type="xsd:string">none</value>
 											</entry>
 											<entry>
 												<key>transition-duration</key>
@@ -1939,72 +856,8 @@
 									<attributes>
 										<attributes>
 											<entry>
-												<key>background-size</key>
-												<value xsi:type="xsd:string">auto auto</value>
-											</entry>
-											<entry>
-												<key>border-bottom-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-image-outset</key>
-												<value xsi:type="xsd:string">0</value>
-											</entry>
-											<entry>
-												<key>border-image-repeat</key>
-												<value xsi:type="xsd:string">stretch stretch</value>
-											</entry>
-											<entry>
-												<key>border-image-width</key>
-												<value xsi:type="xsd:string">1</value>
-											</entry>
-											<entry>
-												<key>border-left-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-right-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-top-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
-											</entry>
-											<entry>
-												<key>caret-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>column-rule-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
 												<key>display</key>
 												<value xsi:type="xsd:string">inline</value>
-											</entry>
-											<entry>
-												<key>font-family</key>
-												<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-											</entry>
-											<entry>
-												<key>font-size</key>
-												<value xsi:type="xsd:string">14px</value>
-											</entry>
-											<entry>
-												<key>line-height</key>
-												<value xsi:type="xsd:string">17px</value>
-											</entry>
-											<entry>
-												<key>margin-bottom</key>
-												<value xsi:type="xsd:string">0px</value>
 											</entry>
 											<entry>
 												<key>margin-top</key>
@@ -2015,28 +868,8 @@
 												<value xsi:type="xsd:string">48px</value>
 											</entry>
 											<entry>
-												<key>outline-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>padding-left</key>
-												<value xsi:type="xsd:string">0px</value>
-											</entry>
-											<entry>
-												<key>quotes</key>
-												<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-											</entry>
-											<entry>
 												<key>text-align</key>
 												<value xsi:type="xsd:string">left</value>
-											</entry>
-											<entry>
-												<key>text-decoration-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>unicode-bidi</key>
-												<value xsi:type="xsd:string">isolate</value>
 											</entry>
 										</attributes>
 									</attributes>
@@ -2057,96 +890,16 @@
 										<attributes>
 											<attributes>
 												<entry>
-													<key>background-size</key>
-													<value xsi:type="xsd:string">auto auto</value>
-												</entry>
-												<entry>
-													<key>border-bottom-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-image-outset</key>
-													<value xsi:type="xsd:string">0</value>
-												</entry>
-												<entry>
-													<key>border-image-repeat</key>
-													<value xsi:type="xsd:string">stretch stretch</value>
-												</entry>
-												<entry>
-													<key>border-image-width</key>
-													<value xsi:type="xsd:string">1</value>
-												</entry>
-												<entry>
-													<key>border-left-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-right-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-top-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
-													<key>caret-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>column-rule-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>display</key>
 													<value xsi:type="xsd:string">inline-block</value>
-												</entry>
-												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">14px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">17px</value>
 												</entry>
 												<entry>
 													<key>list-style-type</key>
 													<value xsi:type="xsd:string">none</value>
 												</entry>
 												<entry>
-													<key>outline-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>position</key>
 													<value xsi:type="xsd:string">relative</value>
-												</entry>
-												<entry>
-													<key>quotes</key>
-													<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-												</entry>
-												<entry>
-													<key>text-align</key>
-													<value xsi:type="xsd:string">left</value>
-												</entry>
-												<entry>
-													<key>text-decoration-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>unicode-bidi</key>
-													<value xsi:type="xsd:string">isolate</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -2164,86 +917,7 @@
 													<attribute key="type" xsi:type="stringAttribute">SPAN</attribute>
 												</attributes>
 											</identifyingAttributes>
-											<attributes>
-												<attributes>
-													<entry>
-														<key>background-size</key>
-														<value xsi:type="xsd:string">auto auto</value>
-													</entry>
-													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-image-outset</key>
-														<value xsi:type="xsd:string">0</value>
-													</entry>
-													<entry>
-														<key>border-image-repeat</key>
-														<value xsi:type="xsd:string">stretch stretch</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">14px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">17px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>quotes</key>
-														<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-												</attributes>
-											</attributes>
+											<attributes/>
 											<containedComponents retestId="for_testers">
 												<identifyingAttributes>
 													<attributes>
@@ -2262,20 +936,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
 															<key>border-bottom-color</key>
 															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
 														</entry>
 														<entry>
 															<key>border-left-color</key>
@@ -2288,10 +950,6 @@
 														<entry>
 															<key>border-top-color</key>
 															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
 														</entry>
 														<entry>
 															<key>caret-color</key>
@@ -2310,20 +968,8 @@
 															<value xsi:type="xsd:string">inline-block</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
 															<key>line-height</key>
 															<value xsi:type="xsd:string">32px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
 														</entry>
 														<entry>
 															<key>outline-color</key>
@@ -2346,20 +992,8 @@
 															<value xsi:type="xsd:string">8px</value>
 														</entry>
 														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
 															<key>text-decoration-color</key>
 															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>text-decoration-line</key>
-															<value xsi:type="xsd:string">none</value>
 														</entry>
 														<entry>
 															<key>transition-duration</key>
@@ -2402,14 +1036,6 @@
 														<value xsi:type="xsd:string">rgb(212, 218, 223)</value>
 													</entry>
 													<entry>
-														<key>background-size</key>
-														<value xsi:type="xsd:string">auto auto</value>
-													</entry>
-													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>border-bottom-left-radius</key>
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
@@ -2418,100 +1044,20 @@
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
 													<entry>
-														<key>border-image-outset</key>
-														<value xsi:type="xsd:string">0</value>
-													</entry>
-													<entry>
-														<key>border-image-repeat</key>
-														<value xsi:type="xsd:string">stretch stretch</value>
-													</entry>
-													<entry>
-														<key>border-image-width</key>
-														<value xsi:type="xsd:string">1</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">14px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">17px</value>
-													</entry>
-													<entry>
 														<key>list-style-type</key>
 														<value xsi:type="xsd:string">circle</value>
-													</entry>
-													<entry>
-														<key>margin-bottom</key>
-														<value xsi:type="xsd:string">0px</value>
-													</entry>
-													<entry>
-														<key>margin-top</key>
-														<value xsi:type="xsd:string">0px</value>
 													</entry>
 													<entry>
 														<key>min-width</key>
 														<value xsi:type="xsd:string">100%</value>
 													</entry>
 													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>padding-left</key>
-														<value xsi:type="xsd:string">0px</value>
-													</entry>
-													<entry>
 														<key>position</key>
 														<value xsi:type="xsd:string">absolute</value>
 													</entry>
 													<entry>
-														<key>quotes</key>
-														<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-													</entry>
-													<entry>
 														<key>right</key>
 														<value xsi:type="xsd:string">-144px</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 													</entry>
 													<entry>
 														<key>top</key>
@@ -2528,10 +1074,6 @@
 													<entry>
 														<key>transition-property</key>
 														<value xsi:type="xsd:string">opacity</value>
-													</entry>
-													<entry>
-														<key>unicode-bidi</key>
-														<value xsi:type="xsd:string">isolate</value>
 													</entry>
 													<entry>
 														<key>z-index</key>
@@ -2556,76 +1098,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">17px</value>
-														</entry>
-														<entry>
 															<key>list-style-type</key>
 															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
 															<key>overflow</key>
@@ -2644,32 +1118,8 @@
 															<value xsi:type="xsd:string">relative</value>
 														</entry>
 														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
-														</entry>
-														<entry>
 															<key>transition-property</key>
 															<value xsi:type="xsd:string">height</value>
-														</entry>
-														<entry>
-															<key>unicode-bidi</key>
-															<value xsi:type="xsd:string">isolate</value>
 														</entry>
 													</attributes>
 												</attributes>
@@ -2691,20 +1141,8 @@
 													<attributes>
 														<attributes>
 															<entry>
-																<key>background-size</key>
-																<value xsi:type="xsd:string">auto auto</value>
-															</entry>
-															<entry>
 																<key>border-bottom-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>border-image-outset</key>
-																<value xsi:type="xsd:string">0</value>
-															</entry>
-															<entry>
-																<key>border-image-repeat</key>
-																<value xsi:type="xsd:string">stretch stretch</value>
 															</entry>
 															<entry>
 																<key>border-left-color</key>
@@ -2717,10 +1155,6 @@
 															<entry>
 																<key>border-top-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
 															</entry>
 															<entry>
 																<key>caret-color</key>
@@ -2739,20 +1173,12 @@
 																<value xsi:type="xsd:string">inline-block</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
 																<key>font-size</key>
 																<value xsi:type="xsd:string">13px</value>
 															</entry>
 															<entry>
 																<key>line-height</key>
 																<value xsi:type="xsd:string">32px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>outline-color</key>
@@ -2775,20 +1201,8 @@
 																<value xsi:type="xsd:string">6px</value>
 															</entry>
 															<entry>
-																<key>quotes</key>
-																<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
 																<key>text-decoration-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>text-decoration-line</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>transition-duration</key>
@@ -2827,76 +1241,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">17px</value>
-														</entry>
-														<entry>
 															<key>list-style-type</key>
 															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
 															<key>overflow</key>
@@ -2915,32 +1261,8 @@
 															<value xsi:type="xsd:string">relative</value>
 														</entry>
 														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
-														</entry>
-														<entry>
 															<key>transition-property</key>
 															<value xsi:type="xsd:string">height</value>
-														</entry>
-														<entry>
-															<key>unicode-bidi</key>
-															<value xsi:type="xsd:string">isolate</value>
 														</entry>
 													</attributes>
 												</attributes>
@@ -2962,20 +1284,8 @@
 													<attributes>
 														<attributes>
 															<entry>
-																<key>background-size</key>
-																<value xsi:type="xsd:string">auto auto</value>
-															</entry>
-															<entry>
 																<key>border-bottom-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>border-image-outset</key>
-																<value xsi:type="xsd:string">0</value>
-															</entry>
-															<entry>
-																<key>border-image-repeat</key>
-																<value xsi:type="xsd:string">stretch stretch</value>
 															</entry>
 															<entry>
 																<key>border-left-color</key>
@@ -2988,10 +1298,6 @@
 															<entry>
 																<key>border-top-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
 															</entry>
 															<entry>
 																<key>caret-color</key>
@@ -3010,20 +1316,12 @@
 																<value xsi:type="xsd:string">inline-block</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
 																<key>font-size</key>
 																<value xsi:type="xsd:string">13px</value>
 															</entry>
 															<entry>
 																<key>line-height</key>
 																<value xsi:type="xsd:string">32px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>outline-color</key>
@@ -3046,20 +1344,8 @@
 																<value xsi:type="xsd:string">6px</value>
 															</entry>
 															<entry>
-																<key>quotes</key>
-																<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
 																<key>text-decoration-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>text-decoration-line</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>transition-duration</key>
@@ -3098,76 +1384,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">17px</value>
-														</entry>
-														<entry>
 															<key>list-style-type</key>
 															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
 															<key>overflow</key>
@@ -3186,32 +1404,8 @@
 															<value xsi:type="xsd:string">relative</value>
 														</entry>
 														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
-														</entry>
-														<entry>
 															<key>transition-property</key>
 															<value xsi:type="xsd:string">height</value>
-														</entry>
-														<entry>
-															<key>unicode-bidi</key>
-															<value xsi:type="xsd:string">isolate</value>
 														</entry>
 													</attributes>
 												</attributes>
@@ -3233,20 +1427,8 @@
 													<attributes>
 														<attributes>
 															<entry>
-																<key>background-size</key>
-																<value xsi:type="xsd:string">auto auto</value>
-															</entry>
-															<entry>
 																<key>border-bottom-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>border-image-outset</key>
-																<value xsi:type="xsd:string">0</value>
-															</entry>
-															<entry>
-																<key>border-image-repeat</key>
-																<value xsi:type="xsd:string">stretch stretch</value>
 															</entry>
 															<entry>
 																<key>border-left-color</key>
@@ -3259,10 +1441,6 @@
 															<entry>
 																<key>border-top-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
 															</entry>
 															<entry>
 																<key>caret-color</key>
@@ -3281,20 +1459,12 @@
 																<value xsi:type="xsd:string">inline-block</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
 																<key>font-size</key>
 																<value xsi:type="xsd:string">13px</value>
 															</entry>
 															<entry>
 																<key>line-height</key>
 																<value xsi:type="xsd:string">32px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>outline-color</key>
@@ -3317,20 +1487,8 @@
 																<value xsi:type="xsd:string">6px</value>
 															</entry>
 															<entry>
-																<key>quotes</key>
-																<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
 																<key>text-decoration-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>text-decoration-line</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>transition-duration</key>
@@ -3369,76 +1527,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">17px</value>
-														</entry>
-														<entry>
 															<key>list-style-type</key>
 															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
 															<key>overflow</key>
@@ -3457,32 +1547,8 @@
 															<value xsi:type="xsd:string">relative</value>
 														</entry>
 														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
-														</entry>
-														<entry>
 															<key>transition-property</key>
 															<value xsi:type="xsd:string">height</value>
-														</entry>
-														<entry>
-															<key>unicode-bidi</key>
-															<value xsi:type="xsd:string">isolate</value>
 														</entry>
 													</attributes>
 												</attributes>
@@ -3504,20 +1570,8 @@
 													<attributes>
 														<attributes>
 															<entry>
-																<key>background-size</key>
-																<value xsi:type="xsd:string">auto auto</value>
-															</entry>
-															<entry>
 																<key>border-bottom-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>border-image-outset</key>
-																<value xsi:type="xsd:string">0</value>
-															</entry>
-															<entry>
-																<key>border-image-repeat</key>
-																<value xsi:type="xsd:string">stretch stretch</value>
 															</entry>
 															<entry>
 																<key>border-left-color</key>
@@ -3530,10 +1584,6 @@
 															<entry>
 																<key>border-top-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
 															</entry>
 															<entry>
 																<key>caret-color</key>
@@ -3552,20 +1602,12 @@
 																<value xsi:type="xsd:string">inline-block</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
 																<key>font-size</key>
 																<value xsi:type="xsd:string">13px</value>
 															</entry>
 															<entry>
 																<key>line-height</key>
 																<value xsi:type="xsd:string">32px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>outline-color</key>
@@ -3588,20 +1630,8 @@
 																<value xsi:type="xsd:string">6px</value>
 															</entry>
 															<entry>
-																<key>quotes</key>
-																<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
 																<key>text-decoration-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>text-decoration-line</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>transition-duration</key>
@@ -3642,96 +1672,16 @@
 										<attributes>
 											<attributes>
 												<entry>
-													<key>background-size</key>
-													<value xsi:type="xsd:string">auto auto</value>
-												</entry>
-												<entry>
-													<key>border-bottom-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-image-outset</key>
-													<value xsi:type="xsd:string">0</value>
-												</entry>
-												<entry>
-													<key>border-image-repeat</key>
-													<value xsi:type="xsd:string">stretch stretch</value>
-												</entry>
-												<entry>
-													<key>border-image-width</key>
-													<value xsi:type="xsd:string">1</value>
-												</entry>
-												<entry>
-													<key>border-left-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-right-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-top-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
-													<key>caret-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>column-rule-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>display</key>
 													<value xsi:type="xsd:string">inline-block</value>
-												</entry>
-												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">14px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">17px</value>
 												</entry>
 												<entry>
 													<key>list-style-type</key>
 													<value xsi:type="xsd:string">none</value>
 												</entry>
 												<entry>
-													<key>outline-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>position</key>
 													<value xsi:type="xsd:string">relative</value>
-												</entry>
-												<entry>
-													<key>quotes</key>
-													<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-												</entry>
-												<entry>
-													<key>text-align</key>
-													<value xsi:type="xsd:string">left</value>
-												</entry>
-												<entry>
-													<key>text-decoration-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>unicode-bidi</key>
-													<value xsi:type="xsd:string">isolate</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -3749,86 +1699,7 @@
 													<attribute key="type" xsi:type="stringAttribute">SPAN</attribute>
 												</attributes>
 											</identifyingAttributes>
-											<attributes>
-												<attributes>
-													<entry>
-														<key>background-size</key>
-														<value xsi:type="xsd:string">auto auto</value>
-													</entry>
-													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-image-outset</key>
-														<value xsi:type="xsd:string">0</value>
-													</entry>
-													<entry>
-														<key>border-image-repeat</key>
-														<value xsi:type="xsd:string">stretch stretch</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">14px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">17px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>quotes</key>
-														<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-												</attributes>
-											</attributes>
+											<attributes/>
 											<containedComponents retestId="for_developers">
 												<identifyingAttributes>
 													<attributes>
@@ -3847,20 +1718,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
 															<key>border-bottom-color</key>
 															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
 														</entry>
 														<entry>
 															<key>border-left-color</key>
@@ -3873,10 +1732,6 @@
 														<entry>
 															<key>border-top-color</key>
 															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
 														</entry>
 														<entry>
 															<key>caret-color</key>
@@ -3895,20 +1750,8 @@
 															<value xsi:type="xsd:string">inline-block</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
 															<key>line-height</key>
 															<value xsi:type="xsd:string">32px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
 														</entry>
 														<entry>
 															<key>outline-color</key>
@@ -3931,20 +1774,8 @@
 															<value xsi:type="xsd:string">8px</value>
 														</entry>
 														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
 															<key>text-decoration-color</key>
 															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>text-decoration-line</key>
-															<value xsi:type="xsd:string">none</value>
 														</entry>
 														<entry>
 															<key>transition-duration</key>
@@ -3987,14 +1818,6 @@
 														<value xsi:type="xsd:string">rgb(212, 218, 223)</value>
 													</entry>
 													<entry>
-														<key>background-size</key>
-														<value xsi:type="xsd:string">auto auto</value>
-													</entry>
-													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>border-bottom-left-radius</key>
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
@@ -4003,96 +1826,16 @@
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
 													<entry>
-														<key>border-image-outset</key>
-														<value xsi:type="xsd:string">0</value>
-													</entry>
-													<entry>
-														<key>border-image-repeat</key>
-														<value xsi:type="xsd:string">stretch stretch</value>
-													</entry>
-													<entry>
-														<key>border-image-width</key>
-														<value xsi:type="xsd:string">1</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">14px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">17px</value>
-													</entry>
-													<entry>
 														<key>list-style-type</key>
 														<value xsi:type="xsd:string">circle</value>
-													</entry>
-													<entry>
-														<key>margin-bottom</key>
-														<value xsi:type="xsd:string">0px</value>
-													</entry>
-													<entry>
-														<key>margin-top</key>
-														<value xsi:type="xsd:string">0px</value>
 													</entry>
 													<entry>
 														<key>min-width</key>
 														<value xsi:type="xsd:string">100%</value>
 													</entry>
 													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>padding-left</key>
-														<value xsi:type="xsd:string">0px</value>
-													</entry>
-													<entry>
 														<key>position</key>
 														<value xsi:type="xsd:string">absolute</value>
-													</entry>
-													<entry>
-														<key>quotes</key>
-														<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 													</entry>
 													<entry>
 														<key>top</key>
@@ -4109,10 +1852,6 @@
 													<entry>
 														<key>transition-property</key>
 														<value xsi:type="xsd:string">opacity</value>
-													</entry>
-													<entry>
-														<key>unicode-bidi</key>
-														<value xsi:type="xsd:string">isolate</value>
 													</entry>
 													<entry>
 														<key>z-index</key>
@@ -4137,76 +1876,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">17px</value>
-														</entry>
-														<entry>
 															<key>list-style-type</key>
 															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
 															<key>overflow</key>
@@ -4225,32 +1896,8 @@
 															<value xsi:type="xsd:string">relative</value>
 														</entry>
 														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
-														</entry>
-														<entry>
 															<key>transition-property</key>
 															<value xsi:type="xsd:string">height</value>
-														</entry>
-														<entry>
-															<key>unicode-bidi</key>
-															<value xsi:type="xsd:string">isolate</value>
 														</entry>
 													</attributes>
 												</attributes>
@@ -4272,20 +1919,8 @@
 													<attributes>
 														<attributes>
 															<entry>
-																<key>background-size</key>
-																<value xsi:type="xsd:string">auto auto</value>
-															</entry>
-															<entry>
 																<key>border-bottom-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>border-image-outset</key>
-																<value xsi:type="xsd:string">0</value>
-															</entry>
-															<entry>
-																<key>border-image-repeat</key>
-																<value xsi:type="xsd:string">stretch stretch</value>
 															</entry>
 															<entry>
 																<key>border-left-color</key>
@@ -4298,10 +1933,6 @@
 															<entry>
 																<key>border-top-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
 															</entry>
 															<entry>
 																<key>caret-color</key>
@@ -4320,20 +1951,12 @@
 																<value xsi:type="xsd:string">inline-block</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
 																<key>font-size</key>
 																<value xsi:type="xsd:string">13px</value>
 															</entry>
 															<entry>
 																<key>line-height</key>
 																<value xsi:type="xsd:string">32px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>outline-color</key>
@@ -4356,20 +1979,8 @@
 																<value xsi:type="xsd:string">6px</value>
 															</entry>
 															<entry>
-																<key>quotes</key>
-																<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
 																<key>text-decoration-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>text-decoration-line</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>transition-duration</key>
@@ -4408,76 +2019,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">17px</value>
-														</entry>
-														<entry>
 															<key>list-style-type</key>
 															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
 															<key>overflow</key>
@@ -4496,32 +2039,8 @@
 															<value xsi:type="xsd:string">relative</value>
 														</entry>
 														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
-														</entry>
-														<entry>
 															<key>transition-property</key>
 															<value xsi:type="xsd:string">height</value>
-														</entry>
-														<entry>
-															<key>unicode-bidi</key>
-															<value xsi:type="xsd:string">isolate</value>
 														</entry>
 													</attributes>
 												</attributes>
@@ -4543,20 +2062,8 @@
 													<attributes>
 														<attributes>
 															<entry>
-																<key>background-size</key>
-																<value xsi:type="xsd:string">auto auto</value>
-															</entry>
-															<entry>
 																<key>border-bottom-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>border-image-outset</key>
-																<value xsi:type="xsd:string">0</value>
-															</entry>
-															<entry>
-																<key>border-image-repeat</key>
-																<value xsi:type="xsd:string">stretch stretch</value>
 															</entry>
 															<entry>
 																<key>border-left-color</key>
@@ -4569,10 +2076,6 @@
 															<entry>
 																<key>border-top-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
 															</entry>
 															<entry>
 																<key>caret-color</key>
@@ -4591,20 +2094,12 @@
 																<value xsi:type="xsd:string">inline-block</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
 																<key>font-size</key>
 																<value xsi:type="xsd:string">13px</value>
 															</entry>
 															<entry>
 																<key>line-height</key>
 																<value xsi:type="xsd:string">32px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>outline-color</key>
@@ -4627,20 +2122,8 @@
 																<value xsi:type="xsd:string">6px</value>
 															</entry>
 															<entry>
-																<key>quotes</key>
-																<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
 																<key>text-decoration-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>text-decoration-line</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>transition-duration</key>
@@ -4679,76 +2162,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">17px</value>
-														</entry>
-														<entry>
 															<key>list-style-type</key>
 															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
 															<key>overflow</key>
@@ -4767,32 +2182,8 @@
 															<value xsi:type="xsd:string">relative</value>
 														</entry>
 														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
-														</entry>
-														<entry>
 															<key>transition-property</key>
 															<value xsi:type="xsd:string">height</value>
-														</entry>
-														<entry>
-															<key>unicode-bidi</key>
-															<value xsi:type="xsd:string">isolate</value>
 														</entry>
 													</attributes>
 												</attributes>
@@ -4814,20 +2205,8 @@
 													<attributes>
 														<attributes>
 															<entry>
-																<key>background-size</key>
-																<value xsi:type="xsd:string">auto auto</value>
-															</entry>
-															<entry>
 																<key>border-bottom-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>border-image-outset</key>
-																<value xsi:type="xsd:string">0</value>
-															</entry>
-															<entry>
-																<key>border-image-repeat</key>
-																<value xsi:type="xsd:string">stretch stretch</value>
 															</entry>
 															<entry>
 																<key>border-left-color</key>
@@ -4840,10 +2219,6 @@
 															<entry>
 																<key>border-top-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
 															</entry>
 															<entry>
 																<key>caret-color</key>
@@ -4862,20 +2237,12 @@
 																<value xsi:type="xsd:string">inline-block</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
 																<key>font-size</key>
 																<value xsi:type="xsd:string">13px</value>
 															</entry>
 															<entry>
 																<key>line-height</key>
 																<value xsi:type="xsd:string">32px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>outline-color</key>
@@ -4898,20 +2265,8 @@
 																<value xsi:type="xsd:string">6px</value>
 															</entry>
 															<entry>
-																<key>quotes</key>
-																<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
 																<key>text-decoration-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>text-decoration-line</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>transition-duration</key>
@@ -4952,96 +2307,16 @@
 										<attributes>
 											<attributes>
 												<entry>
-													<key>background-size</key>
-													<value xsi:type="xsd:string">auto auto</value>
-												</entry>
-												<entry>
-													<key>border-bottom-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-image-outset</key>
-													<value xsi:type="xsd:string">0</value>
-												</entry>
-												<entry>
-													<key>border-image-repeat</key>
-													<value xsi:type="xsd:string">stretch stretch</value>
-												</entry>
-												<entry>
-													<key>border-image-width</key>
-													<value xsi:type="xsd:string">1</value>
-												</entry>
-												<entry>
-													<key>border-left-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-right-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-top-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
-													<key>caret-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>column-rule-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>display</key>
 													<value xsi:type="xsd:string">inline-block</value>
-												</entry>
-												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">14px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">17px</value>
 												</entry>
 												<entry>
 													<key>list-style-type</key>
 													<value xsi:type="xsd:string">none</value>
 												</entry>
 												<entry>
-													<key>outline-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>position</key>
 													<value xsi:type="xsd:string">relative</value>
-												</entry>
-												<entry>
-													<key>quotes</key>
-													<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-												</entry>
-												<entry>
-													<key>text-align</key>
-													<value xsi:type="xsd:string">left</value>
-												</entry>
-												<entry>
-													<key>text-decoration-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>unicode-bidi</key>
-													<value xsi:type="xsd:string">isolate</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -5059,86 +2334,7 @@
 													<attribute key="type" xsi:type="stringAttribute">SPAN</attribute>
 												</attributes>
 											</identifyingAttributes>
-											<attributes>
-												<attributes>
-													<entry>
-														<key>background-size</key>
-														<value xsi:type="xsd:string">auto auto</value>
-													</entry>
-													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-image-outset</key>
-														<value xsi:type="xsd:string">0</value>
-													</entry>
-													<entry>
-														<key>border-image-repeat</key>
-														<value xsi:type="xsd:string">stretch stretch</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">14px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">17px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>quotes</key>
-														<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-												</attributes>
-											</attributes>
+											<attributes/>
 											<containedComponents retestId="for_managers">
 												<identifyingAttributes>
 													<attributes>
@@ -5157,20 +2353,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
 															<key>border-bottom-color</key>
 															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
 														</entry>
 														<entry>
 															<key>border-left-color</key>
@@ -5183,10 +2367,6 @@
 														<entry>
 															<key>border-top-color</key>
 															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
 														</entry>
 														<entry>
 															<key>caret-color</key>
@@ -5205,20 +2385,8 @@
 															<value xsi:type="xsd:string">inline-block</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
 															<key>line-height</key>
 															<value xsi:type="xsd:string">32px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
 														</entry>
 														<entry>
 															<key>outline-color</key>
@@ -5241,20 +2409,8 @@
 															<value xsi:type="xsd:string">8px</value>
 														</entry>
 														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
 															<key>text-decoration-color</key>
 															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>text-decoration-line</key>
-															<value xsi:type="xsd:string">none</value>
 														</entry>
 														<entry>
 															<key>transition-duration</key>
@@ -5297,14 +2453,6 @@
 														<value xsi:type="xsd:string">rgb(212, 218, 223)</value>
 													</entry>
 													<entry>
-														<key>background-size</key>
-														<value xsi:type="xsd:string">auto auto</value>
-													</entry>
-													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>border-bottom-left-radius</key>
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
@@ -5313,100 +2461,20 @@
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
 													<entry>
-														<key>border-image-outset</key>
-														<value xsi:type="xsd:string">0</value>
-													</entry>
-													<entry>
-														<key>border-image-repeat</key>
-														<value xsi:type="xsd:string">stretch stretch</value>
-													</entry>
-													<entry>
-														<key>border-image-width</key>
-														<value xsi:type="xsd:string">1</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">14px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">17px</value>
-													</entry>
-													<entry>
 														<key>list-style-type</key>
 														<value xsi:type="xsd:string">circle</value>
-													</entry>
-													<entry>
-														<key>margin-bottom</key>
-														<value xsi:type="xsd:string">0px</value>
-													</entry>
-													<entry>
-														<key>margin-top</key>
-														<value xsi:type="xsd:string">0px</value>
 													</entry>
 													<entry>
 														<key>min-width</key>
 														<value xsi:type="xsd:string">100%</value>
 													</entry>
 													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>padding-left</key>
-														<value xsi:type="xsd:string">0px</value>
-													</entry>
-													<entry>
 														<key>position</key>
 														<value xsi:type="xsd:string">absolute</value>
 													</entry>
 													<entry>
-														<key>quotes</key>
-														<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-													</entry>
-													<entry>
 														<key>right</key>
 														<value xsi:type="xsd:string">-84px</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 													</entry>
 													<entry>
 														<key>top</key>
@@ -5423,10 +2491,6 @@
 													<entry>
 														<key>transition-property</key>
 														<value xsi:type="xsd:string">opacity</value>
-													</entry>
-													<entry>
-														<key>unicode-bidi</key>
-														<value xsi:type="xsd:string">isolate</value>
 													</entry>
 													<entry>
 														<key>z-index</key>
@@ -5451,76 +2515,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">17px</value>
-														</entry>
-														<entry>
 															<key>list-style-type</key>
 															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
 															<key>overflow</key>
@@ -5539,32 +2535,8 @@
 															<value xsi:type="xsd:string">relative</value>
 														</entry>
 														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
-														</entry>
-														<entry>
 															<key>transition-property</key>
 															<value xsi:type="xsd:string">height</value>
-														</entry>
-														<entry>
-															<key>unicode-bidi</key>
-															<value xsi:type="xsd:string">isolate</value>
 														</entry>
 													</attributes>
 												</attributes>
@@ -5586,20 +2558,8 @@
 													<attributes>
 														<attributes>
 															<entry>
-																<key>background-size</key>
-																<value xsi:type="xsd:string">auto auto</value>
-															</entry>
-															<entry>
 																<key>border-bottom-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>border-image-outset</key>
-																<value xsi:type="xsd:string">0</value>
-															</entry>
-															<entry>
-																<key>border-image-repeat</key>
-																<value xsi:type="xsd:string">stretch stretch</value>
 															</entry>
 															<entry>
 																<key>border-left-color</key>
@@ -5612,10 +2572,6 @@
 															<entry>
 																<key>border-top-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
 															</entry>
 															<entry>
 																<key>caret-color</key>
@@ -5634,20 +2590,12 @@
 																<value xsi:type="xsd:string">inline-block</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
 																<key>font-size</key>
 																<value xsi:type="xsd:string">13px</value>
 															</entry>
 															<entry>
 																<key>line-height</key>
 																<value xsi:type="xsd:string">32px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>outline-color</key>
@@ -5670,20 +2618,8 @@
 																<value xsi:type="xsd:string">6px</value>
 															</entry>
 															<entry>
-																<key>quotes</key>
-																<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
 																<key>text-decoration-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>text-decoration-line</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>transition-duration</key>
@@ -5722,76 +2658,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">17px</value>
-														</entry>
-														<entry>
 															<key>list-style-type</key>
 															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
 															<key>overflow</key>
@@ -5810,32 +2678,8 @@
 															<value xsi:type="xsd:string">relative</value>
 														</entry>
 														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
-														</entry>
-														<entry>
 															<key>transition-property</key>
 															<value xsi:type="xsd:string">height</value>
-														</entry>
-														<entry>
-															<key>unicode-bidi</key>
-															<value xsi:type="xsd:string">isolate</value>
 														</entry>
 													</attributes>
 												</attributes>
@@ -5857,20 +2701,8 @@
 													<attributes>
 														<attributes>
 															<entry>
-																<key>background-size</key>
-																<value xsi:type="xsd:string">auto auto</value>
-															</entry>
-															<entry>
 																<key>border-bottom-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>border-image-outset</key>
-																<value xsi:type="xsd:string">0</value>
-															</entry>
-															<entry>
-																<key>border-image-repeat</key>
-																<value xsi:type="xsd:string">stretch stretch</value>
 															</entry>
 															<entry>
 																<key>border-left-color</key>
@@ -5883,10 +2715,6 @@
 															<entry>
 																<key>border-top-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
 															</entry>
 															<entry>
 																<key>caret-color</key>
@@ -5905,20 +2733,12 @@
 																<value xsi:type="xsd:string">inline-block</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
 																<key>font-size</key>
 																<value xsi:type="xsd:string">13px</value>
 															</entry>
 															<entry>
 																<key>line-height</key>
 																<value xsi:type="xsd:string">32px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>outline-color</key>
@@ -5941,20 +2761,8 @@
 																<value xsi:type="xsd:string">6px</value>
 															</entry>
 															<entry>
-																<key>quotes</key>
-																<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
 																<key>text-decoration-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>text-decoration-line</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>transition-duration</key>
@@ -5993,76 +2801,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">17px</value>
-														</entry>
-														<entry>
 															<key>list-style-type</key>
 															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
 															<key>overflow</key>
@@ -6081,32 +2821,8 @@
 															<value xsi:type="xsd:string">relative</value>
 														</entry>
 														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
-														</entry>
-														<entry>
 															<key>transition-property</key>
 															<value xsi:type="xsd:string">height</value>
-														</entry>
-														<entry>
-															<key>unicode-bidi</key>
-															<value xsi:type="xsd:string">isolate</value>
 														</entry>
 													</attributes>
 												</attributes>
@@ -6128,20 +2844,8 @@
 													<attributes>
 														<attributes>
 															<entry>
-																<key>background-size</key>
-																<value xsi:type="xsd:string">auto auto</value>
-															</entry>
-															<entry>
 																<key>border-bottom-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>border-image-outset</key>
-																<value xsi:type="xsd:string">0</value>
-															</entry>
-															<entry>
-																<key>border-image-repeat</key>
-																<value xsi:type="xsd:string">stretch stretch</value>
 															</entry>
 															<entry>
 																<key>border-left-color</key>
@@ -6154,10 +2858,6 @@
 															<entry>
 																<key>border-top-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
 															</entry>
 															<entry>
 																<key>caret-color</key>
@@ -6176,20 +2876,12 @@
 																<value xsi:type="xsd:string">inline-block</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
 																<key>font-size</key>
 																<value xsi:type="xsd:string">13px</value>
 															</entry>
 															<entry>
 																<key>line-height</key>
 																<value xsi:type="xsd:string">32px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>outline-color</key>
@@ -6212,20 +2904,8 @@
 																<value xsi:type="xsd:string">6px</value>
 															</entry>
 															<entry>
-																<key>quotes</key>
-																<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
 																<key>text-decoration-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>text-decoration-line</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>transition-duration</key>
@@ -6266,96 +2946,16 @@
 										<attributes>
 											<attributes>
 												<entry>
-													<key>background-size</key>
-													<value xsi:type="xsd:string">auto auto</value>
-												</entry>
-												<entry>
-													<key>border-bottom-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-image-outset</key>
-													<value xsi:type="xsd:string">0</value>
-												</entry>
-												<entry>
-													<key>border-image-repeat</key>
-													<value xsi:type="xsd:string">stretch stretch</value>
-												</entry>
-												<entry>
-													<key>border-image-width</key>
-													<value xsi:type="xsd:string">1</value>
-												</entry>
-												<entry>
-													<key>border-left-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-right-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-top-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
-													<key>caret-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>column-rule-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>display</key>
 													<value xsi:type="xsd:string">inline-block</value>
-												</entry>
-												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">14px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">17px</value>
 												</entry>
 												<entry>
 													<key>list-style-type</key>
 													<value xsi:type="xsd:string">none</value>
 												</entry>
 												<entry>
-													<key>outline-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>position</key>
 													<value xsi:type="xsd:string">relative</value>
-												</entry>
-												<entry>
-													<key>quotes</key>
-													<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-												</entry>
-												<entry>
-													<key>text-align</key>
-													<value xsi:type="xsd:string">left</value>
-												</entry>
-												<entry>
-													<key>text-decoration-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>unicode-bidi</key>
-													<value xsi:type="xsd:string">isolate</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -6373,86 +2973,7 @@
 													<attribute key="type" xsi:type="stringAttribute">SPAN</attribute>
 												</attributes>
 											</identifyingAttributes>
-											<attributes>
-												<attributes>
-													<entry>
-														<key>background-size</key>
-														<value xsi:type="xsd:string">auto auto</value>
-													</entry>
-													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-image-outset</key>
-														<value xsi:type="xsd:string">0</value>
-													</entry>
-													<entry>
-														<key>border-image-repeat</key>
-														<value xsi:type="xsd:string">stretch stretch</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">14px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">17px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>quotes</key>
-														<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-												</attributes>
-											</attributes>
+											<attributes/>
 											<containedComponents retestId="about">
 												<identifyingAttributes>
 													<attributes>
@@ -6471,20 +2992,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
 															<key>border-bottom-color</key>
 															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
 														</entry>
 														<entry>
 															<key>border-left-color</key>
@@ -6497,10 +3006,6 @@
 														<entry>
 															<key>border-top-color</key>
 															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
 														</entry>
 														<entry>
 															<key>caret-color</key>
@@ -6519,20 +3024,8 @@
 															<value xsi:type="xsd:string">inline-block</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
 															<key>line-height</key>
 															<value xsi:type="xsd:string">32px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
 														</entry>
 														<entry>
 															<key>outline-color</key>
@@ -6555,20 +3048,8 @@
 															<value xsi:type="xsd:string">8px</value>
 														</entry>
 														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
 															<key>text-decoration-color</key>
 															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>text-decoration-line</key>
-															<value xsi:type="xsd:string">none</value>
 														</entry>
 														<entry>
 															<key>transition-duration</key>
@@ -6611,14 +3092,6 @@
 														<value xsi:type="xsd:string">rgb(212, 218, 223)</value>
 													</entry>
 													<entry>
-														<key>background-size</key>
-														<value xsi:type="xsd:string">auto auto</value>
-													</entry>
-													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>border-bottom-left-radius</key>
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
@@ -6627,100 +3100,20 @@
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
 													<entry>
-														<key>border-image-outset</key>
-														<value xsi:type="xsd:string">0</value>
-													</entry>
-													<entry>
-														<key>border-image-repeat</key>
-														<value xsi:type="xsd:string">stretch stretch</value>
-													</entry>
-													<entry>
-														<key>border-image-width</key>
-														<value xsi:type="xsd:string">1</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">14px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">17px</value>
-													</entry>
-													<entry>
 														<key>list-style-type</key>
 														<value xsi:type="xsd:string">circle</value>
-													</entry>
-													<entry>
-														<key>margin-bottom</key>
-														<value xsi:type="xsd:string">0px</value>
-													</entry>
-													<entry>
-														<key>margin-top</key>
-														<value xsi:type="xsd:string">0px</value>
 													</entry>
 													<entry>
 														<key>min-width</key>
 														<value xsi:type="xsd:string">100%</value>
 													</entry>
 													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>padding-left</key>
-														<value xsi:type="xsd:string">0px</value>
-													</entry>
-													<entry>
 														<key>position</key>
 														<value xsi:type="xsd:string">absolute</value>
 													</entry>
 													<entry>
-														<key>quotes</key>
-														<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-													</entry>
-													<entry>
 														<key>right</key>
 														<value xsi:type="xsd:string">-58px</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 													</entry>
 													<entry>
 														<key>top</key>
@@ -6737,10 +3130,6 @@
 													<entry>
 														<key>transition-property</key>
 														<value xsi:type="xsd:string">opacity</value>
-													</entry>
-													<entry>
-														<key>unicode-bidi</key>
-														<value xsi:type="xsd:string">isolate</value>
 													</entry>
 													<entry>
 														<key>z-index</key>
@@ -6765,76 +3154,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">17px</value>
-														</entry>
-														<entry>
 															<key>list-style-type</key>
 															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
 															<key>overflow</key>
@@ -6853,32 +3174,8 @@
 															<value xsi:type="xsd:string">relative</value>
 														</entry>
 														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
-														</entry>
-														<entry>
 															<key>transition-property</key>
 															<value xsi:type="xsd:string">height</value>
-														</entry>
-														<entry>
-															<key>unicode-bidi</key>
-															<value xsi:type="xsd:string">isolate</value>
 														</entry>
 													</attributes>
 												</attributes>
@@ -6900,20 +3197,8 @@
 													<attributes>
 														<attributes>
 															<entry>
-																<key>background-size</key>
-																<value xsi:type="xsd:string">auto auto</value>
-															</entry>
-															<entry>
 																<key>border-bottom-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>border-image-outset</key>
-																<value xsi:type="xsd:string">0</value>
-															</entry>
-															<entry>
-																<key>border-image-repeat</key>
-																<value xsi:type="xsd:string">stretch stretch</value>
 															</entry>
 															<entry>
 																<key>border-left-color</key>
@@ -6926,10 +3211,6 @@
 															<entry>
 																<key>border-top-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
 															</entry>
 															<entry>
 																<key>caret-color</key>
@@ -6948,20 +3229,12 @@
 																<value xsi:type="xsd:string">inline-block</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
 																<key>font-size</key>
 																<value xsi:type="xsd:string">13px</value>
 															</entry>
 															<entry>
 																<key>line-height</key>
 																<value xsi:type="xsd:string">32px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>outline-color</key>
@@ -6984,20 +3257,8 @@
 																<value xsi:type="xsd:string">6px</value>
 															</entry>
 															<entry>
-																<key>quotes</key>
-																<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
 																<key>text-decoration-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>text-decoration-line</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>transition-duration</key>
@@ -7036,76 +3297,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">17px</value>
-														</entry>
-														<entry>
 															<key>list-style-type</key>
 															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
 															<key>overflow</key>
@@ -7124,32 +3317,8 @@
 															<value xsi:type="xsd:string">relative</value>
 														</entry>
 														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
-														</entry>
-														<entry>
 															<key>transition-property</key>
 															<value xsi:type="xsd:string">height</value>
-														</entry>
-														<entry>
-															<key>unicode-bidi</key>
-															<value xsi:type="xsd:string">isolate</value>
 														</entry>
 													</attributes>
 												</attributes>
@@ -7171,20 +3340,8 @@
 													<attributes>
 														<attributes>
 															<entry>
-																<key>background-size</key>
-																<value xsi:type="xsd:string">auto auto</value>
-															</entry>
-															<entry>
 																<key>border-bottom-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>border-image-outset</key>
-																<value xsi:type="xsd:string">0</value>
-															</entry>
-															<entry>
-																<key>border-image-repeat</key>
-																<value xsi:type="xsd:string">stretch stretch</value>
 															</entry>
 															<entry>
 																<key>border-left-color</key>
@@ -7197,10 +3354,6 @@
 															<entry>
 																<key>border-top-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
 															</entry>
 															<entry>
 																<key>caret-color</key>
@@ -7219,20 +3372,12 @@
 																<value xsi:type="xsd:string">inline-block</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
 																<key>font-size</key>
 																<value xsi:type="xsd:string">13px</value>
 															</entry>
 															<entry>
 																<key>line-height</key>
 																<value xsi:type="xsd:string">32px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>outline-color</key>
@@ -7255,20 +3400,8 @@
 																<value xsi:type="xsd:string">6px</value>
 															</entry>
 															<entry>
-																<key>quotes</key>
-																<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
 																<key>text-decoration-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>text-decoration-line</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>transition-duration</key>
@@ -7307,76 +3440,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">17px</value>
-														</entry>
-														<entry>
 															<key>list-style-type</key>
 															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
 															<key>overflow</key>
@@ -7395,32 +3460,8 @@
 															<value xsi:type="xsd:string">relative</value>
 														</entry>
 														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
-														</entry>
-														<entry>
 															<key>transition-property</key>
 															<value xsi:type="xsd:string">height</value>
-														</entry>
-														<entry>
-															<key>unicode-bidi</key>
-															<value xsi:type="xsd:string">isolate</value>
 														</entry>
 													</attributes>
 												</attributes>
@@ -7442,20 +3483,8 @@
 													<attributes>
 														<attributes>
 															<entry>
-																<key>background-size</key>
-																<value xsi:type="xsd:string">auto auto</value>
-															</entry>
-															<entry>
 																<key>border-bottom-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>border-image-outset</key>
-																<value xsi:type="xsd:string">0</value>
-															</entry>
-															<entry>
-																<key>border-image-repeat</key>
-																<value xsi:type="xsd:string">stretch stretch</value>
 															</entry>
 															<entry>
 																<key>border-left-color</key>
@@ -7468,10 +3497,6 @@
 															<entry>
 																<key>border-top-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
 															</entry>
 															<entry>
 																<key>caret-color</key>
@@ -7490,20 +3515,12 @@
 																<value xsi:type="xsd:string">inline-block</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
 																<key>font-size</key>
 																<value xsi:type="xsd:string">13px</value>
 															</entry>
 															<entry>
 																<key>line-height</key>
 																<value xsi:type="xsd:string">32px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>outline-color</key>
@@ -7526,20 +3543,8 @@
 																<value xsi:type="xsd:string">6px</value>
 															</entry>
 															<entry>
-																<key>quotes</key>
-																<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
 																<key>text-decoration-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>text-decoration-line</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>transition-duration</key>
@@ -7568,7 +3573,7 @@
 											<attributes>
 												<attribute key="class" xsi:type="stringAttribute">dropdown lang</attribute>
 												<attribute key="outline" xsi:type="outlineAttribute">
-													<x>1113</x>
+													<x>1118</x>
 													<y>36</y>
 													<height>48</height>
 													<width>35</width>
@@ -7581,96 +3586,16 @@
 										<attributes>
 											<attributes>
 												<entry>
-													<key>background-size</key>
-													<value xsi:type="xsd:string">auto auto</value>
-												</entry>
-												<entry>
-													<key>border-bottom-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-image-outset</key>
-													<value xsi:type="xsd:string">0</value>
-												</entry>
-												<entry>
-													<key>border-image-repeat</key>
-													<value xsi:type="xsd:string">stretch stretch</value>
-												</entry>
-												<entry>
-													<key>border-image-width</key>
-													<value xsi:type="xsd:string">1</value>
-												</entry>
-												<entry>
-													<key>border-left-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-right-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-top-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
-													<key>caret-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>column-rule-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>display</key>
 													<value xsi:type="xsd:string">inline-block</value>
-												</entry>
-												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">14px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">17px</value>
 												</entry>
 												<entry>
 													<key>list-style-type</key>
 													<value xsi:type="xsd:string">none</value>
 												</entry>
 												<entry>
-													<key>outline-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>position</key>
 													<value xsi:type="xsd:string">relative</value>
-												</entry>
-												<entry>
-													<key>quotes</key>
-													<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-												</entry>
-												<entry>
-													<key>text-align</key>
-													<value xsi:type="xsd:string">left</value>
-												</entry>
-												<entry>
-													<key>text-decoration-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>unicode-bidi</key>
-													<value xsi:type="xsd:string">isolate</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -7692,20 +3617,8 @@
 											<attributes>
 												<attributes>
 													<entry>
-														<key>background-size</key>
-														<value xsi:type="xsd:string">auto auto</value>
-													</entry>
-													<entry>
 														<key>border-bottom-color</key>
 														<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-													</entry>
-													<entry>
-														<key>border-image-outset</key>
-														<value xsi:type="xsd:string">0</value>
-													</entry>
-													<entry>
-														<key>border-image-repeat</key>
-														<value xsi:type="xsd:string">stretch stretch</value>
 													</entry>
 													<entry>
 														<key>border-left-color</key>
@@ -7720,10 +3633,6 @@
 														<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 													</entry>
 													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
 														<key>caret-color</key>
 														<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 													</entry>
@@ -7736,24 +3645,8 @@
 														<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 													</entry>
 													<entry>
-														<key>display</key>
-														<value xsi:type="xsd:string">inline-block</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">14px</value>
-													</entry>
-													<entry>
 														<key>line-height</key>
 														<value xsi:type="xsd:string">32px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
 													</entry>
 													<entry>
 														<key>outline-color</key>
@@ -7776,20 +3669,8 @@
 														<value xsi:type="xsd:string">8px</value>
 													</entry>
 													<entry>
-														<key>quotes</key>
-														<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
 														<key>text-decoration-color</key>
 														<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-													</entry>
-													<entry>
-														<key>text-decoration-line</key>
-														<value xsi:type="xsd:string">none</value>
 													</entry>
 													<entry>
 														<key>transition-duration</key>
@@ -7823,92 +3704,12 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
 															<key>display</key>
 															<value xsi:type="xsd:string">inline</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">32px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>margin-right</key>
 															<value xsi:type="xsd:string">5px</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 														</entry>
 													</attributes>
 												</attributes>
@@ -7928,86 +3729,7 @@
 														<attribute key="type" xsi:type="stringAttribute">SPAN</attribute>
 													</attributes>
 												</identifyingAttributes>
-												<attributes>
-													<attributes>
-														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">32px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-													</attributes>
-												</attributes>
+												<attributes/>
 											</containedComponents>
 										</containedComponents>
 										<containedComponents retestId="ul">
@@ -8037,10 +3759,6 @@
 														<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
 													</entry>
 													<entry>
-														<key>background-size</key>
-														<value xsi:type="xsd:string">auto auto</value>
-													</entry>
-													<entry>
 														<key>border-bottom-color</key>
 														<value xsi:type="xsd:string">rgba(0, 0, 0, 0.15)</value>
 													</entry>
@@ -8059,18 +3777,6 @@
 													<entry>
 														<key>border-bottom-width</key>
 														<value xsi:type="xsd:string">1px</value>
-													</entry>
-													<entry>
-														<key>border-image-outset</key>
-														<value xsi:type="xsd:string">0</value>
-													</entry>
-													<entry>
-														<key>border-image-repeat</key>
-														<value xsi:type="xsd:string">stretch stretch</value>
-													</entry>
-													<entry>
-														<key>border-image-width</key>
-														<value xsi:type="xsd:string">1</value>
 													</entry>
 													<entry>
 														<key>border-left-color</key>
@@ -8117,40 +3823,12 @@
 														<value xsi:type="xsd:string">rgba(0, 0, 0, 0.176) 0px 6px 12px 0px</value>
 													</entry>
 													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-													</entry>
-													<entry>
 														<key>left</key>
 														<value xsi:type="xsd:string">-125px</value>
 													</entry>
 													<entry>
 														<key>line-height</key>
 														<value xsi:type="xsd:string">19px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
-														<key>margin-bottom</key>
-														<value xsi:type="xsd:string">0px</value>
 													</entry>
 													<entry>
 														<key>margin-top</key>
@@ -8161,16 +3839,8 @@
 														<value xsi:type="xsd:string">160px</value>
 													</entry>
 													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>padding-bottom</key>
 														<value xsi:type="xsd:string">5px</value>
-													</entry>
-													<entry>
-														<key>padding-left</key>
-														<value xsi:type="xsd:string">0px</value>
 													</entry>
 													<entry>
 														<key>padding-top</key>
@@ -8179,18 +3849,6 @@
 													<entry>
 														<key>position</key>
 														<value xsi:type="xsd:string">absolute</value>
-													</entry>
-													<entry>
-														<key>quotes</key>
-														<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 													</entry>
 													<entry>
 														<key>top</key>
@@ -8207,10 +3865,6 @@
 													<entry>
 														<key>transition-property</key>
 														<value xsi:type="xsd:string">opacity</value>
-													</entry>
-													<entry>
-														<key>unicode-bidi</key>
-														<value xsi:type="xsd:string">isolate</value>
 													</entry>
 													<entry>
 														<key>z-index</key>
@@ -8235,24 +3889,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
 															<key>border-bottom-color</key>
 															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
 														</entry>
 														<entry>
 															<key>border-left-color</key>
@@ -8264,42 +3902,6 @@
 														</entry>
 														<entry>
 															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">19px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
@@ -8319,32 +3921,8 @@
 															<value xsi:type="xsd:string">relative</value>
 														</entry>
 														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
-														</entry>
-														<entry>
 															<key>transition-property</key>
 															<value xsi:type="xsd:string">height</value>
-														</entry>
-														<entry>
-															<key>unicode-bidi</key>
-															<value xsi:type="xsd:string">isolate</value>
 														</entry>
 													</attributes>
 												</attributes>
@@ -8365,20 +3943,8 @@
 													<attributes>
 														<attributes>
 															<entry>
-																<key>background-size</key>
-																<value xsi:type="xsd:string">auto auto</value>
-															</entry>
-															<entry>
 																<key>border-bottom-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>border-image-outset</key>
-																<value xsi:type="xsd:string">0</value>
-															</entry>
-															<entry>
-																<key>border-image-repeat</key>
-																<value xsi:type="xsd:string">stretch stretch</value>
 															</entry>
 															<entry>
 																<key>border-left-color</key>
@@ -8391,10 +3957,6 @@
 															<entry>
 																<key>border-top-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
 															</entry>
 															<entry>
 																<key>caret-color</key>
@@ -8413,20 +3975,12 @@
 																<value xsi:type="xsd:string">inline-block</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
 																<key>font-size</key>
 																<value xsi:type="xsd:string">15px</value>
 															</entry>
 															<entry>
 																<key>line-height</key>
 																<value xsi:type="xsd:string">32px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>outline-color</key>
@@ -8449,20 +4003,8 @@
 																<value xsi:type="xsd:string">5px</value>
 															</entry>
 															<entry>
-																<key>quotes</key>
-																<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
 																<key>text-decoration-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>text-decoration-line</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>transition-duration</key>
@@ -8500,40 +4042,12 @@
 														<attributes>
 															<attributes>
 																<entry>
-																	<key>background-size</key>
-																	<value xsi:type="xsd:string">auto auto</value>
-																</entry>
-																<entry>
-																	<key>border-bottom-color</key>
-																	<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-																</entry>
-																<entry>
 																	<key>border-bottom-left-radius</key>
 																	<value xsi:type="xsd:string">3px</value>
 																</entry>
 																<entry>
 																	<key>border-bottom-right-radius</key>
 																	<value xsi:type="xsd:string">3px</value>
-																</entry>
-																<entry>
-																	<key>border-image-outset</key>
-																	<value xsi:type="xsd:string">0</value>
-																</entry>
-																<entry>
-																	<key>border-image-repeat</key>
-																	<value xsi:type="xsd:string">stretch stretch</value>
-																</entry>
-																<entry>
-																	<key>border-left-color</key>
-																	<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-																</entry>
-																<entry>
-																	<key>border-right-color</key>
-																	<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-																</entry>
-																<entry>
-																	<key>border-top-color</key>
-																	<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 																</entry>
 																<entry>
 																	<key>border-top-left-radius</key>
@@ -8544,64 +4058,12 @@
 																	<value xsi:type="xsd:string">3px</value>
 																</entry>
 																<entry>
-																	<key>box-sizing</key>
-																	<value xsi:type="xsd:string">border-box</value>
-																</entry>
-																<entry>
-																	<key>caret-color</key>
-																	<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-																</entry>
-																<entry>
-																	<key>color</key>
-																	<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-																</entry>
-																<entry>
-																	<key>column-rule-color</key>
-																	<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-																</entry>
-																<entry>
-																	<key>font-family</key>
-																	<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-																</entry>
-																<entry>
-																	<key>font-size</key>
-																	<value xsi:type="xsd:string">15px</value>
-																</entry>
-																<entry>
-																	<key>line-height</key>
-																	<value xsi:type="xsd:string">32px</value>
-																</entry>
-																<entry>
-																	<key>list-style-type</key>
-																	<value xsi:type="xsd:string">none</value>
-																</entry>
-																<entry>
 																	<key>margin-right</key>
 																	<value xsi:type="xsd:string">8px</value>
 																</entry>
 																<entry>
 																	<key>max-width</key>
 																	<value xsi:type="xsd:string">100%</value>
-																</entry>
-																<entry>
-																	<key>outline-color</key>
-																	<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-																</entry>
-																<entry>
-																	<key>quotes</key>
-																	<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-																</entry>
-																<entry>
-																	<key>text-align</key>
-																	<value xsi:type="xsd:string">left</value>
-																</entry>
-																<entry>
-																	<key>text-decoration-color</key>
-																	<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-																</entry>
-																<entry>
-																	<key>white-space</key>
-																	<value xsi:type="xsd:string">nowrap</value>
 																</entry>
 															</attributes>
 														</attributes>
@@ -8630,32 +4092,8 @@
 															<value xsi:type="xsd:string">rgb(249, 249, 249)</value>
 														</entry>
 														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
 															<key>border-bottom-color</key>
 															<value xsi:type="xsd:string">rgb(229, 229, 229)</value>
-														</entry>
-														<entry>
-															<key>border-bottom-style</key>
-															<value xsi:type="xsd:string">solid</value>
-														</entry>
-														<entry>
-															<key>border-bottom-width</key>
-															<value xsi:type="xsd:string">1px</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
 														</entry>
 														<entry>
 															<key>border-left-color</key>
@@ -8674,10 +4112,6 @@
 															<value xsi:type="xsd:string">rgba(0, 0, 0, 0.03) 0px -2px 1px 0px inset</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(63, 60, 57)</value>
 														</entry>
@@ -8694,28 +4128,12 @@
 															<value xsi:type="xsd:string">rgb(63, 60, 57)</value>
 														</entry>
 														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
 															<key>font-size</key>
 															<value xsi:type="xsd:string">15px</value>
 														</entry>
 														<entry>
 															<key>line-height</key>
 															<value xsi:type="xsd:string">18px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>margin-top</key>
-															<value xsi:type="xsd:string">-5px</value>
 														</entry>
 														<entry>
 															<key>outline-color</key>
@@ -8754,32 +4172,12 @@
 															<value xsi:type="xsd:string">relative</value>
 														</entry>
 														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
 															<key>text-decoration-color</key>
 															<value xsi:type="xsd:string">rgb(63, 60, 57)</value>
 														</entry>
 														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
-														</entry>
-														<entry>
 															<key>transition-property</key>
 															<value xsi:type="xsd:string">height</value>
-														</entry>
-														<entry>
-															<key>unicode-bidi</key>
-															<value xsi:type="xsd:string">isolate</value>
 														</entry>
 														<entry>
 															<key>white-space</key>
@@ -8805,10 +4203,6 @@
 													<attributes>
 														<attributes>
 															<entry>
-																<key>background-size</key>
-																<value xsi:type="xsd:string">auto auto</value>
-															</entry>
-															<entry>
 																<key>border-bottom-color</key>
 																<value xsi:type="xsd:string">rgb(63, 60, 57)</value>
 															</entry>
@@ -8821,26 +4215,6 @@
 																<value xsi:type="xsd:string">3px</value>
 															</entry>
 															<entry>
-																<key>border-image-outset</key>
-																<value xsi:type="xsd:string">0</value>
-															</entry>
-															<entry>
-																<key>border-image-repeat</key>
-																<value xsi:type="xsd:string">stretch stretch</value>
-															</entry>
-															<entry>
-																<key>border-left-color</key>
-																<value xsi:type="xsd:string">rgb(63, 60, 57)</value>
-															</entry>
-															<entry>
-																<key>border-right-color</key>
-																<value xsi:type="xsd:string">rgb(63, 60, 57)</value>
-															</entry>
-															<entry>
-																<key>border-top-color</key>
-																<value xsi:type="xsd:string">rgb(63, 60, 57)</value>
-															</entry>
-															<entry>
 																<key>border-top-left-radius</key>
 																<value xsi:type="xsd:string">3px</value>
 															</entry>
@@ -8849,64 +4223,12 @@
 																<value xsi:type="xsd:string">3px</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
-																<key>caret-color</key>
-																<value xsi:type="xsd:string">rgb(63, 60, 57)</value>
-															</entry>
-															<entry>
-																<key>color</key>
-																<value xsi:type="xsd:string">rgb(63, 60, 57)</value>
-															</entry>
-															<entry>
-																<key>column-rule-color</key>
-																<value xsi:type="xsd:string">rgb(63, 60, 57)</value>
-															</entry>
-															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
-																<key>font-size</key>
-																<value xsi:type="xsd:string">15px</value>
-															</entry>
-															<entry>
-																<key>line-height</key>
-																<value xsi:type="xsd:string">18px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
-															</entry>
-															<entry>
 																<key>margin-right</key>
 																<value xsi:type="xsd:string">8px</value>
 															</entry>
 															<entry>
 																<key>max-width</key>
 																<value xsi:type="xsd:string">100%</value>
-															</entry>
-															<entry>
-																<key>outline-color</key>
-																<value xsi:type="xsd:string">rgb(63, 60, 57)</value>
-															</entry>
-															<entry>
-																<key>quotes</key>
-																<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
-																<key>text-decoration-color</key>
-																<value xsi:type="xsd:string">rgb(63, 60, 57)</value>
-															</entry>
-															<entry>
-																<key>white-space</key>
-																<value xsi:type="xsd:string">nowrap</value>
 															</entry>
 														</attributes>
 													</attributes>
@@ -8933,78 +4255,7 @@
 							<attribute key="type" xsi:type="stringAttribute">SCRIPT</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">15px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="consolelogretest">
 					<identifyingAttributes>
@@ -9023,78 +4274,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">SCRIPT</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">15px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="script">
 					<identifyingAttributes>
@@ -9110,78 +4290,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">SCRIPT</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">15px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="windowjquery">
 					<identifyingAttributes>
@@ -9198,78 +4307,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">SCRIPT</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">15px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="script">
 					<identifyingAttributes>
@@ -9285,78 +4323,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">SCRIPT</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">15px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="script">
 					<identifyingAttributes>
@@ -9372,78 +4339,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">SCRIPT</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">15px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="script">
 					<identifyingAttributes>
@@ -9459,78 +4355,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">SCRIPT</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">15px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="script">
 					<identifyingAttributes>
@@ -9546,78 +4371,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">SCRIPT</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">15px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="script">
 					<identifyingAttributes>
@@ -9633,78 +4387,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">SCRIPT</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">15px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="script">
 					<identifyingAttributes>
@@ -9720,78 +4403,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">SCRIPT</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">15px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="script">
 					<identifyingAttributes>
@@ -9807,78 +4419,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">SCRIPT</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">15px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="section">
 					<identifyingAttributes>
@@ -9901,82 +4442,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<key>background-color</key>
 								<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
 							</entry>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">15px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>unicode-bidi</key>
-								<value xsi:type="xsd:string">isolate</value>
-							</entry>
 						</attributes>
 					</attributes>
 					<containedComponents retestId="div">
@@ -9998,96 +4463,24 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 						<attributes>
 							<attributes>
 								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-bottom-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>border-left-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-right-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-top-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
 									<key>bottom</key>
 									<value xsi:type="xsd:string">588px</value>
-								</entry>
-								<entry>
-									<key>box-sizing</key>
-									<value xsi:type="xsd:string">border-box</value>
-								</entry>
-								<entry>
-									<key>caret-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>column-rule-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-								</entry>
-								<entry>
-									<key>font-size</key>
-									<value xsi:type="xsd:string">15px</value>
 								</entry>
 								<entry>
 									<key>left</key>
 									<value xsi:type="xsd:string">1046px</value>
 								</entry>
 								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">30px</value>
-								</entry>
-								<entry>
-									<key>outline-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
 									<key>position</key>
 									<value xsi:type="xsd:string">fixed</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
 								</entry>
 								<entry>
 									<key>right</key>
 									<value xsi:type="xsd:string">10px</value>
 								</entry>
 								<entry>
-									<key>text-decoration-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
 									<key>top</key>
 									<value xsi:type="xsd:string">106px</value>
-								</entry>
-								<entry>
-									<key>unicode-bidi</key>
-									<value xsi:type="xsd:string">isolate</value>
 								</entry>
 								<entry>
 									<key>z-index</key>
@@ -10111,82 +4504,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<attribute key="type" xsi:type="stringAttribute">DIV</attribute>
 							</attributes>
 						</identifyingAttributes>
-						<attributes>
-							<attributes>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-bottom-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>border-left-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-right-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-top-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>box-sizing</key>
-									<value xsi:type="xsd:string">border-box</value>
-								</entry>
-								<entry>
-									<key>caret-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>column-rule-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-								</entry>
-								<entry>
-									<key>font-size</key>
-									<value xsi:type="xsd:string">15px</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">30px</value>
-								</entry>
-								<entry>
-									<key>outline-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
-									<key>text-decoration-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>unicode-bidi</key>
-									<value xsi:type="xsd:string">isolate</value>
-								</entry>
-							</attributes>
-						</attributes>
+						<attributes/>
 						<containedComponents retestId="ul">
 							<identifyingAttributes>
 								<attributes>
@@ -10205,80 +4523,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attributes>
 								<attributes>
 									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
-										<key>border-bottom-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>border-left-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>border-right-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>border-top-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>box-sizing</key>
-										<value xsi:type="xsd:string">border-box</value>
-									</entry>
-									<entry>
-										<key>caret-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>column-rule-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">15px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">30px</value>
-									</entry>
-									<entry>
 										<key>list-style-type</key>
 										<value xsi:type="xsd:string">none</value>
-									</entry>
-									<entry>
-										<key>margin-bottom</key>
-										<value xsi:type="xsd:string">0px</value>
-									</entry>
-									<entry>
-										<key>margin-top</key>
-										<value xsi:type="xsd:string">0px</value>
-									</entry>
-									<entry>
-										<key>outline-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 									</entry>
 									<entry>
 										<key>overflow</key>
@@ -10293,24 +4539,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 										<value xsi:type="xsd:string">hidden</value>
 									</entry>
 									<entry>
-										<key>padding-left</key>
-										<value xsi:type="xsd:string">0px</value>
-									</entry>
-									<entry>
 										<key>position</key>
 										<value xsi:type="xsd:string">relative</value>
-									</entry>
-									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
-										<key>text-decoration-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>unicode-bidi</key>
-										<value xsi:type="xsd:string">isolate</value>
 									</entry>
 								</attributes>
 							</attributes>
@@ -10331,88 +4561,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<attributes>
 									<attributes>
 										<entry>
-											<key>background-size</key>
-											<value xsi:type="xsd:string">auto auto</value>
-										</entry>
-										<entry>
-											<key>border-bottom-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-image-outset</key>
-											<value xsi:type="xsd:string">0</value>
-										</entry>
-										<entry>
-											<key>border-image-repeat</key>
-											<value xsi:type="xsd:string">stretch stretch</value>
-										</entry>
-										<entry>
-											<key>border-image-width</key>
-											<value xsi:type="xsd:string">1</value>
-										</entry>
-										<entry>
-											<key>border-left-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-right-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-top-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>box-sizing</key>
-											<value xsi:type="xsd:string">border-box</value>
-										</entry>
-										<entry>
-											<key>caret-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>column-rule-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>font-family</key>
-											<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-										</entry>
-										<entry>
-											<key>font-size</key>
-											<value xsi:type="xsd:string">15px</value>
-										</entry>
-										<entry>
-											<key>line-height</key>
-											<value xsi:type="xsd:string">30px</value>
-										</entry>
-										<entry>
-											<key>list-style-type</key>
-											<value xsi:type="xsd:string">none</value>
-										</entry>
-										<entry>
-											<key>outline-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>quotes</key>
-											<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-										</entry>
-										<entry>
 											<key>text-align</key>
 											<value xsi:type="xsd:string">left</value>
-										</entry>
-										<entry>
-											<key>text-decoration-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>unicode-bidi</key>
-											<value xsi:type="xsd:string">isolate</value>
 										</entry>
 									</attributes>
 								</attributes>
@@ -10434,10 +4584,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 									<attributes>
 										<attributes>
 											<entry>
-												<key>background-size</key>
-												<value xsi:type="xsd:string">auto auto</value>
-											</entry>
-											<entry>
 												<key>border-bottom-color</key>
 												<value xsi:type="xsd:string">rgb(175, 175, 175)</value>
 											</entry>
@@ -10448,58 +4594,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 											<entry>
 												<key>border-bottom-width</key>
 												<value xsi:type="xsd:string">1px</value>
-											</entry>
-											<entry>
-												<key>border-image-outset</key>
-												<value xsi:type="xsd:string">0</value>
-											</entry>
-											<entry>
-												<key>border-image-repeat</key>
-												<value xsi:type="xsd:string">stretch stretch</value>
-											</entry>
-											<entry>
-												<key>border-left-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-right-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-top-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
-											</entry>
-											<entry>
-												<key>caret-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>column-rule-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>font-family</key>
-												<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-											</entry>
-											<entry>
-												<key>font-size</key>
-												<value xsi:type="xsd:string">15px</value>
-											</entry>
-											<entry>
-												<key>line-height</key>
-												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
-												<key>list-style-type</key>
-												<value xsi:type="xsd:string">none</value>
 											</entry>
 											<entry>
 												<key>margin-left</key>
@@ -10514,28 +4608,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<value xsi:type="xsd:string">1020px</value>
 											</entry>
 											<entry>
-												<key>outline-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
 												<key>padding-bottom</key>
 												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
-												<key>quotes</key>
-												<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-											</entry>
-											<entry>
-												<key>text-align</key>
-												<value xsi:type="xsd:string">left</value>
-											</entry>
-											<entry>
-												<key>text-decoration-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>unicode-bidi</key>
-												<value xsi:type="xsd:string">isolate</value>
 											</entry>
 										</attributes>
 									</attributes>
@@ -10557,20 +4631,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 										<attributes>
 											<attributes>
 												<entry>
-													<key>background-size</key>
-													<value xsi:type="xsd:string">auto auto</value>
-												</entry>
-												<entry>
 													<key>border-bottom-color</key>
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-												</entry>
-												<entry>
-													<key>border-image-outset</key>
-													<value xsi:type="xsd:string">0</value>
-												</entry>
-												<entry>
-													<key>border-image-repeat</key>
-													<value xsi:type="xsd:string">stretch stretch</value>
 												</entry>
 												<entry>
 													<key>border-left-color</key>
@@ -10585,10 +4647,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 												</entry>
 												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
 													<key>caret-color</key>
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 												</entry>
@@ -10599,22 +4657,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<entry>
 													<key>column-rule-color</key>
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-												</entry>
-												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">15px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">30px</value>
-												</entry>
-												<entry>
-													<key>list-style-type</key>
-													<value xsi:type="xsd:string">none</value>
 												</entry>
 												<entry>
 													<key>margin-bottom</key>
@@ -10637,20 +4679,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 												</entry>
 												<entry>
-													<key>quotes</key>
-													<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-												</entry>
-												<entry>
 													<key>text-align</key>
 													<value xsi:type="xsd:string">center</value>
 												</entry>
 												<entry>
 													<key>text-decoration-color</key>
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-												</entry>
-												<entry>
-													<key>unicode-bidi</key>
-													<value xsi:type="xsd:string">isolate</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -10672,20 +4706,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 											<attributes>
 												<attributes>
 													<entry>
-														<key>background-size</key>
-														<value xsi:type="xsd:string">auto auto</value>
-													</entry>
-													<entry>
 														<key>border-bottom-color</key>
 														<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-													</entry>
-													<entry>
-														<key>border-image-outset</key>
-														<value xsi:type="xsd:string">0</value>
-													</entry>
-													<entry>
-														<key>border-image-repeat</key>
-														<value xsi:type="xsd:string">stretch stretch</value>
 													</entry>
 													<entry>
 														<key>border-left-color</key>
@@ -10698,10 +4720,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<entry>
 														<key>border-top-color</key>
 														<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
 													</entry>
 													<entry>
 														<key>caret-color</key>
@@ -10724,16 +4742,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">40px</value>
 													</entry>
 													<entry>
-														<key>font-weight</key>
-														<value xsi:type="xsd:string">400</value>
-													</entry>
-													<entry>
 														<key>line-height</key>
 														<value xsi:type="xsd:string">48px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
 													</entry>
 													<entry>
 														<key>margin-bottom</key>
@@ -10748,24 +4758,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 													</entry>
 													<entry>
-														<key>quotes</key>
-														<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">center</value>
-													</entry>
-													<entry>
 														<key>text-decoration-color</key>
 														<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 													</entry>
-													<entry>
-														<key>unicode-bidi</key>
-														<value xsi:type="xsd:string">isolate</value>
-													</entry>
 												</attributes>
 											</attributes>
-											<containedComponents retestId="2f34d004-e9fe-41b0-97dc-d48031aec9ee">
+											<containedComponents retestId="347656f0-b124-4151-9fe3-8b6a0e3983e3">
 												<identifyingAttributes>
 													<attributes>
 														<attribute key="outline" xsi:type="outlineAttribute">
@@ -10783,20 +4781,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<attributes>
 													<attributes>
 														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
 															<key>border-bottom-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
 														</entry>
 														<entry>
 															<key>border-left-color</key>
@@ -10811,10 +4797,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
@@ -10827,32 +4809,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">&quot;Gill Sans MT&quot;, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">40px</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">48px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">center</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -10879,20 +4837,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<attributes>
 													<attributes>
 														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
 															<key>border-bottom-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
 														</entry>
 														<entry>
 															<key>border-left-color</key>
@@ -10907,10 +4853,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
@@ -10923,32 +4865,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">&quot;Gill Sans MT&quot;, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">40px</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">48px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">center</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -10975,20 +4893,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<attributes>
 													<attributes>
 														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
 															<key>border-bottom-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
 														</entry>
 														<entry>
 															<key>border-left-color</key>
@@ -11003,10 +4909,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
@@ -11019,32 +4921,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">&quot;Gill Sans MT&quot;, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">40px</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">48px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">center</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -11071,20 +4949,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<attributes>
 													<attributes>
 														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
 															<key>border-bottom-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
 														</entry>
 														<entry>
 															<key>border-left-color</key>
@@ -11099,10 +4965,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
@@ -11115,32 +4977,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">&quot;Gill Sans MT&quot;, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">40px</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">48px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">center</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -11149,7 +4987,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													</attributes>
 												</attributes>
 											</containedComponents>
-											<containedComponents retestId="a52217bf-38f1-4e74-ae1c-0f64f73d1079">
+											<containedComponents retestId="fa87f7ee-2a05-4da5-8955-8dd9f6b944b0">
 												<identifyingAttributes>
 													<attributes>
 														<attribute key="outline" xsi:type="outlineAttribute">
@@ -11167,20 +5005,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<attributes>
 													<attributes>
 														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
 															<key>border-bottom-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
 														</entry>
 														<entry>
 															<key>border-left-color</key>
@@ -11195,10 +5021,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
@@ -11211,32 +5033,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">&quot;Gill Sans MT&quot;, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">40px</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">48px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">center</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -11265,47 +5063,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 										<attributes>
 											<attributes>
 												<entry>
-													<key>background-size</key>
-													<value xsi:type="xsd:string">auto auto</value>
-												</entry>
-												<entry>
 													<key>border-bottom-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-image-outset</key>
-													<value xsi:type="xsd:string">0</value>
-												</entry>
-												<entry>
-													<key>border-image-repeat</key>
-													<value xsi:type="xsd:string">stretch stretch</value>
-												</entry>
-												<entry>
-													<key>border-left-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-right-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-top-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
-													<key>caret-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>column-rule-color</key>
 													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 												<entry>
@@ -11313,28 +5071,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<value xsi:type="xsd:string">right</value>
 												</entry>
 												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">15px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">30px</value>
-												</entry>
-												<entry>
-													<key>list-style-type</key>
-													<value xsi:type="xsd:string">none</value>
-												</entry>
-												<entry>
 													<key>min-height</key>
 													<value xsi:type="xsd:string">1px</value>
-												</entry>
-												<entry>
-													<key>outline-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 												<entry>
 													<key>padding-left</key>
@@ -11347,22 +5085,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<entry>
 													<key>position</key>
 													<value xsi:type="xsd:string">relative</value>
-												</entry>
-												<entry>
-													<key>quotes</key>
-													<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-												</entry>
-												<entry>
-													<key>text-align</key>
-													<value xsi:type="xsd:string">left</value>
-												</entry>
-												<entry>
-													<key>text-decoration-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>unicode-bidi</key>
-													<value xsi:type="xsd:string">isolate</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -11380,86 +5102,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 												</attributes>
 											</identifyingAttributes>
-											<attributes>
-												<attributes>
-													<entry>
-														<key>background-size</key>
-														<value xsi:type="xsd:string">auto auto</value>
-													</entry>
-													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-image-outset</key>
-														<value xsi:type="xsd:string">0</value>
-													</entry>
-													<entry>
-														<key>border-image-repeat</key>
-														<value xsi:type="xsd:string">stretch stretch</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>quotes</key>
-														<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-												</attributes>
-											</attributes>
+											<attributes/>
 										</containedComponents>
 										<containedComponents retestId="br">
 											<identifyingAttributes>
@@ -11475,86 +5118,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 												</attributes>
 											</identifyingAttributes>
-											<attributes>
-												<attributes>
-													<entry>
-														<key>background-size</key>
-														<value xsi:type="xsd:string">auto auto</value>
-													</entry>
-													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-image-outset</key>
-														<value xsi:type="xsd:string">0</value>
-													</entry>
-													<entry>
-														<key>border-image-repeat</key>
-														<value xsi:type="xsd:string">stretch stretch</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>quotes</key>
-														<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-												</attributes>
-											</attributes>
+											<attributes/>
 										</containedComponents>
 										<containedComponents retestId="br">
 											<identifyingAttributes>
@@ -11570,86 +5134,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 												</attributes>
 											</identifyingAttributes>
-											<attributes>
-												<attributes>
-													<entry>
-														<key>background-size</key>
-														<value xsi:type="xsd:string">auto auto</value>
-													</entry>
-													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-image-outset</key>
-														<value xsi:type="xsd:string">0</value>
-													</entry>
-													<entry>
-														<key>border-image-repeat</key>
-														<value xsi:type="xsd:string">stretch stretch</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>quotes</key>
-														<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-												</attributes>
-											</attributes>
+											<attributes/>
 										</containedComponents>
 										<containedComponents retestId="iframe">
 											<identifyingAttributes>
@@ -11669,88 +5154,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 											<attributes>
 												<attributes>
 													<entry>
-														<key>background-size</key>
-														<value xsi:type="xsd:string">auto auto</value>
-													</entry>
-													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-image-outset</key>
-														<value xsi:type="xsd:string">0</value>
-													</entry>
-													<entry>
-														<key>border-image-repeat</key>
-														<value xsi:type="xsd:string">stretch stretch</value>
-													</entry>
-													<entry>
-														<key>border-image-width</key>
-														<value xsi:type="xsd:string">1</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>display</key>
 														<value xsi:type="xsd:string">inline</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>quotes</key>
-														<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 													</entry>
 												</attributes>
 											</attributes>
@@ -11774,20 +5179,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 										<attributes>
 											<attributes>
 												<entry>
-													<key>background-size</key>
-													<value xsi:type="xsd:string">auto auto</value>
-												</entry>
-												<entry>
 													<key>border-bottom-color</key>
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-												</entry>
-												<entry>
-													<key>border-image-outset</key>
-													<value xsi:type="xsd:string">0</value>
-												</entry>
-												<entry>
-													<key>border-image-repeat</key>
-													<value xsi:type="xsd:string">stretch stretch</value>
 												</entry>
 												<entry>
 													<key>border-left-color</key>
@@ -11800,10 +5193,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<entry>
 													<key>border-top-color</key>
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-												</entry>
-												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
 												</entry>
 												<entry>
 													<key>caret-color</key>
@@ -11820,22 +5209,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<entry>
 													<key>float</key>
 													<value xsi:type="xsd:string">right</value>
-												</entry>
-												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">15px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">30px</value>
-												</entry>
-												<entry>
-													<key>list-style-type</key>
-													<value xsi:type="xsd:string">none</value>
 												</entry>
 												<entry>
 													<key>margin-bottom</key>
@@ -11862,20 +5235,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<value xsi:type="xsd:string">relative</value>
 												</entry>
 												<entry>
-													<key>quotes</key>
-													<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-												</entry>
-												<entry>
 													<key>text-align</key>
 													<value xsi:type="xsd:string">right</value>
 												</entry>
 												<entry>
 													<key>text-decoration-color</key>
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-												</entry>
-												<entry>
-													<key>unicode-bidi</key>
-													<value xsi:type="xsd:string">isolate</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -11896,64 +5261,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 											<attributes>
 												<attributes>
 													<entry>
-														<key>background-size</key>
-														<value xsi:type="xsd:string">auto auto</value>
-													</entry>
-													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-													</entry>
-													<entry>
-														<key>border-image-outset</key>
-														<value xsi:type="xsd:string">0</value>
-													</entry>
-													<entry>
-														<key>border-image-repeat</key>
-														<value xsi:type="xsd:string">stretch stretch</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
 														<key>font-size</key>
 														<value xsi:type="xsd:string">17px</value>
 													</entry>
 													<entry>
 														<key>line-height</key>
 														<value xsi:type="xsd:string">36px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
 													</entry>
 													<entry>
 														<key>margin-bottom</key>
@@ -11971,26 +5284,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<key>margin-top</key>
 														<value xsi:type="xsd:string">12px</value>
 													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-													</entry>
-													<entry>
-														<key>quotes</key>
-														<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">right</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-													</entry>
-													<entry>
-														<key>unicode-bidi</key>
-														<value xsi:type="xsd:string">isolate</value>
-													</entry>
 												</attributes>
 											</attributes>
 											<containedComponents retestId="br">
@@ -12007,86 +5300,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 													</attributes>
 												</identifyingAttributes>
-												<attributes>
-													<attributes>
-														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">17px</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">36px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">right</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-													</attributes>
-												</attributes>
+												<attributes/>
 											</containedComponents>
 											<containedComponents retestId="br">
 												<identifyingAttributes>
@@ -12102,86 +5316,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 													</attributes>
 												</identifyingAttributes>
-												<attributes>
-													<attributes>
-														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">17px</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">36px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">right</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-													</attributes>
-												</attributes>
+												<attributes/>
 											</containedComponents>
 											<containedComponents retestId="have_you_had">
 												<identifyingAttributes>
@@ -12201,20 +5336,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<attributes>
 													<attributes>
 														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
 															<key>border-bottom-color</key>
 															<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
 														</entry>
 														<entry>
 															<key>border-left-color</key>
@@ -12229,10 +5352,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 														</entry>
@@ -12245,36 +5364,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">17px</value>
-														</entry>
-														<entry>
-															<key>font-style</key>
-															<value xsi:type="xsd:string">normal</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">36px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-														</entry>
-														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">right</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -12296,86 +5387,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 														</attributes>
 													</identifyingAttributes>
-													<attributes>
-														<attributes>
-															<entry>
-																<key>background-size</key>
-																<value xsi:type="xsd:string">auto auto</value>
-															</entry>
-															<entry>
-																<key>border-bottom-color</key>
-																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-															</entry>
-															<entry>
-																<key>border-image-outset</key>
-																<value xsi:type="xsd:string">0</value>
-															</entry>
-															<entry>
-																<key>border-image-repeat</key>
-																<value xsi:type="xsd:string">stretch stretch</value>
-															</entry>
-															<entry>
-																<key>border-left-color</key>
-																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-															</entry>
-															<entry>
-																<key>border-right-color</key>
-																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-															</entry>
-															<entry>
-																<key>border-top-color</key>
-																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-															</entry>
-															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
-																<key>caret-color</key>
-																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-															</entry>
-															<entry>
-																<key>color</key>
-																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-															</entry>
-															<entry>
-																<key>column-rule-color</key>
-																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-															</entry>
-															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-															</entry>
-															<entry>
-																<key>font-size</key>
-																<value xsi:type="xsd:string">17px</value>
-															</entry>
-															<entry>
-																<key>line-height</key>
-																<value xsi:type="xsd:string">36px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
-															</entry>
-															<entry>
-																<key>outline-color</key>
-																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-															</entry>
-															<entry>
-																<key>quotes</key>
-																<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">right</value>
-															</entry>
-															<entry>
-																<key>text-decoration-color</key>
-																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-															</entry>
-														</attributes>
-													</attributes>
+													<attributes/>
 												</containedComponents>
 											</containedComponents>
 											<containedComponents retestId="use_an_artifici">
@@ -12396,20 +5408,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<attributes>
 													<attributes>
 														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
 															<key>border-bottom-color</key>
 															<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
 														</entry>
 														<entry>
 															<key>border-left-color</key>
@@ -12424,10 +5424,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 														</entry>
@@ -12440,36 +5436,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">17px</value>
-														</entry>
-														<entry>
-															<key>font-style</key>
-															<value xsi:type="xsd:string">normal</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">36px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-														</entry>
-														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">right</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -12496,20 +5464,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<attributes>
 													<attributes>
 														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
 															<key>border-bottom-color</key>
 															<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
 														</entry>
 														<entry>
 															<key>border-left-color</key>
@@ -12524,10 +5480,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 														</entry>
@@ -12540,36 +5492,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">17px</value>
-														</entry>
-														<entry>
-															<key>font-style</key>
-															<value xsi:type="xsd:string">normal</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">36px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-														</entry>
-														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">right</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -12578,7 +5502,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													</attributes>
 												</attributes>
 											</containedComponents>
-											<containedComponents retestId="660df334-c33a-4de6-9243-daa9249ebd4e">
+											<containedComponents retestId="36773dc6-cf5c-4e2e-9e1f-d6733a3c2861">
 												<identifyingAttributes>
 													<attributes>
 														<attribute key="outline" xsi:type="outlineAttribute">
@@ -12596,20 +5520,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<attributes>
 													<attributes>
 														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
 															<key>border-bottom-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
 														</entry>
 														<entry>
 															<key>border-left-color</key>
@@ -12624,10 +5536,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
@@ -12640,32 +5548,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">17px</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">36px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">right</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -12692,20 +5576,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<attributes>
 													<attributes>
 														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
 															<key>border-bottom-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
 														</entry>
 														<entry>
 															<key>border-left-color</key>
@@ -12720,10 +5592,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
@@ -12736,32 +5604,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">17px</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">36px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">right</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -12791,88 +5635,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<attributes>
 									<attributes>
 										<entry>
-											<key>background-size</key>
-											<value xsi:type="xsd:string">auto auto</value>
-										</entry>
-										<entry>
-											<key>border-bottom-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-image-outset</key>
-											<value xsi:type="xsd:string">0</value>
-										</entry>
-										<entry>
-											<key>border-image-repeat</key>
-											<value xsi:type="xsd:string">stretch stretch</value>
-										</entry>
-										<entry>
-											<key>border-image-width</key>
-											<value xsi:type="xsd:string">1</value>
-										</entry>
-										<entry>
-											<key>border-left-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-right-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-top-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>box-sizing</key>
-											<value xsi:type="xsd:string">border-box</value>
-										</entry>
-										<entry>
-											<key>caret-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>column-rule-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>font-family</key>
-											<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-										</entry>
-										<entry>
-											<key>font-size</key>
-											<value xsi:type="xsd:string">15px</value>
-										</entry>
-										<entry>
-											<key>line-height</key>
-											<value xsi:type="xsd:string">30px</value>
-										</entry>
-										<entry>
-											<key>list-style-type</key>
-											<value xsi:type="xsd:string">none</value>
-										</entry>
-										<entry>
-											<key>outline-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>quotes</key>
-											<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-										</entry>
-										<entry>
 											<key>text-align</key>
 											<value xsi:type="xsd:string">left</value>
-										</entry>
-										<entry>
-											<key>text-decoration-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>unicode-bidi</key>
-											<value xsi:type="xsd:string">isolate</value>
 										</entry>
 									</attributes>
 								</attributes>
@@ -12894,10 +5658,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 									<attributes>
 										<attributes>
 											<entry>
-												<key>background-size</key>
-												<value xsi:type="xsd:string">auto auto</value>
-											</entry>
-											<entry>
 												<key>border-bottom-color</key>
 												<value xsi:type="xsd:string">rgb(175, 175, 175)</value>
 											</entry>
@@ -12908,58 +5668,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 											<entry>
 												<key>border-bottom-width</key>
 												<value xsi:type="xsd:string">1px</value>
-											</entry>
-											<entry>
-												<key>border-image-outset</key>
-												<value xsi:type="xsd:string">0</value>
-											</entry>
-											<entry>
-												<key>border-image-repeat</key>
-												<value xsi:type="xsd:string">stretch stretch</value>
-											</entry>
-											<entry>
-												<key>border-left-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-right-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-top-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
-											</entry>
-											<entry>
-												<key>caret-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>column-rule-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>font-family</key>
-												<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-											</entry>
-											<entry>
-												<key>font-size</key>
-												<value xsi:type="xsd:string">15px</value>
-											</entry>
-											<entry>
-												<key>line-height</key>
-												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
-												<key>list-style-type</key>
-												<value xsi:type="xsd:string">none</value>
 											</entry>
 											<entry>
 												<key>margin-left</key>
@@ -12974,28 +5682,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<value xsi:type="xsd:string">1020px</value>
 											</entry>
 											<entry>
-												<key>outline-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
 												<key>padding-bottom</key>
 												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
-												<key>quotes</key>
-												<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-											</entry>
-											<entry>
-												<key>text-align</key>
-												<value xsi:type="xsd:string">left</value>
-											</entry>
-											<entry>
-												<key>text-decoration-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>unicode-bidi</key>
-												<value xsi:type="xsd:string">isolate</value>
 											</entry>
 										</attributes>
 									</attributes>
@@ -13017,20 +5705,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 										<attributes>
 											<attributes>
 												<entry>
-													<key>background-size</key>
-													<value xsi:type="xsd:string">auto auto</value>
-												</entry>
-												<entry>
 													<key>border-bottom-color</key>
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-												</entry>
-												<entry>
-													<key>border-image-outset</key>
-													<value xsi:type="xsd:string">0</value>
-												</entry>
-												<entry>
-													<key>border-image-repeat</key>
-													<value xsi:type="xsd:string">stretch stretch</value>
 												</entry>
 												<entry>
 													<key>border-left-color</key>
@@ -13045,10 +5721,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 												</entry>
 												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
 													<key>caret-color</key>
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 												</entry>
@@ -13059,22 +5731,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<entry>
 													<key>column-rule-color</key>
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-												</entry>
-												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">15px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">30px</value>
-												</entry>
-												<entry>
-													<key>list-style-type</key>
-													<value xsi:type="xsd:string">none</value>
 												</entry>
 												<entry>
 													<key>margin-bottom</key>
@@ -13097,20 +5753,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 												</entry>
 												<entry>
-													<key>quotes</key>
-													<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-												</entry>
-												<entry>
 													<key>text-align</key>
 													<value xsi:type="xsd:string">center</value>
 												</entry>
 												<entry>
 													<key>text-decoration-color</key>
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-												</entry>
-												<entry>
-													<key>unicode-bidi</key>
-													<value xsi:type="xsd:string">isolate</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -13131,24 +5779,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 											<attributes>
 												<attributes>
 													<entry>
-														<key>background-size</key>
-														<value xsi:type="xsd:string">auto auto</value>
-													</entry>
-													<entry>
 														<key>border-bottom-color</key>
 														<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-													</entry>
-													<entry>
-														<key>border-image-outset</key>
-														<value xsi:type="xsd:string">0</value>
-													</entry>
-													<entry>
-														<key>border-image-repeat</key>
-														<value xsi:type="xsd:string">stretch stretch</value>
-													</entry>
-													<entry>
-														<key>border-image-width</key>
-														<value xsi:type="xsd:string">1</value>
 													</entry>
 													<entry>
 														<key>border-left-color</key>
@@ -13161,10 +5793,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<entry>
 														<key>border-top-color</key>
 														<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
 													</entry>
 													<entry>
 														<key>caret-color</key>
@@ -13195,10 +5823,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">42px</value>
 													</entry>
 													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
 														<key>margin-bottom</key>
 														<value xsi:type="xsd:string">6px</value>
 													</entry>
@@ -13211,20 +5835,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
 													</entry>
 													<entry>
-														<key>quotes</key>
-														<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">center</value>
-													</entry>
-													<entry>
 														<key>text-decoration-color</key>
 														<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-													</entry>
-													<entry>
-														<key>unicode-bidi</key>
-														<value xsi:type="xsd:string">isolate</value>
 													</entry>
 												</attributes>
 											</attributes>
@@ -13246,40 +5858,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<attributes>
 													<attributes>
 														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
 															<key>border-bottom-left-radius</key>
 															<value xsi:type="xsd:string">3px</value>
 														</entry>
 														<entry>
 															<key>border-bottom-right-radius</key>
 															<value xsi:type="xsd:string">3px</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
 														</entry>
 														<entry>
 															<key>border-top-left-radius</key>
@@ -13290,64 +5874,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">3px</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">30px</value>
-														</entry>
-														<entry>
-															<key>font-weight</key>
-															<value xsi:type="xsd:string">700</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">42px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>margin-right</key>
 															<value xsi:type="xsd:string">-30px</value>
 														</entry>
 														<entry>
 															<key>max-width</key>
 															<value xsi:type="xsd:string">100%</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">center</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
 														</entry>
 														<entry>
 															<key>vertical-align</key>
@@ -13374,20 +5906,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<attributes>
 													<attributes>
 														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
 															<key>border-bottom-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
 														</entry>
 														<entry>
 															<key>border-left-color</key>
@@ -13402,10 +5922,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
@@ -13418,36 +5934,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">30px</value>
-														</entry>
-														<entry>
-															<key>font-weight</key>
-															<value xsi:type="xsd:string">700</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">42px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">center</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -13456,7 +5944,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													</attributes>
 												</attributes>
 											</containedComponents>
-											<containedComponents retestId="f3ae2da0-994e-4e4d-bb43-8d3c27a096a9">
+											<containedComponents retestId="a601b968-5fc2-4cad-979f-09b7c9f946f2">
 												<identifyingAttributes>
 													<attributes>
 														<attribute key="outline" xsi:type="outlineAttribute">
@@ -13474,20 +5962,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<attributes>
 													<attributes>
 														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
 															<key>border-bottom-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
 														</entry>
 														<entry>
 															<key>border-left-color</key>
@@ -13502,10 +5978,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
@@ -13518,36 +5990,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">30px</value>
-														</entry>
-														<entry>
-															<key>font-weight</key>
-															<value xsi:type="xsd:string">700</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">42px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">center</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -13576,47 +6020,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 										<attributes>
 											<attributes>
 												<entry>
-													<key>background-size</key>
-													<value xsi:type="xsd:string">auto auto</value>
-												</entry>
-												<entry>
 													<key>border-bottom-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-image-outset</key>
-													<value xsi:type="xsd:string">0</value>
-												</entry>
-												<entry>
-													<key>border-image-repeat</key>
-													<value xsi:type="xsd:string">stretch stretch</value>
-												</entry>
-												<entry>
-													<key>border-left-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-right-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-top-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
-													<key>caret-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>column-rule-color</key>
 													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 												<entry>
@@ -13624,28 +6028,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<value xsi:type="xsd:string">left</value>
 												</entry>
 												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">15px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">30px</value>
-												</entry>
-												<entry>
-													<key>list-style-type</key>
-													<value xsi:type="xsd:string">none</value>
-												</entry>
-												<entry>
 													<key>min-height</key>
 													<value xsi:type="xsd:string">1px</value>
-												</entry>
-												<entry>
-													<key>outline-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 												<entry>
 													<key>padding-left</key>
@@ -13658,22 +6042,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<entry>
 													<key>position</key>
 													<value xsi:type="xsd:string">relative</value>
-												</entry>
-												<entry>
-													<key>quotes</key>
-													<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-												</entry>
-												<entry>
-													<key>text-align</key>
-													<value xsi:type="xsd:string">left</value>
-												</entry>
-												<entry>
-													<key>text-decoration-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>unicode-bidi</key>
-													<value xsi:type="xsd:string">isolate</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -13694,40 +6062,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 											<attributes>
 												<attributes>
 													<entry>
-														<key>background-size</key>
-														<value xsi:type="xsd:string">auto auto</value>
-													</entry>
-													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>border-bottom-left-radius</key>
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
 													<entry>
 														<key>border-bottom-right-radius</key>
 														<value xsi:type="xsd:string">3px</value>
-													</entry>
-													<entry>
-														<key>border-image-outset</key>
-														<value xsi:type="xsd:string">0</value>
-													</entry>
-													<entry>
-														<key>border-image-repeat</key>
-														<value xsi:type="xsd:string">stretch stretch</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 													</entry>
 													<entry>
 														<key>border-top-left-radius</key>
@@ -13738,64 +6078,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
 													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>display</key>
-														<value xsi:type="xsd:string">block</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
 														<key>max-height</key>
 														<value xsi:type="xsd:string">430px</value>
 													</entry>
 													<entry>
 														<key>max-width</key>
 														<value xsi:type="xsd:string">100%</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>quotes</key>
-														<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 													</entry>
 													<entry>
 														<key>vertical-align</key>
@@ -13823,47 +6111,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 										<attributes>
 											<attributes>
 												<entry>
-													<key>background-size</key>
-													<value xsi:type="xsd:string">auto auto</value>
-												</entry>
-												<entry>
 													<key>border-bottom-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-image-outset</key>
-													<value xsi:type="xsd:string">0</value>
-												</entry>
-												<entry>
-													<key>border-image-repeat</key>
-													<value xsi:type="xsd:string">stretch stretch</value>
-												</entry>
-												<entry>
-													<key>border-left-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-right-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-top-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
-													<key>caret-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>column-rule-color</key>
 													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 												<entry>
@@ -13871,28 +6119,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<value xsi:type="xsd:string">right</value>
 												</entry>
 												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">15px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">30px</value>
-												</entry>
-												<entry>
-													<key>list-style-type</key>
-													<value xsi:type="xsd:string">none</value>
-												</entry>
-												<entry>
 													<key>min-height</key>
 													<value xsi:type="xsd:string">1px</value>
-												</entry>
-												<entry>
-													<key>outline-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 												<entry>
 													<key>padding-left</key>
@@ -13905,22 +6133,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<entry>
 													<key>position</key>
 													<value xsi:type="xsd:string">relative</value>
-												</entry>
-												<entry>
-													<key>quotes</key>
-													<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-												</entry>
-												<entry>
-													<key>text-align</key>
-													<value xsi:type="xsd:string">left</value>
-												</entry>
-												<entry>
-													<key>text-decoration-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>unicode-bidi</key>
-													<value xsi:type="xsd:string">isolate</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -13942,20 +6154,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 											<attributes>
 												<attributes>
 													<entry>
-														<key>background-size</key>
-														<value xsi:type="xsd:string">auto auto</value>
-													</entry>
-													<entry>
 														<key>border-bottom-color</key>
 														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-													</entry>
-													<entry>
-														<key>border-image-outset</key>
-														<value xsi:type="xsd:string">0</value>
-													</entry>
-													<entry>
-														<key>border-image-repeat</key>
-														<value xsi:type="xsd:string">stretch stretch</value>
 													</entry>
 													<entry>
 														<key>border-left-color</key>
@@ -13970,10 +6170,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 													</entry>
 													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
 														<key>caret-color</key>
 														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 													</entry>
@@ -13986,40 +6182,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 													</entry>
 													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
 														<key>outline-color</key>
 														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 													</entry>
 													<entry>
-														<key>quotes</key>
-														<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
 														<key>text-decoration-color</key>
 														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-													</entry>
-													<entry>
-														<key>unicode-bidi</key>
-														<value xsi:type="xsd:string">isolate</value>
 													</entry>
 												</attributes>
 											</attributes>
@@ -14040,68 +6208,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<attributes>
 													<attributes>
 														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-														</entry>
-														<entry>
 															<key>font-size</key>
 															<value xsi:type="xsd:string">17px</value>
 														</entry>
 														<entry>
 															<key>line-height</key>
 															<value xsi:type="xsd:string">36px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>margin-bottom</key>
-															<value xsi:type="xsd:string">0px</value>
 														</entry>
 														<entry>
 															<key>margin-left</key>
@@ -14114,26 +6226,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<entry>
 															<key>margin-top</key>
 															<value xsi:type="xsd:string">12px</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>unicode-bidi</key>
-															<value xsi:type="xsd:string">isolate</value>
 														</entry>
 													</attributes>
 												</attributes>
@@ -14151,86 +6243,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 														</attributes>
 													</identifyingAttributes>
-													<attributes>
-														<attributes>
-															<entry>
-																<key>background-size</key>
-																<value xsi:type="xsd:string">auto auto</value>
-															</entry>
-															<entry>
-																<key>border-bottom-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>border-image-outset</key>
-																<value xsi:type="xsd:string">0</value>
-															</entry>
-															<entry>
-																<key>border-image-repeat</key>
-																<value xsi:type="xsd:string">stretch stretch</value>
-															</entry>
-															<entry>
-																<key>border-left-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>border-right-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>border-top-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
-																<key>caret-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>column-rule-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-															</entry>
-															<entry>
-																<key>font-size</key>
-																<value xsi:type="xsd:string">17px</value>
-															</entry>
-															<entry>
-																<key>line-height</key>
-																<value xsi:type="xsd:string">36px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
-															</entry>
-															<entry>
-																<key>outline-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>quotes</key>
-																<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
-																<key>text-decoration-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-														</attributes>
-													</attributes>
+													<attributes/>
 												</containedComponents>
 												<containedComponents retestId="no_need_to_crea">
 													<identifyingAttributes>
@@ -14250,20 +6263,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<attributes>
 														<attributes>
 															<entry>
-																<key>background-size</key>
-																<value xsi:type="xsd:string">auto auto</value>
-															</entry>
-															<entry>
 																<key>border-bottom-color</key>
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-															</entry>
-															<entry>
-																<key>border-image-outset</key>
-																<value xsi:type="xsd:string">0</value>
-															</entry>
-															<entry>
-																<key>border-image-repeat</key>
-																<value xsi:type="xsd:string">stretch stretch</value>
 															</entry>
 															<entry>
 																<key>border-left-color</key>
@@ -14278,10 +6279,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 															</entry>
@@ -14294,36 +6291,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-															</entry>
-															<entry>
-																<key>font-size</key>
-																<value xsi:type="xsd:string">17px</value>
-															</entry>
-															<entry>
-																<key>font-style</key>
-																<value xsi:type="xsd:string">normal</value>
-															</entry>
-															<entry>
-																<key>line-height</key>
-																<value xsi:type="xsd:string">36px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
-															</entry>
-															<entry>
 																<key>outline-color</key>
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-															</entry>
-															<entry>
-																<key>quotes</key>
-																<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
 															</entry>
 															<entry>
 																<key>text-decoration-color</key>
@@ -14332,7 +6301,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														</attributes>
 													</attributes>
 												</containedComponents>
-												<containedComponents retestId="c1e760f8-7dba-466f-9e4c-c2753ec6af33">
+												<containedComponents retestId="756fb34e-b109-4972-8bb3-93f4b032a68d">
 													<identifyingAttributes>
 														<attributes>
 															<attribute key="outline" xsi:type="outlineAttribute">
@@ -14350,20 +6319,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<attributes>
 														<attributes>
 															<entry>
-																<key>background-size</key>
-																<value xsi:type="xsd:string">auto auto</value>
-															</entry>
-															<entry>
 																<key>border-bottom-color</key>
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-															</entry>
-															<entry>
-																<key>border-image-outset</key>
-																<value xsi:type="xsd:string">0</value>
-															</entry>
-															<entry>
-																<key>border-image-repeat</key>
-																<value xsi:type="xsd:string">stretch stretch</value>
 															</entry>
 															<entry>
 																<key>border-left-color</key>
@@ -14378,10 +6335,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 															</entry>
@@ -14394,32 +6347,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-															</entry>
-															<entry>
-																<key>font-size</key>
-																<value xsi:type="xsd:string">17px</value>
-															</entry>
-															<entry>
-																<key>line-height</key>
-																<value xsi:type="xsd:string">36px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
-															</entry>
-															<entry>
 																<key>outline-color</key>
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-															</entry>
-															<entry>
-																<key>quotes</key>
-																<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
 															</entry>
 															<entry>
 																<key>text-decoration-color</key>
@@ -14446,20 +6375,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<attributes>
 														<attributes>
 															<entry>
-																<key>background-size</key>
-																<value xsi:type="xsd:string">auto auto</value>
-															</entry>
-															<entry>
 																<key>border-bottom-color</key>
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-															</entry>
-															<entry>
-																<key>border-image-outset</key>
-																<value xsi:type="xsd:string">0</value>
-															</entry>
-															<entry>
-																<key>border-image-repeat</key>
-																<value xsi:type="xsd:string">stretch stretch</value>
 															</entry>
 															<entry>
 																<key>border-left-color</key>
@@ -14474,10 +6391,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 															</entry>
@@ -14490,32 +6403,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-															</entry>
-															<entry>
-																<key>font-size</key>
-																<value xsi:type="xsd:string">17px</value>
-															</entry>
-															<entry>
-																<key>line-height</key>
-																<value xsi:type="xsd:string">36px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
-															</entry>
-															<entry>
 																<key>outline-color</key>
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-															</entry>
-															<entry>
-																<key>quotes</key>
-																<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
 															</entry>
 															<entry>
 																<key>text-decoration-color</key>
@@ -14542,20 +6431,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<attributes>
 														<attributes>
 															<entry>
-																<key>background-size</key>
-																<value xsi:type="xsd:string">auto auto</value>
-															</entry>
-															<entry>
 																<key>border-bottom-color</key>
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-															</entry>
-															<entry>
-																<key>border-image-outset</key>
-																<value xsi:type="xsd:string">0</value>
-															</entry>
-															<entry>
-																<key>border-image-repeat</key>
-																<value xsi:type="xsd:string">stretch stretch</value>
 															</entry>
 															<entry>
 																<key>border-left-color</key>
@@ -14570,10 +6447,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 															</entry>
@@ -14586,32 +6459,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-															</entry>
-															<entry>
-																<key>font-size</key>
-																<value xsi:type="xsd:string">17px</value>
-															</entry>
-															<entry>
-																<key>line-height</key>
-																<value xsi:type="xsd:string">36px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
-															</entry>
-															<entry>
 																<key>outline-color</key>
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-															</entry>
-															<entry>
-																<key>quotes</key>
-																<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
 															</entry>
 															<entry>
 																<key>text-decoration-color</key>
@@ -14642,88 +6491,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<attributes>
 									<attributes>
 										<entry>
-											<key>background-size</key>
-											<value xsi:type="xsd:string">auto auto</value>
-										</entry>
-										<entry>
-											<key>border-bottom-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-image-outset</key>
-											<value xsi:type="xsd:string">0</value>
-										</entry>
-										<entry>
-											<key>border-image-repeat</key>
-											<value xsi:type="xsd:string">stretch stretch</value>
-										</entry>
-										<entry>
-											<key>border-image-width</key>
-											<value xsi:type="xsd:string">1</value>
-										</entry>
-										<entry>
-											<key>border-left-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-right-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-top-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>box-sizing</key>
-											<value xsi:type="xsd:string">border-box</value>
-										</entry>
-										<entry>
-											<key>caret-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>column-rule-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>font-family</key>
-											<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-										</entry>
-										<entry>
-											<key>font-size</key>
-											<value xsi:type="xsd:string">15px</value>
-										</entry>
-										<entry>
-											<key>line-height</key>
-											<value xsi:type="xsd:string">30px</value>
-										</entry>
-										<entry>
-											<key>list-style-type</key>
-											<value xsi:type="xsd:string">none</value>
-										</entry>
-										<entry>
-											<key>outline-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>quotes</key>
-											<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-										</entry>
-										<entry>
 											<key>text-align</key>
 											<value xsi:type="xsd:string">left</value>
-										</entry>
-										<entry>
-											<key>text-decoration-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>unicode-bidi</key>
-											<value xsi:type="xsd:string">isolate</value>
 										</entry>
 									</attributes>
 								</attributes>
@@ -14745,10 +6514,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 									<attributes>
 										<attributes>
 											<entry>
-												<key>background-size</key>
-												<value xsi:type="xsd:string">auto auto</value>
-											</entry>
-											<entry>
 												<key>border-bottom-color</key>
 												<value xsi:type="xsd:string">rgb(175, 175, 175)</value>
 											</entry>
@@ -14759,58 +6524,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 											<entry>
 												<key>border-bottom-width</key>
 												<value xsi:type="xsd:string">1px</value>
-											</entry>
-											<entry>
-												<key>border-image-outset</key>
-												<value xsi:type="xsd:string">0</value>
-											</entry>
-											<entry>
-												<key>border-image-repeat</key>
-												<value xsi:type="xsd:string">stretch stretch</value>
-											</entry>
-											<entry>
-												<key>border-left-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-right-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-top-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
-											</entry>
-											<entry>
-												<key>caret-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>column-rule-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>font-family</key>
-												<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-											</entry>
-											<entry>
-												<key>font-size</key>
-												<value xsi:type="xsd:string">15px</value>
-											</entry>
-											<entry>
-												<key>line-height</key>
-												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
-												<key>list-style-type</key>
-												<value xsi:type="xsd:string">none</value>
 											</entry>
 											<entry>
 												<key>margin-left</key>
@@ -14825,28 +6538,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<value xsi:type="xsd:string">1020px</value>
 											</entry>
 											<entry>
-												<key>outline-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
 												<key>padding-bottom</key>
 												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
-												<key>quotes</key>
-												<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-											</entry>
-											<entry>
-												<key>text-align</key>
-												<value xsi:type="xsd:string">left</value>
-											</entry>
-											<entry>
-												<key>text-decoration-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>unicode-bidi</key>
-												<value xsi:type="xsd:string">isolate</value>
 											</entry>
 										</attributes>
 									</attributes>
@@ -14868,20 +6561,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 										<attributes>
 											<attributes>
 												<entry>
-													<key>background-size</key>
-													<value xsi:type="xsd:string">auto auto</value>
-												</entry>
-												<entry>
 													<key>border-bottom-color</key>
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-												</entry>
-												<entry>
-													<key>border-image-outset</key>
-													<value xsi:type="xsd:string">0</value>
-												</entry>
-												<entry>
-													<key>border-image-repeat</key>
-													<value xsi:type="xsd:string">stretch stretch</value>
 												</entry>
 												<entry>
 													<key>border-left-color</key>
@@ -14896,10 +6577,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 												</entry>
 												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
 													<key>caret-color</key>
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 												</entry>
@@ -14910,22 +6587,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<entry>
 													<key>column-rule-color</key>
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-												</entry>
-												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">15px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">30px</value>
-												</entry>
-												<entry>
-													<key>list-style-type</key>
-													<value xsi:type="xsd:string">none</value>
 												</entry>
 												<entry>
 													<key>margin-bottom</key>
@@ -14948,20 +6609,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 												</entry>
 												<entry>
-													<key>quotes</key>
-													<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-												</entry>
-												<entry>
 													<key>text-align</key>
 													<value xsi:type="xsd:string">center</value>
 												</entry>
 												<entry>
 													<key>text-decoration-color</key>
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-												</entry>
-												<entry>
-													<key>unicode-bidi</key>
-													<value xsi:type="xsd:string">isolate</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -14982,24 +6635,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 											<attributes>
 												<attributes>
 													<entry>
-														<key>background-size</key>
-														<value xsi:type="xsd:string">auto auto</value>
-													</entry>
-													<entry>
 														<key>border-bottom-color</key>
 														<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-													</entry>
-													<entry>
-														<key>border-image-outset</key>
-														<value xsi:type="xsd:string">0</value>
-													</entry>
-													<entry>
-														<key>border-image-repeat</key>
-														<value xsi:type="xsd:string">stretch stretch</value>
-													</entry>
-													<entry>
-														<key>border-image-width</key>
-														<value xsi:type="xsd:string">1</value>
 													</entry>
 													<entry>
 														<key>border-left-color</key>
@@ -15012,10 +6649,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<entry>
 														<key>border-top-color</key>
 														<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
 													</entry>
 													<entry>
 														<key>caret-color</key>
@@ -15046,10 +6679,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">42px</value>
 													</entry>
 													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
 														<key>margin-bottom</key>
 														<value xsi:type="xsd:string">6px</value>
 													</entry>
@@ -15062,20 +6691,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
 													</entry>
 													<entry>
-														<key>quotes</key>
-														<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">center</value>
-													</entry>
-													<entry>
 														<key>text-decoration-color</key>
 														<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-													</entry>
-													<entry>
-														<key>unicode-bidi</key>
-														<value xsi:type="xsd:string">isolate</value>
 													</entry>
 												</attributes>
 											</attributes>
@@ -15097,40 +6714,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<attributes>
 													<attributes>
 														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
 															<key>border-bottom-left-radius</key>
 															<value xsi:type="xsd:string">3px</value>
 														</entry>
 														<entry>
 															<key>border-bottom-right-radius</key>
 															<value xsi:type="xsd:string">3px</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
 														</entry>
 														<entry>
 															<key>border-top-left-radius</key>
@@ -15141,64 +6730,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">3px</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">30px</value>
-														</entry>
-														<entry>
-															<key>font-weight</key>
-															<value xsi:type="xsd:string">700</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">42px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>margin-right</key>
 															<value xsi:type="xsd:string">-30px</value>
 														</entry>
 														<entry>
 															<key>max-width</key>
 															<value xsi:type="xsd:string">100%</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">center</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
 														</entry>
 														<entry>
 															<key>vertical-align</key>
@@ -15225,20 +6762,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<attributes>
 													<attributes>
 														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
 															<key>border-bottom-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
 														</entry>
 														<entry>
 															<key>border-left-color</key>
@@ -15253,10 +6778,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
@@ -15269,36 +6790,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">30px</value>
-														</entry>
-														<entry>
-															<key>font-weight</key>
-															<value xsi:type="xsd:string">700</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">42px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">center</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -15307,7 +6800,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													</attributes>
 												</attributes>
 											</containedComponents>
-											<containedComponents retestId="a2eacd01-156c-410d-84c2-83822522a324">
+											<containedComponents retestId="550a051a-45e7-4f7e-aac3-8a925a19a155">
 												<identifyingAttributes>
 													<attributes>
 														<attribute key="outline" xsi:type="outlineAttribute">
@@ -15325,20 +6818,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<attributes>
 													<attributes>
 														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
 															<key>border-bottom-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
 														</entry>
 														<entry>
 															<key>border-left-color</key>
@@ -15353,10 +6834,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
@@ -15369,36 +6846,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">30px</value>
-														</entry>
-														<entry>
-															<key>font-weight</key>
-															<value xsi:type="xsd:string">700</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">42px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">center</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -15427,47 +6876,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 										<attributes>
 											<attributes>
 												<entry>
-													<key>background-size</key>
-													<value xsi:type="xsd:string">auto auto</value>
-												</entry>
-												<entry>
 													<key>border-bottom-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-image-outset</key>
-													<value xsi:type="xsd:string">0</value>
-												</entry>
-												<entry>
-													<key>border-image-repeat</key>
-													<value xsi:type="xsd:string">stretch stretch</value>
-												</entry>
-												<entry>
-													<key>border-left-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-right-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-top-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
-													<key>caret-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>column-rule-color</key>
 													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 												<entry>
@@ -15475,28 +6884,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<value xsi:type="xsd:string">left</value>
 												</entry>
 												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">15px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">30px</value>
-												</entry>
-												<entry>
-													<key>list-style-type</key>
-													<value xsi:type="xsd:string">none</value>
-												</entry>
-												<entry>
 													<key>min-height</key>
 													<value xsi:type="xsd:string">1px</value>
-												</entry>
-												<entry>
-													<key>outline-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 												<entry>
 													<key>padding-left</key>
@@ -15509,22 +6898,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<entry>
 													<key>position</key>
 													<value xsi:type="xsd:string">relative</value>
-												</entry>
-												<entry>
-													<key>quotes</key>
-													<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-												</entry>
-												<entry>
-													<key>text-align</key>
-													<value xsi:type="xsd:string">left</value>
-												</entry>
-												<entry>
-													<key>text-decoration-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>unicode-bidi</key>
-													<value xsi:type="xsd:string">isolate</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -15546,20 +6919,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 											<attributes>
 												<attributes>
 													<entry>
-														<key>background-size</key>
-														<value xsi:type="xsd:string">auto auto</value>
-													</entry>
-													<entry>
 														<key>border-bottom-color</key>
 														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-													</entry>
-													<entry>
-														<key>border-image-outset</key>
-														<value xsi:type="xsd:string">0</value>
-													</entry>
-													<entry>
-														<key>border-image-repeat</key>
-														<value xsi:type="xsd:string">stretch stretch</value>
 													</entry>
 													<entry>
 														<key>border-left-color</key>
@@ -15574,10 +6935,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 													</entry>
 													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
 														<key>caret-color</key>
 														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 													</entry>
@@ -15590,28 +6947,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 													</entry>
 													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
 														<key>outline-color</key>
 														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-													</entry>
-													<entry>
-														<key>quotes</key>
-														<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
 													</entry>
 													<entry>
 														<key>text-align</key>
@@ -15620,10 +6957,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<entry>
 														<key>text-decoration-color</key>
 														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-													</entry>
-													<entry>
-														<key>unicode-bidi</key>
-														<value xsi:type="xsd:string">isolate</value>
 													</entry>
 												</attributes>
 											</attributes>
@@ -15650,68 +6983,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<attributes>
 													<attributes>
 														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-														</entry>
-														<entry>
 															<key>font-size</key>
 															<value xsi:type="xsd:string">17px</value>
 														</entry>
 														<entry>
 															<key>line-height</key>
 															<value xsi:type="xsd:string">36px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>margin-bottom</key>
-															<value xsi:type="xsd:string">0px</value>
 														</entry>
 														<entry>
 															<key>margin-left</key>
@@ -15724,26 +7001,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<entry>
 															<key>margin-top</key>
 															<value xsi:type="xsd:string">12px</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">right</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>unicode-bidi</key>
-															<value xsi:type="xsd:string">isolate</value>
 														</entry>
 													</attributes>
 												</attributes>
@@ -15761,86 +7018,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 														</attributes>
 													</identifyingAttributes>
-													<attributes>
-														<attributes>
-															<entry>
-																<key>background-size</key>
-																<value xsi:type="xsd:string">auto auto</value>
-															</entry>
-															<entry>
-																<key>border-bottom-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>border-image-outset</key>
-																<value xsi:type="xsd:string">0</value>
-															</entry>
-															<entry>
-																<key>border-image-repeat</key>
-																<value xsi:type="xsd:string">stretch stretch</value>
-															</entry>
-															<entry>
-																<key>border-left-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>border-right-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>border-top-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
-																<key>caret-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>column-rule-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-															</entry>
-															<entry>
-																<key>font-size</key>
-																<value xsi:type="xsd:string">17px</value>
-															</entry>
-															<entry>
-																<key>line-height</key>
-																<value xsi:type="xsd:string">36px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
-															</entry>
-															<entry>
-																<key>outline-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>quotes</key>
-																<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">right</value>
-															</entry>
-															<entry>
-																<key>text-decoration-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-														</attributes>
-													</attributes>
+													<attributes/>
 												</containedComponents>
 												<containedComponents retestId="retest_compares">
 													<identifyingAttributes>
@@ -15860,20 +7038,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<attributes>
 														<attributes>
 															<entry>
-																<key>background-size</key>
-																<value xsi:type="xsd:string">auto auto</value>
-															</entry>
-															<entry>
 																<key>border-bottom-color</key>
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-															</entry>
-															<entry>
-																<key>border-image-outset</key>
-																<value xsi:type="xsd:string">0</value>
-															</entry>
-															<entry>
-																<key>border-image-repeat</key>
-																<value xsi:type="xsd:string">stretch stretch</value>
 															</entry>
 															<entry>
 																<key>border-left-color</key>
@@ -15888,10 +7054,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 															</entry>
@@ -15904,36 +7066,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-															</entry>
-															<entry>
-																<key>font-size</key>
-																<value xsi:type="xsd:string">17px</value>
-															</entry>
-															<entry>
-																<key>font-style</key>
-																<value xsi:type="xsd:string">normal</value>
-															</entry>
-															<entry>
-																<key>line-height</key>
-																<value xsi:type="xsd:string">36px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
-															</entry>
-															<entry>
 																<key>outline-color</key>
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-															</entry>
-															<entry>
-																<key>quotes</key>
-																<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">right</value>
 															</entry>
 															<entry>
 																<key>text-decoration-color</key>
@@ -15963,47 +7097,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 										<attributes>
 											<attributes>
 												<entry>
-													<key>background-size</key>
-													<value xsi:type="xsd:string">auto auto</value>
-												</entry>
-												<entry>
 													<key>border-bottom-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-image-outset</key>
-													<value xsi:type="xsd:string">0</value>
-												</entry>
-												<entry>
-													<key>border-image-repeat</key>
-													<value xsi:type="xsd:string">stretch stretch</value>
-												</entry>
-												<entry>
-													<key>border-left-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-right-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-top-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
-													<key>caret-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>column-rule-color</key>
 													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 												<entry>
@@ -16011,28 +7105,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<value xsi:type="xsd:string">right</value>
 												</entry>
 												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">15px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">30px</value>
-												</entry>
-												<entry>
-													<key>list-style-type</key>
-													<value xsi:type="xsd:string">none</value>
-												</entry>
-												<entry>
 													<key>min-height</key>
 													<value xsi:type="xsd:string">1px</value>
-												</entry>
-												<entry>
-													<key>outline-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 												<entry>
 													<key>padding-left</key>
@@ -16045,22 +7119,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<entry>
 													<key>position</key>
 													<value xsi:type="xsd:string">relative</value>
-												</entry>
-												<entry>
-													<key>quotes</key>
-													<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-												</entry>
-												<entry>
-													<key>text-align</key>
-													<value xsi:type="xsd:string">left</value>
-												</entry>
-												<entry>
-													<key>text-decoration-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>unicode-bidi</key>
-													<value xsi:type="xsd:string">isolate</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -16078,86 +7136,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 												</attributes>
 											</identifyingAttributes>
-											<attributes>
-												<attributes>
-													<entry>
-														<key>background-size</key>
-														<value xsi:type="xsd:string">auto auto</value>
-													</entry>
-													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-image-outset</key>
-														<value xsi:type="xsd:string">0</value>
-													</entry>
-													<entry>
-														<key>border-image-repeat</key>
-														<value xsi:type="xsd:string">stretch stretch</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>quotes</key>
-														<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-												</attributes>
-											</attributes>
+											<attributes/>
 										</containedComponents>
 										<containedComponents retestId="img">
 											<identifyingAttributes>
@@ -16176,40 +7155,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 											<attributes>
 												<attributes>
 													<entry>
-														<key>background-size</key>
-														<value xsi:type="xsd:string">auto auto</value>
-													</entry>
-													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>border-bottom-left-radius</key>
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
 													<entry>
 														<key>border-bottom-right-radius</key>
 														<value xsi:type="xsd:string">3px</value>
-													</entry>
-													<entry>
-														<key>border-image-outset</key>
-														<value xsi:type="xsd:string">0</value>
-													</entry>
-													<entry>
-														<key>border-image-repeat</key>
-														<value xsi:type="xsd:string">stretch stretch</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 													</entry>
 													<entry>
 														<key>border-top-left-radius</key>
@@ -16220,64 +7171,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
 													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>display</key>
-														<value xsi:type="xsd:string">block</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
 														<key>max-height</key>
 														<value xsi:type="xsd:string">200px</value>
 													</entry>
 													<entry>
 														<key>max-width</key>
 														<value xsi:type="xsd:string">100%</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>quotes</key>
-														<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 													</entry>
 													<entry>
 														<key>vertical-align</key>
@@ -16303,40 +7202,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 											<attributes>
 												<attributes>
 													<entry>
-														<key>background-size</key>
-														<value xsi:type="xsd:string">auto auto</value>
-													</entry>
-													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>border-bottom-left-radius</key>
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
 													<entry>
 														<key>border-bottom-right-radius</key>
 														<value xsi:type="xsd:string">3px</value>
-													</entry>
-													<entry>
-														<key>border-image-outset</key>
-														<value xsi:type="xsd:string">0</value>
-													</entry>
-													<entry>
-														<key>border-image-repeat</key>
-														<value xsi:type="xsd:string">stretch stretch</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 													</entry>
 													<entry>
 														<key>border-top-left-radius</key>
@@ -16347,64 +7218,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
 													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>display</key>
-														<value xsi:type="xsd:string">block</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
 														<key>max-height</key>
 														<value xsi:type="xsd:string">200px</value>
 													</entry>
 													<entry>
 														<key>max-width</key>
 														<value xsi:type="xsd:string">100%</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>quotes</key>
-														<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 													</entry>
 													<entry>
 														<key>vertical-align</key>
@@ -16433,88 +7252,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<attributes>
 									<attributes>
 										<entry>
-											<key>background-size</key>
-											<value xsi:type="xsd:string">auto auto</value>
-										</entry>
-										<entry>
-											<key>border-bottom-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-image-outset</key>
-											<value xsi:type="xsd:string">0</value>
-										</entry>
-										<entry>
-											<key>border-image-repeat</key>
-											<value xsi:type="xsd:string">stretch stretch</value>
-										</entry>
-										<entry>
-											<key>border-image-width</key>
-											<value xsi:type="xsd:string">1</value>
-										</entry>
-										<entry>
-											<key>border-left-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-right-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-top-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>box-sizing</key>
-											<value xsi:type="xsd:string">border-box</value>
-										</entry>
-										<entry>
-											<key>caret-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>column-rule-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>font-family</key>
-											<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-										</entry>
-										<entry>
-											<key>font-size</key>
-											<value xsi:type="xsd:string">15px</value>
-										</entry>
-										<entry>
-											<key>line-height</key>
-											<value xsi:type="xsd:string">30px</value>
-										</entry>
-										<entry>
-											<key>list-style-type</key>
-											<value xsi:type="xsd:string">none</value>
-										</entry>
-										<entry>
-											<key>outline-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>quotes</key>
-											<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-										</entry>
-										<entry>
 											<key>text-align</key>
 											<value xsi:type="xsd:string">left</value>
-										</entry>
-										<entry>
-											<key>text-decoration-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>unicode-bidi</key>
-											<value xsi:type="xsd:string">isolate</value>
 										</entry>
 									</attributes>
 								</attributes>
@@ -16536,10 +7275,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 									<attributes>
 										<attributes>
 											<entry>
-												<key>background-size</key>
-												<value xsi:type="xsd:string">auto auto</value>
-											</entry>
-											<entry>
 												<key>border-bottom-color</key>
 												<value xsi:type="xsd:string">rgb(175, 175, 175)</value>
 											</entry>
@@ -16550,58 +7285,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 											<entry>
 												<key>border-bottom-width</key>
 												<value xsi:type="xsd:string">1px</value>
-											</entry>
-											<entry>
-												<key>border-image-outset</key>
-												<value xsi:type="xsd:string">0</value>
-											</entry>
-											<entry>
-												<key>border-image-repeat</key>
-												<value xsi:type="xsd:string">stretch stretch</value>
-											</entry>
-											<entry>
-												<key>border-left-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-right-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-top-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
-											</entry>
-											<entry>
-												<key>caret-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>column-rule-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>font-family</key>
-												<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-											</entry>
-											<entry>
-												<key>font-size</key>
-												<value xsi:type="xsd:string">15px</value>
-											</entry>
-											<entry>
-												<key>line-height</key>
-												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
-												<key>list-style-type</key>
-												<value xsi:type="xsd:string">none</value>
 											</entry>
 											<entry>
 												<key>margin-left</key>
@@ -16616,28 +7299,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<value xsi:type="xsd:string">1020px</value>
 											</entry>
 											<entry>
-												<key>outline-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
 												<key>padding-bottom</key>
 												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
-												<key>quotes</key>
-												<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-											</entry>
-											<entry>
-												<key>text-align</key>
-												<value xsi:type="xsd:string">left</value>
-											</entry>
-											<entry>
-												<key>text-decoration-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>unicode-bidi</key>
-												<value xsi:type="xsd:string">isolate</value>
 											</entry>
 										</attributes>
 									</attributes>
@@ -16659,20 +7322,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 										<attributes>
 											<attributes>
 												<entry>
-													<key>background-size</key>
-													<value xsi:type="xsd:string">auto auto</value>
-												</entry>
-												<entry>
 													<key>border-bottom-color</key>
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-												</entry>
-												<entry>
-													<key>border-image-outset</key>
-													<value xsi:type="xsd:string">0</value>
-												</entry>
-												<entry>
-													<key>border-image-repeat</key>
-													<value xsi:type="xsd:string">stretch stretch</value>
 												</entry>
 												<entry>
 													<key>border-left-color</key>
@@ -16687,10 +7338,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 												</entry>
 												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
 													<key>caret-color</key>
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 												</entry>
@@ -16701,22 +7348,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<entry>
 													<key>column-rule-color</key>
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-												</entry>
-												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">15px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">30px</value>
-												</entry>
-												<entry>
-													<key>list-style-type</key>
-													<value xsi:type="xsd:string">none</value>
 												</entry>
 												<entry>
 													<key>margin-bottom</key>
@@ -16739,20 +7370,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 												</entry>
 												<entry>
-													<key>quotes</key>
-													<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-												</entry>
-												<entry>
 													<key>text-align</key>
 													<value xsi:type="xsd:string">center</value>
 												</entry>
 												<entry>
 													<key>text-decoration-color</key>
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-												</entry>
-												<entry>
-													<key>unicode-bidi</key>
-													<value xsi:type="xsd:string">isolate</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -16773,24 +7396,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 											<attributes>
 												<attributes>
 													<entry>
-														<key>background-size</key>
-														<value xsi:type="xsd:string">auto auto</value>
-													</entry>
-													<entry>
 														<key>border-bottom-color</key>
 														<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-													</entry>
-													<entry>
-														<key>border-image-outset</key>
-														<value xsi:type="xsd:string">0</value>
-													</entry>
-													<entry>
-														<key>border-image-repeat</key>
-														<value xsi:type="xsd:string">stretch stretch</value>
-													</entry>
-													<entry>
-														<key>border-image-width</key>
-														<value xsi:type="xsd:string">1</value>
 													</entry>
 													<entry>
 														<key>border-left-color</key>
@@ -16803,10 +7410,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<entry>
 														<key>border-top-color</key>
 														<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
 													</entry>
 													<entry>
 														<key>caret-color</key>
@@ -16837,10 +7440,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">42px</value>
 													</entry>
 													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
 														<key>margin-bottom</key>
 														<value xsi:type="xsd:string">6px</value>
 													</entry>
@@ -16853,20 +7452,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
 													</entry>
 													<entry>
-														<key>quotes</key>
-														<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">center</value>
-													</entry>
-													<entry>
 														<key>text-decoration-color</key>
 														<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-													</entry>
-													<entry>
-														<key>unicode-bidi</key>
-														<value xsi:type="xsd:string">isolate</value>
 													</entry>
 												</attributes>
 											</attributes>
@@ -16888,40 +7475,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<attributes>
 													<attributes>
 														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
 															<key>border-bottom-left-radius</key>
 															<value xsi:type="xsd:string">3px</value>
 														</entry>
 														<entry>
 															<key>border-bottom-right-radius</key>
 															<value xsi:type="xsd:string">3px</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
 														</entry>
 														<entry>
 															<key>border-top-left-radius</key>
@@ -16932,64 +7491,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">3px</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">30px</value>
-														</entry>
-														<entry>
-															<key>font-weight</key>
-															<value xsi:type="xsd:string">700</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">42px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>margin-right</key>
 															<value xsi:type="xsd:string">-30px</value>
 														</entry>
 														<entry>
 															<key>max-width</key>
 															<value xsi:type="xsd:string">100%</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">center</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
 														</entry>
 														<entry>
 															<key>vertical-align</key>
@@ -17016,20 +7523,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<attributes>
 													<attributes>
 														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
 															<key>border-bottom-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
 														</entry>
 														<entry>
 															<key>border-left-color</key>
@@ -17044,10 +7539,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
@@ -17060,36 +7551,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">30px</value>
-														</entry>
-														<entry>
-															<key>font-weight</key>
-															<value xsi:type="xsd:string">700</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">42px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">center</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -17098,7 +7561,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													</attributes>
 												</attributes>
 											</containedComponents>
-											<containedComponents retestId="79f62791-6d09-49e9-9aff-85e9f715ee22">
+											<containedComponents retestId="a3ddba42-2d94-421e-8efe-f6e4bfbe1e95">
 												<identifyingAttributes>
 													<attributes>
 														<attribute key="outline" xsi:type="outlineAttribute">
@@ -17116,20 +7579,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<attributes>
 													<attributes>
 														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
 															<key>border-bottom-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
 														</entry>
 														<entry>
 															<key>border-left-color</key>
@@ -17144,10 +7595,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
@@ -17160,36 +7607,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">30px</value>
-														</entry>
-														<entry>
-															<key>font-weight</key>
-															<value xsi:type="xsd:string">700</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">42px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">center</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -17218,47 +7637,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 										<attributes>
 											<attributes>
 												<entry>
-													<key>background-size</key>
-													<value xsi:type="xsd:string">auto auto</value>
-												</entry>
-												<entry>
 													<key>border-bottom-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-image-outset</key>
-													<value xsi:type="xsd:string">0</value>
-												</entry>
-												<entry>
-													<key>border-image-repeat</key>
-													<value xsi:type="xsd:string">stretch stretch</value>
-												</entry>
-												<entry>
-													<key>border-left-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-right-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-top-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
-													<key>caret-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>column-rule-color</key>
 													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 												<entry>
@@ -17266,28 +7645,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<value xsi:type="xsd:string">left</value>
 												</entry>
 												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">15px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">30px</value>
-												</entry>
-												<entry>
-													<key>list-style-type</key>
-													<value xsi:type="xsd:string">none</value>
-												</entry>
-												<entry>
 													<key>min-height</key>
 													<value xsi:type="xsd:string">1px</value>
-												</entry>
-												<entry>
-													<key>outline-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 												<entry>
 													<key>padding-left</key>
@@ -17300,22 +7659,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<entry>
 													<key>position</key>
 													<value xsi:type="xsd:string">relative</value>
-												</entry>
-												<entry>
-													<key>quotes</key>
-													<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-												</entry>
-												<entry>
-													<key>text-align</key>
-													<value xsi:type="xsd:string">left</value>
-												</entry>
-												<entry>
-													<key>text-decoration-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>unicode-bidi</key>
-													<value xsi:type="xsd:string">isolate</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -17333,86 +7676,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 												</attributes>
 											</identifyingAttributes>
-											<attributes>
-												<attributes>
-													<entry>
-														<key>background-size</key>
-														<value xsi:type="xsd:string">auto auto</value>
-													</entry>
-													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-image-outset</key>
-														<value xsi:type="xsd:string">0</value>
-													</entry>
-													<entry>
-														<key>border-image-repeat</key>
-														<value xsi:type="xsd:string">stretch stretch</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>quotes</key>
-														<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-												</attributes>
-											</attributes>
+											<attributes/>
 										</containedComponents>
 										<containedComponents retestId="br">
 											<identifyingAttributes>
@@ -17428,86 +7692,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 												</attributes>
 											</identifyingAttributes>
-											<attributes>
-												<attributes>
-													<entry>
-														<key>background-size</key>
-														<value xsi:type="xsd:string">auto auto</value>
-													</entry>
-													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-image-outset</key>
-														<value xsi:type="xsd:string">0</value>
-													</entry>
-													<entry>
-														<key>border-image-repeat</key>
-														<value xsi:type="xsd:string">stretch stretch</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>quotes</key>
-														<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-												</attributes>
-											</attributes>
+											<attributes/>
 										</containedComponents>
 										<containedComponents retestId="br">
 											<identifyingAttributes>
@@ -17523,86 +7708,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 												</attributes>
 											</identifyingAttributes>
-											<attributes>
-												<attributes>
-													<entry>
-														<key>background-size</key>
-														<value xsi:type="xsd:string">auto auto</value>
-													</entry>
-													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-image-outset</key>
-														<value xsi:type="xsd:string">0</value>
-													</entry>
-													<entry>
-														<key>border-image-repeat</key>
-														<value xsi:type="xsd:string">stretch stretch</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>quotes</key>
-														<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-												</attributes>
-											</attributes>
+											<attributes/>
 										</containedComponents>
 										<containedComponents retestId="img">
 											<identifyingAttributes>
@@ -17621,40 +7727,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 											<attributes>
 												<attributes>
 													<entry>
-														<key>background-size</key>
-														<value xsi:type="xsd:string">auto auto</value>
-													</entry>
-													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>border-bottom-left-radius</key>
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
 													<entry>
 														<key>border-bottom-right-radius</key>
 														<value xsi:type="xsd:string">3px</value>
-													</entry>
-													<entry>
-														<key>border-image-outset</key>
-														<value xsi:type="xsd:string">0</value>
-													</entry>
-													<entry>
-														<key>border-image-repeat</key>
-														<value xsi:type="xsd:string">stretch stretch</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 													</entry>
 													<entry>
 														<key>border-top-left-radius</key>
@@ -17665,64 +7743,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
 													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>display</key>
-														<value xsi:type="xsd:string">block</value>
-													</entry>
-													<entry>
 														<key>float</key>
 														<value xsi:type="xsd:string">right</value>
 													</entry>
 													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
 														<key>max-width</key>
 														<value xsi:type="xsd:string">400px</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>quotes</key>
-														<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 													</entry>
 													<entry>
 														<key>vertical-align</key>
@@ -17750,47 +7776,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 										<attributes>
 											<attributes>
 												<entry>
-													<key>background-size</key>
-													<value xsi:type="xsd:string">auto auto</value>
-												</entry>
-												<entry>
 													<key>border-bottom-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-image-outset</key>
-													<value xsi:type="xsd:string">0</value>
-												</entry>
-												<entry>
-													<key>border-image-repeat</key>
-													<value xsi:type="xsd:string">stretch stretch</value>
-												</entry>
-												<entry>
-													<key>border-left-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-right-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-top-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
-													<key>caret-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>column-rule-color</key>
 													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 												<entry>
@@ -17798,28 +7784,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<value xsi:type="xsd:string">right</value>
 												</entry>
 												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">15px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">30px</value>
-												</entry>
-												<entry>
-													<key>list-style-type</key>
-													<value xsi:type="xsd:string">none</value>
-												</entry>
-												<entry>
 													<key>min-height</key>
 													<value xsi:type="xsd:string">1px</value>
-												</entry>
-												<entry>
-													<key>outline-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 												<entry>
 													<key>padding-left</key>
@@ -17832,22 +7798,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<entry>
 													<key>position</key>
 													<value xsi:type="xsd:string">relative</value>
-												</entry>
-												<entry>
-													<key>quotes</key>
-													<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-												</entry>
-												<entry>
-													<key>text-align</key>
-													<value xsi:type="xsd:string">left</value>
-												</entry>
-												<entry>
-													<key>text-decoration-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>unicode-bidi</key>
-													<value xsi:type="xsd:string">isolate</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -17869,20 +7819,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 											<attributes>
 												<attributes>
 													<entry>
-														<key>background-size</key>
-														<value xsi:type="xsd:string">auto auto</value>
-													</entry>
-													<entry>
 														<key>border-bottom-color</key>
 														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-													</entry>
-													<entry>
-														<key>border-image-outset</key>
-														<value xsi:type="xsd:string">0</value>
-													</entry>
-													<entry>
-														<key>border-image-repeat</key>
-														<value xsi:type="xsd:string">stretch stretch</value>
 													</entry>
 													<entry>
 														<key>border-left-color</key>
@@ -17897,10 +7835,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 													</entry>
 													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
 														<key>caret-color</key>
 														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 													</entry>
@@ -17913,40 +7847,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 													</entry>
 													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
 														<key>outline-color</key>
 														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 													</entry>
 													<entry>
-														<key>quotes</key>
-														<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
 														<key>text-decoration-color</key>
 														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-													</entry>
-													<entry>
-														<key>unicode-bidi</key>
-														<value xsi:type="xsd:string">isolate</value>
 													</entry>
 												</attributes>
 											</attributes>
@@ -17967,68 +7873,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<attributes>
 													<attributes>
 														<entry>
-															<key>background-size</key>
-															<value xsi:type="xsd:string">auto auto</value>
-														</entry>
-														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-image-outset</key>
-															<value xsi:type="xsd:string">0</value>
-														</entry>
-														<entry>
-															<key>border-image-repeat</key>
-															<value xsi:type="xsd:string">stretch stretch</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-														</entry>
-														<entry>
 															<key>font-size</key>
 															<value xsi:type="xsd:string">17px</value>
 														</entry>
 														<entry>
 															<key>line-height</key>
 															<value xsi:type="xsd:string">36px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>margin-bottom</key>
-															<value xsi:type="xsd:string">0px</value>
 														</entry>
 														<entry>
 															<key>margin-left</key>
@@ -18041,26 +7891,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<entry>
 															<key>margin-top</key>
 															<value xsi:type="xsd:string">12px</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>quotes</key>
-															<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>unicode-bidi</key>
-															<value xsi:type="xsd:string">isolate</value>
 														</entry>
 													</attributes>
 												</attributes>
@@ -18078,86 +7908,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 														</attributes>
 													</identifyingAttributes>
-													<attributes>
-														<attributes>
-															<entry>
-																<key>background-size</key>
-																<value xsi:type="xsd:string">auto auto</value>
-															</entry>
-															<entry>
-																<key>border-bottom-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>border-image-outset</key>
-																<value xsi:type="xsd:string">0</value>
-															</entry>
-															<entry>
-																<key>border-image-repeat</key>
-																<value xsi:type="xsd:string">stretch stretch</value>
-															</entry>
-															<entry>
-																<key>border-left-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>border-right-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>border-top-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
-																<key>caret-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>column-rule-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-															</entry>
-															<entry>
-																<key>font-size</key>
-																<value xsi:type="xsd:string">17px</value>
-															</entry>
-															<entry>
-																<key>line-height</key>
-																<value xsi:type="xsd:string">36px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
-															</entry>
-															<entry>
-																<key>outline-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>quotes</key>
-																<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
-																<key>text-decoration-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-														</attributes>
-													</attributes>
+													<attributes/>
 												</containedComponents>
 												<containedComponents retestId="br">
 													<identifyingAttributes>
@@ -18173,86 +7924,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 														</attributes>
 													</identifyingAttributes>
-													<attributes>
-														<attributes>
-															<entry>
-																<key>background-size</key>
-																<value xsi:type="xsd:string">auto auto</value>
-															</entry>
-															<entry>
-																<key>border-bottom-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>border-image-outset</key>
-																<value xsi:type="xsd:string">0</value>
-															</entry>
-															<entry>
-																<key>border-image-repeat</key>
-																<value xsi:type="xsd:string">stretch stretch</value>
-															</entry>
-															<entry>
-																<key>border-left-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>border-right-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>border-top-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
-																<key>caret-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>column-rule-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-															</entry>
-															<entry>
-																<key>font-size</key>
-																<value xsi:type="xsd:string">17px</value>
-															</entry>
-															<entry>
-																<key>line-height</key>
-																<value xsi:type="xsd:string">36px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
-															</entry>
-															<entry>
-																<key>outline-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>quotes</key>
-																<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
-																<key>text-decoration-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-														</attributes>
-													</attributes>
+													<attributes/>
 												</containedComponents>
 												<containedComponents retestId="the_future_of">
 													<identifyingAttributes>
@@ -18272,20 +7944,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<attributes>
 														<attributes>
 															<entry>
-																<key>background-size</key>
-																<value xsi:type="xsd:string">auto auto</value>
-															</entry>
-															<entry>
 																<key>border-bottom-color</key>
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-															</entry>
-															<entry>
-																<key>border-image-outset</key>
-																<value xsi:type="xsd:string">0</value>
-															</entry>
-															<entry>
-																<key>border-image-repeat</key>
-																<value xsi:type="xsd:string">stretch stretch</value>
 															</entry>
 															<entry>
 																<key>border-left-color</key>
@@ -18300,10 +7960,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 															</entry>
@@ -18316,36 +7972,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-															</entry>
-															<entry>
-																<key>font-size</key>
-																<value xsi:type="xsd:string">17px</value>
-															</entry>
-															<entry>
-																<key>font-style</key>
-																<value xsi:type="xsd:string">normal</value>
-															</entry>
-															<entry>
-																<key>line-height</key>
-																<value xsi:type="xsd:string">36px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
-															</entry>
-															<entry>
 																<key>outline-color</key>
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-															</entry>
-															<entry>
-																<key>quotes</key>
-																<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
 															</entry>
 															<entry>
 																<key>text-decoration-color</key>
@@ -18372,20 +8000,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<attributes>
 														<attributes>
 															<entry>
-																<key>background-size</key>
-																<value xsi:type="xsd:string">auto auto</value>
-															</entry>
-															<entry>
 																<key>border-bottom-color</key>
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-															</entry>
-															<entry>
-																<key>border-image-outset</key>
-																<value xsi:type="xsd:string">0</value>
-															</entry>
-															<entry>
-																<key>border-image-repeat</key>
-																<value xsi:type="xsd:string">stretch stretch</value>
 															</entry>
 															<entry>
 																<key>border-left-color</key>
@@ -18400,10 +8016,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 															</entry>
@@ -18416,36 +8028,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-															</entry>
-															<entry>
-																<key>font-size</key>
-																<value xsi:type="xsd:string">17px</value>
-															</entry>
-															<entry>
-																<key>font-style</key>
-																<value xsi:type="xsd:string">normal</value>
-															</entry>
-															<entry>
-																<key>line-height</key>
-																<value xsi:type="xsd:string">36px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
-															</entry>
-															<entry>
 																<key>outline-color</key>
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-															</entry>
-															<entry>
-																<key>quotes</key>
-																<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
 															</entry>
 															<entry>
 																<key>text-decoration-color</key>
@@ -18454,7 +8038,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														</attributes>
 													</attributes>
 												</containedComponents>
-												<containedComponents retestId="78165030-00bd-42ee-9016-1c0a43e058ec">
+												<containedComponents retestId="67a0e928-7702-4993-a887-989df45a8d59">
 													<identifyingAttributes>
 														<attributes>
 															<attribute key="outline" xsi:type="outlineAttribute">
@@ -18472,20 +8056,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<attributes>
 														<attributes>
 															<entry>
-																<key>background-size</key>
-																<value xsi:type="xsd:string">auto auto</value>
-															</entry>
-															<entry>
 																<key>border-bottom-color</key>
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-															</entry>
-															<entry>
-																<key>border-image-outset</key>
-																<value xsi:type="xsd:string">0</value>
-															</entry>
-															<entry>
-																<key>border-image-repeat</key>
-																<value xsi:type="xsd:string">stretch stretch</value>
 															</entry>
 															<entry>
 																<key>border-left-color</key>
@@ -18500,10 +8072,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 															</entry>
@@ -18516,32 +8084,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-															</entry>
-															<entry>
-																<key>font-size</key>
-																<value xsi:type="xsd:string">17px</value>
-															</entry>
-															<entry>
-																<key>line-height</key>
-																<value xsi:type="xsd:string">36px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
-															</entry>
-															<entry>
 																<key>outline-color</key>
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-															</entry>
-															<entry>
-																<key>quotes</key>
-																<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
 															</entry>
 															<entry>
 																<key>text-decoration-color</key>
@@ -18580,88 +8124,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
 							</entry>
 							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">15px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
 								<key>padding-bottom</key>
 								<value xsi:type="xsd:string">42px</value>
 							</entry>
 							<entry>
 								<key>padding-top</key>
 								<value xsi:type="xsd:string">60px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>unicode-bidi</key>
-								<value xsi:type="xsd:string">isolate</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -18683,62 +8151,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 						<attributes>
 							<attributes>
 								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-bottom-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>border-left-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-right-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-top-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>box-sizing</key>
-									<value xsi:type="xsd:string">border-box</value>
-								</entry>
-								<entry>
-									<key>caret-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>column-rule-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-								</entry>
-								<entry>
-									<key>font-size</key>
-									<value xsi:type="xsd:string">15px</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">30px</value>
-								</entry>
-								<entry>
 									<key>margin-left</key>
 									<value xsi:type="xsd:string">168px</value>
 								</entry>
@@ -18749,22 +8161,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<entry>
 									<key>max-width</key>
 									<value xsi:type="xsd:string">1020px</value>
-								</entry>
-								<entry>
-									<key>outline-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
-									<key>text-decoration-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>unicode-bidi</key>
-									<value xsi:type="xsd:string">isolate</value>
 								</entry>
 							</attributes>
 						</attributes>
@@ -18783,82 +8179,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 									<attribute key="type" xsi:type="stringAttribute">DIV</attribute>
 								</attributes>
 							</identifyingAttributes>
-							<attributes>
-								<attributes>
-									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
-										<key>border-bottom-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>border-left-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>border-right-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>border-top-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>box-sizing</key>
-										<value xsi:type="xsd:string">border-box</value>
-									</entry>
-									<entry>
-										<key>caret-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>column-rule-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">15px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">30px</value>
-									</entry>
-									<entry>
-										<key>outline-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
-										<key>text-decoration-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>unicode-bidi</key>
-										<value xsi:type="xsd:string">isolate</value>
-									</entry>
-								</attributes>
-							</attributes>
+							<attributes/>
 							<containedComponents retestId="div">
 								<identifyingAttributes>
 									<attributes>
@@ -18877,72 +8198,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<attributes>
 									<attributes>
 										<entry>
-											<key>background-size</key>
-											<value xsi:type="xsd:string">auto auto</value>
-										</entry>
-										<entry>
-											<key>border-bottom-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-image-outset</key>
-											<value xsi:type="xsd:string">0</value>
-										</entry>
-										<entry>
-											<key>border-image-repeat</key>
-											<value xsi:type="xsd:string">stretch stretch</value>
-										</entry>
-										<entry>
-											<key>border-left-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-right-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-top-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>box-sizing</key>
-											<value xsi:type="xsd:string">border-box</value>
-										</entry>
-										<entry>
-											<key>caret-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>column-rule-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
 											<key>float</key>
 											<value xsi:type="xsd:string">left</value>
 										</entry>
 										<entry>
-											<key>font-family</key>
-											<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-										</entry>
-										<entry>
-											<key>font-size</key>
-											<value xsi:type="xsd:string">15px</value>
-										</entry>
-										<entry>
-											<key>line-height</key>
-											<value xsi:type="xsd:string">30px</value>
-										</entry>
-										<entry>
 											<key>min-height</key>
 											<value xsi:type="xsd:string">1px</value>
-										</entry>
-										<entry>
-											<key>outline-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 										</entry>
 										<entry>
 											<key>padding-left</key>
@@ -18955,18 +8216,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 										<entry>
 											<key>position</key>
 											<value xsi:type="xsd:string">relative</value>
-										</entry>
-										<entry>
-											<key>quotes</key>
-											<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-										</entry>
-										<entry>
-											<key>text-decoration-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>unicode-bidi</key>
-											<value xsi:type="xsd:string">isolate</value>
 										</entry>
 									</attributes>
 								</attributes>
@@ -18988,24 +8237,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 									<attributes>
 										<attributes>
 											<entry>
-												<key>background-size</key>
-												<value xsi:type="xsd:string">auto auto</value>
-											</entry>
-											<entry>
 												<key>border-bottom-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-											</entry>
-											<entry>
-												<key>border-image-outset</key>
-												<value xsi:type="xsd:string">0</value>
-											</entry>
-											<entry>
-												<key>border-image-repeat</key>
-												<value xsi:type="xsd:string">stretch stretch</value>
-											</entry>
-											<entry>
-												<key>border-image-width</key>
-												<value xsi:type="xsd:string">1</value>
 											</entry>
 											<entry>
 												<key>border-left-color</key>
@@ -19018,10 +8251,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 											<entry>
 												<key>border-top-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-											</entry>
-											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
 											</entry>
 											<entry>
 												<key>caret-color</key>
@@ -19044,36 +8273,16 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<value xsi:type="xsd:string">18px</value>
 											</entry>
 											<entry>
-												<key>font-weight</key>
-												<value xsi:type="xsd:string">400</value>
-											</entry>
-											<entry>
-												<key>line-height</key>
-												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
 												<key>margin-bottom</key>
 												<value xsi:type="xsd:string">6px</value>
-											</entry>
-											<entry>
-												<key>margin-top</key>
-												<value xsi:type="xsd:string">0px</value>
 											</entry>
 											<entry>
 												<key>outline-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 											</entry>
 											<entry>
-												<key>quotes</key>
-												<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-											</entry>
-											<entry>
 												<key>text-decoration-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-											</entry>
-											<entry>
-												<key>unicode-bidi</key>
-												<value xsi:type="xsd:string">isolate</value>
 											</entry>
 										</attributes>
 									</attributes>
@@ -19097,84 +8306,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 									<attributes>
 										<attributes>
 											<entry>
-												<key>background-size</key>
-												<value xsi:type="xsd:string">auto auto</value>
-											</entry>
-											<entry>
-												<key>border-bottom-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-image-outset</key>
-												<value xsi:type="xsd:string">0</value>
-											</entry>
-											<entry>
-												<key>border-image-repeat</key>
-												<value xsi:type="xsd:string">stretch stretch</value>
-											</entry>
-											<entry>
-												<key>border-left-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-right-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-top-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
-											</entry>
-											<entry>
-												<key>caret-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>column-rule-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>font-family</key>
-												<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-											</entry>
-											<entry>
-												<key>font-size</key>
-												<value xsi:type="xsd:string">15px</value>
-											</entry>
-											<entry>
-												<key>line-height</key>
-												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
 												<key>margin-bottom</key>
 												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
-												<key>margin-top</key>
-												<value xsi:type="xsd:string">0px</value>
-											</entry>
-											<entry>
-												<key>outline-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>quotes</key>
-												<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-											</entry>
-											<entry>
-												<key>text-decoration-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>unicode-bidi</key>
-												<value xsi:type="xsd:string">isolate</value>
 											</entry>
 										</attributes>
 									</attributes>
@@ -19192,78 +8325,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 											</attributes>
 										</identifyingAttributes>
-										<attributes>
-											<attributes>
-												<entry>
-													<key>background-size</key>
-													<value xsi:type="xsd:string">auto auto</value>
-												</entry>
-												<entry>
-													<key>border-bottom-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-image-outset</key>
-													<value xsi:type="xsd:string">0</value>
-												</entry>
-												<entry>
-													<key>border-image-repeat</key>
-													<value xsi:type="xsd:string">stretch stretch</value>
-												</entry>
-												<entry>
-													<key>border-left-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-right-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-top-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
-													<key>caret-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>column-rule-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">15px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">30px</value>
-												</entry>
-												<entry>
-													<key>outline-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>quotes</key>
-													<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-												</entry>
-												<entry>
-													<key>text-decoration-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-											</attributes>
-										</attributes>
+										<attributes/>
 									</containedComponents>
 								</containedComponents>
 							</containedComponents>
@@ -19285,72 +8347,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<attributes>
 									<attributes>
 										<entry>
-											<key>background-size</key>
-											<value xsi:type="xsd:string">auto auto</value>
-										</entry>
-										<entry>
-											<key>border-bottom-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-image-outset</key>
-											<value xsi:type="xsd:string">0</value>
-										</entry>
-										<entry>
-											<key>border-image-repeat</key>
-											<value xsi:type="xsd:string">stretch stretch</value>
-										</entry>
-										<entry>
-											<key>border-left-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-right-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-top-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>box-sizing</key>
-											<value xsi:type="xsd:string">border-box</value>
-										</entry>
-										<entry>
-											<key>caret-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>column-rule-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
 											<key>float</key>
 											<value xsi:type="xsd:string">left</value>
 										</entry>
 										<entry>
-											<key>font-family</key>
-											<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-										</entry>
-										<entry>
-											<key>font-size</key>
-											<value xsi:type="xsd:string">15px</value>
-										</entry>
-										<entry>
-											<key>line-height</key>
-											<value xsi:type="xsd:string">30px</value>
-										</entry>
-										<entry>
 											<key>min-height</key>
 											<value xsi:type="xsd:string">1px</value>
-										</entry>
-										<entry>
-											<key>outline-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 										</entry>
 										<entry>
 											<key>padding-left</key>
@@ -19363,18 +8365,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 										<entry>
 											<key>position</key>
 											<value xsi:type="xsd:string">relative</value>
-										</entry>
-										<entry>
-											<key>quotes</key>
-											<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-										</entry>
-										<entry>
-											<key>text-decoration-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>unicode-bidi</key>
-											<value xsi:type="xsd:string">isolate</value>
 										</entry>
 									</attributes>
 								</attributes>
@@ -19396,24 +8386,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 									<attributes>
 										<attributes>
 											<entry>
-												<key>background-size</key>
-												<value xsi:type="xsd:string">auto auto</value>
-											</entry>
-											<entry>
 												<key>border-bottom-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-											</entry>
-											<entry>
-												<key>border-image-outset</key>
-												<value xsi:type="xsd:string">0</value>
-											</entry>
-											<entry>
-												<key>border-image-repeat</key>
-												<value xsi:type="xsd:string">stretch stretch</value>
-											</entry>
-											<entry>
-												<key>border-image-width</key>
-												<value xsi:type="xsd:string">1</value>
 											</entry>
 											<entry>
 												<key>border-left-color</key>
@@ -19426,10 +8400,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 											<entry>
 												<key>border-top-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-											</entry>
-											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
 											</entry>
 											<entry>
 												<key>caret-color</key>
@@ -19452,36 +8422,16 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<value xsi:type="xsd:string">18px</value>
 											</entry>
 											<entry>
-												<key>font-weight</key>
-												<value xsi:type="xsd:string">400</value>
-											</entry>
-											<entry>
-												<key>line-height</key>
-												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
 												<key>margin-bottom</key>
 												<value xsi:type="xsd:string">6px</value>
-											</entry>
-											<entry>
-												<key>margin-top</key>
-												<value xsi:type="xsd:string">0px</value>
 											</entry>
 											<entry>
 												<key>outline-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 											</entry>
 											<entry>
-												<key>quotes</key>
-												<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-											</entry>
-											<entry>
 												<key>text-decoration-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-											</entry>
-											<entry>
-												<key>unicode-bidi</key>
-												<value xsi:type="xsd:string">isolate</value>
 											</entry>
 										</attributes>
 									</attributes>
@@ -19506,84 +8456,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 									<attributes>
 										<attributes>
 											<entry>
-												<key>background-size</key>
-												<value xsi:type="xsd:string">auto auto</value>
-											</entry>
-											<entry>
-												<key>border-bottom-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-image-outset</key>
-												<value xsi:type="xsd:string">0</value>
-											</entry>
-											<entry>
-												<key>border-image-repeat</key>
-												<value xsi:type="xsd:string">stretch stretch</value>
-											</entry>
-											<entry>
-												<key>border-left-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-right-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-top-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
-											</entry>
-											<entry>
-												<key>caret-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>column-rule-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>font-family</key>
-												<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-											</entry>
-											<entry>
-												<key>font-size</key>
-												<value xsi:type="xsd:string">15px</value>
-											</entry>
-											<entry>
-												<key>line-height</key>
-												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
 												<key>margin-bottom</key>
 												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
-												<key>margin-top</key>
-												<value xsi:type="xsd:string">0px</value>
-											</entry>
-											<entry>
-												<key>outline-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>quotes</key>
-												<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-											</entry>
-											<entry>
-												<key>text-decoration-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>unicode-bidi</key>
-												<value xsi:type="xsd:string">isolate</value>
 											</entry>
 										</attributes>
 									</attributes>
@@ -19607,72 +8481,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<attributes>
 									<attributes>
 										<entry>
-											<key>background-size</key>
-											<value xsi:type="xsd:string">auto auto</value>
-										</entry>
-										<entry>
-											<key>border-bottom-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-image-outset</key>
-											<value xsi:type="xsd:string">0</value>
-										</entry>
-										<entry>
-											<key>border-image-repeat</key>
-											<value xsi:type="xsd:string">stretch stretch</value>
-										</entry>
-										<entry>
-											<key>border-left-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-right-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-top-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>box-sizing</key>
-											<value xsi:type="xsd:string">border-box</value>
-										</entry>
-										<entry>
-											<key>caret-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>column-rule-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
 											<key>float</key>
 											<value xsi:type="xsd:string">left</value>
 										</entry>
 										<entry>
-											<key>font-family</key>
-											<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-										</entry>
-										<entry>
-											<key>font-size</key>
-											<value xsi:type="xsd:string">15px</value>
-										</entry>
-										<entry>
-											<key>line-height</key>
-											<value xsi:type="xsd:string">30px</value>
-										</entry>
-										<entry>
 											<key>min-height</key>
 											<value xsi:type="xsd:string">1px</value>
-										</entry>
-										<entry>
-											<key>outline-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 										</entry>
 										<entry>
 											<key>padding-left</key>
@@ -19685,18 +8499,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 										<entry>
 											<key>position</key>
 											<value xsi:type="xsd:string">relative</value>
-										</entry>
-										<entry>
-											<key>quotes</key>
-											<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-										</entry>
-										<entry>
-											<key>text-decoration-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>unicode-bidi</key>
-											<value xsi:type="xsd:string">isolate</value>
 										</entry>
 									</attributes>
 								</attributes>
@@ -19718,24 +8520,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 									<attributes>
 										<attributes>
 											<entry>
-												<key>background-size</key>
-												<value xsi:type="xsd:string">auto auto</value>
-											</entry>
-											<entry>
 												<key>border-bottom-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-											</entry>
-											<entry>
-												<key>border-image-outset</key>
-												<value xsi:type="xsd:string">0</value>
-											</entry>
-											<entry>
-												<key>border-image-repeat</key>
-												<value xsi:type="xsd:string">stretch stretch</value>
-											</entry>
-											<entry>
-												<key>border-image-width</key>
-												<value xsi:type="xsd:string">1</value>
 											</entry>
 											<entry>
 												<key>border-left-color</key>
@@ -19748,10 +8534,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 											<entry>
 												<key>border-top-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-											</entry>
-											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
 											</entry>
 											<entry>
 												<key>caret-color</key>
@@ -19774,36 +8556,16 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<value xsi:type="xsd:string">18px</value>
 											</entry>
 											<entry>
-												<key>font-weight</key>
-												<value xsi:type="xsd:string">400</value>
-											</entry>
-											<entry>
-												<key>line-height</key>
-												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
 												<key>margin-bottom</key>
 												<value xsi:type="xsd:string">6px</value>
-											</entry>
-											<entry>
-												<key>margin-top</key>
-												<value xsi:type="xsd:string">0px</value>
 											</entry>
 											<entry>
 												<key>outline-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 											</entry>
 											<entry>
-												<key>quotes</key>
-												<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-											</entry>
-											<entry>
 												<key>text-decoration-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-											</entry>
-											<entry>
-												<key>unicode-bidi</key>
-												<value xsi:type="xsd:string">isolate</value>
 											</entry>
 										</attributes>
 									</attributes>
@@ -19830,84 +8592,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 									<attributes>
 										<attributes>
 											<entry>
-												<key>background-size</key>
-												<value xsi:type="xsd:string">auto auto</value>
-											</entry>
-											<entry>
-												<key>border-bottom-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-image-outset</key>
-												<value xsi:type="xsd:string">0</value>
-											</entry>
-											<entry>
-												<key>border-image-repeat</key>
-												<value xsi:type="xsd:string">stretch stretch</value>
-											</entry>
-											<entry>
-												<key>border-left-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-right-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-top-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
-											</entry>
-											<entry>
-												<key>caret-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>column-rule-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>font-family</key>
-												<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-											</entry>
-											<entry>
-												<key>font-size</key>
-												<value xsi:type="xsd:string">15px</value>
-											</entry>
-											<entry>
-												<key>line-height</key>
-												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
 												<key>margin-bottom</key>
 												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
-												<key>margin-top</key>
-												<value xsi:type="xsd:string">0px</value>
-											</entry>
-											<entry>
-												<key>outline-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>quotes</key>
-												<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-											</entry>
-											<entry>
-												<key>text-decoration-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>unicode-bidi</key>
-												<value xsi:type="xsd:string">isolate</value>
 											</entry>
 										</attributes>
 									</attributes>
@@ -19931,42 +8617,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 						<attribute key="type" xsi:type="stringAttribute">HEAD</attribute>
 					</attributes>
 				</identifyingAttributes>
-				<attributes>
-					<attributes>
-						<entry>
-							<key>background-size</key>
-							<value xsi:type="xsd:string">auto auto</value>
-						</entry>
-						<entry>
-							<key>border-image-outset</key>
-							<value xsi:type="xsd:string">0</value>
-						</entry>
-						<entry>
-							<key>border-image-repeat</key>
-							<value xsi:type="xsd:string">stretch stretch</value>
-						</entry>
-						<entry>
-							<key>box-sizing</key>
-							<value xsi:type="xsd:string">border-box</value>
-						</entry>
-						<entry>
-							<key>font-family</key>
-							<value xsi:type="xsd:string">serif</value>
-						</entry>
-						<entry>
-							<key>font-size</key>
-							<value xsi:type="xsd:string">10px</value>
-						</entry>
-						<entry>
-							<key>line-height</key>
-							<value xsi:type="xsd:string">13px</value>
-						</entry>
-						<entry>
-							<key>quotes</key>
-							<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-						</entry>
-					</attributes>
-				</attributes>
+				<attributes/>
 				<containedComponents retestId="link">
 					<identifyingAttributes>
 						<attributes>
@@ -19984,24 +8635,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
 								<key>border-bottom-color</key>
 								<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
 							</entry>
 							<entry>
 								<key>border-left-color</key>
@@ -20016,10 +8651,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
 							</entry>
 							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>caret-color</key>
 								<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
 							</entry>
@@ -20032,24 +8663,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
 							</entry>
 							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">13px</value>
-							</entry>
-							<entry>
 								<key>outline-color</key>
 								<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
 							</entry>
 							<entry>
 								<key>text-decoration-color</key>
@@ -20079,24 +8694,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
 								<key>border-bottom-color</key>
 								<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
 							</entry>
 							<entry>
 								<key>border-left-color</key>
@@ -20111,10 +8710,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
 							</entry>
 							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>caret-color</key>
 								<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
 							</entry>
@@ -20127,24 +8722,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
 							</entry>
 							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">13px</value>
-							</entry>
-							<entry>
 								<key>outline-color</key>
 								<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
 							</entry>
 							<entry>
 								<key>text-decoration-color</key>
@@ -20174,24 +8753,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
 								<key>border-bottom-color</key>
 								<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
 							</entry>
 							<entry>
 								<key>border-left-color</key>
@@ -20206,10 +8769,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
 							</entry>
 							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>caret-color</key>
 								<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
 							</entry>
@@ -20222,24 +8781,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
 							</entry>
 							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">13px</value>
-							</entry>
-							<entry>
 								<key>outline-color</key>
 								<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
 							</entry>
 							<entry>
 								<key>text-decoration-color</key>
@@ -20269,24 +8812,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
 								<key>border-bottom-color</key>
 								<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
 							</entry>
 							<entry>
 								<key>border-left-color</key>
@@ -20301,10 +8828,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
 							</entry>
 							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>caret-color</key>
 								<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
 							</entry>
@@ -20317,24 +8840,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
 							</entry>
 							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">13px</value>
-							</entry>
-							<entry>
 								<key>outline-color</key>
 								<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
 							</entry>
 							<entry>
 								<key>text-decoration-color</key>
@@ -20364,24 +8871,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
 								<key>border-bottom-color</key>
 								<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
 							</entry>
 							<entry>
 								<key>border-left-color</key>
@@ -20396,10 +8887,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
 							</entry>
 							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>caret-color</key>
 								<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
 							</entry>
@@ -20412,24 +8899,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
 							</entry>
 							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">13px</value>
-							</entry>
-							<entry>
 								<key>outline-color</key>
 								<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
 							</entry>
 							<entry>
 								<key>text-decoration-color</key>
@@ -20459,24 +8930,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
 								<key>border-bottom-color</key>
 								<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
 							</entry>
 							<entry>
 								<key>border-left-color</key>
@@ -20491,10 +8946,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
 							</entry>
 							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>caret-color</key>
 								<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
 							</entry>
@@ -20507,24 +8958,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
 							</entry>
 							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">13px</value>
-							</entry>
-							<entry>
 								<key>outline-color</key>
 								<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
 							</entry>
 							<entry>
 								<key>text-decoration-color</key>
@@ -20554,24 +8989,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
 								<key>border-bottom-color</key>
 								<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
 							</entry>
 							<entry>
 								<key>border-left-color</key>
@@ -20586,10 +9005,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
 							</entry>
 							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>caret-color</key>
 								<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
 							</entry>
@@ -20602,24 +9017,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
 							</entry>
 							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">13px</value>
-							</entry>
-							<entry>
 								<key>outline-color</key>
 								<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
 							</entry>
 							<entry>
 								<key>text-decoration-color</key>
@@ -20649,24 +9048,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
 								<key>border-bottom-color</key>
 								<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
 							</entry>
 							<entry>
 								<key>border-left-color</key>
@@ -20681,10 +9064,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
 							</entry>
 							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>caret-color</key>
 								<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
 							</entry>
@@ -20697,24 +9076,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
 							</entry>
 							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">13px</value>
-							</entry>
-							<entry>
 								<key>outline-color</key>
 								<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
 							</entry>
 							<entry>
 								<key>text-decoration-color</key>
@@ -20745,48 +9108,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">Initial informations about retest</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">13px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -20809,48 +9132,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">2018</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">13px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -20873,48 +9156,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">© 2018 Jeremias Rößler</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">13px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -20936,48 +9179,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">retest</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">13px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -20999,48 +9202,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">website</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">13px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -21062,48 +9225,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">https://www.retest.de</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">13px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -21125,48 +9248,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">https://www.retest.de/images/logo.png</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">13px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -21189,48 +9272,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">width=device-width, initial-scale=1, maximum-scale=1</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">13px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -21252,48 +9295,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">text/html; charset=UTF-8</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">13px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -21316,48 +9319,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">retest - Java Swing GUI Testing. An innovative approach with artificially intelligent monkey testing.</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">13px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -21380,48 +9343,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">Jeremias Rößler</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">13px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -21444,48 +9367,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">index, follow</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">13px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -21507,48 +9390,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">no-cache</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">13px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -21570,48 +9413,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">3600</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">13px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -21633,48 +9436,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">3600</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">13px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -21696,48 +9459,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">de_DE</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">13px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -21760,48 +9483,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">Jeremias Rößler</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">13px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -21821,46 +9504,11 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">TITLE</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">13px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 			</containedComponents>
 			<screenshot>
-				<persistenceId>window_36d31f5f0d656d380f131db3319b16303862393896b6a3ec3e22a7583c00a016</persistenceId>
+				<persistenceId>window_49ac64cd07020594a384a0b3a24a889025f74dd8ed49e0fbec76aba01d44bcbd</persistenceId>
 				<type>PNG</type>
 			</screenshot>
 		</descriptors>

--- a/src/test/resources/retest/recheck/de.retest.web.SimplePageIT/simple-page-ChromeDriver.open.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.SimplePageIT/simple-page-ChromeDriver.open.recheck/retest.xml
@@ -557,50 +557,7 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 									<attribute key="type" xsi:type="stringAttribute">B</attribute>
 								</attributes>
 							</identifyingAttributes>
-							<attributes>
-								<attributes>
-									<entry>
-										<key>border-bottom-color</key>
-										<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-									</entry>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>border-left-color</key>
-										<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-									</entry>
-									<entry>
-										<key>border-right-color</key>
-										<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-									</entry>
-									<entry>
-										<key>border-top-color</key>
-										<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-									</entry>
-									<entry>
-										<key>caret-color</key>
-										<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-									</entry>
-									<entry>
-										<key>color</key>
-										<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-									</entry>
-									<entry>
-										<key>column-rule-color</key>
-										<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-									</entry>
-									<entry>
-										<key>outline-color</key>
-										<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-									</entry>
-									<entry>
-										<key>text-decoration-color</key>
-										<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-									</entry>
-								</attributes>
-							</attributes>
+							<attributes/>
 						</containedComponents>
 					</containedComponents>
 					<containedComponents retestId="link_with_double">
@@ -696,14 +653,7 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 								<attribute key="type" xsi:type="stringAttribute">A</attribute>
 							</attributes>
 						</identifyingAttributes>
-						<attributes>
-							<attributes>
-								<entry>
-									<key>text-indent</key>
-									<value xsi:type="xsd:string">80%</value>
-								</entry>
-							</attributes>
-						</attributes>
+						<attributes/>
 						<containedComponents retestId="br">
 							<identifyingAttributes>
 								<attributes>
@@ -718,50 +668,7 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 									<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 								</attributes>
 							</identifyingAttributes>
-							<attributes>
-								<attributes>
-									<entry>
-										<key>border-bottom-color</key>
-										<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-									</entry>
-									<entry>
-										<key>border-left-color</key>
-										<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-									</entry>
-									<entry>
-										<key>border-right-color</key>
-										<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-									</entry>
-									<entry>
-										<key>border-top-color</key>
-										<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-									</entry>
-									<entry>
-										<key>caret-color</key>
-										<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-									</entry>
-									<entry>
-										<key>color</key>
-										<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-									</entry>
-									<entry>
-										<key>column-rule-color</key>
-										<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-									</entry>
-									<entry>
-										<key>outline-color</key>
-										<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-									</entry>
-									<entry>
-										<key>text-decoration-color</key>
-										<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-									</entry>
-									<entry>
-										<key>text-indent</key>
-										<value xsi:type="xsd:string">80%</value>
-									</entry>
-								</attributes>
-							</attributes>
+							<attributes/>
 						</containedComponents>
 					</containedComponents>
 				</containedComponents>
@@ -1280,10 +1187,6 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 											<key>padding-top</key>
 											<value xsi:type="xsd:string">1px</value>
 										</entry>
-										<entry>
-											<key>vertical-align</key>
-											<value xsi:type="xsd:string">middle</value>
-										</entry>
 									</attributes>
 								</attributes>
 								<containedComponents retestId="beforespace">
@@ -1301,14 +1204,7 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 											<attribute key="type" xsi:type="stringAttribute">SPAN</attribute>
 										</attributes>
 									</identifyingAttributes>
-									<attributes>
-										<attributes>
-											<entry>
-												<key>border-spacing</key>
-												<value xsi:type="xsd:string">2px 2px</value>
-											</entry>
-										</attributes>
-									</attributes>
+									<attributes/>
 								</containedComponents>
 								<containedComponents retestId="span">
 									<identifyingAttributes>
@@ -1324,14 +1220,7 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 											<attribute key="type" xsi:type="stringAttribute">SPAN</attribute>
 										</attributes>
 									</identifyingAttributes>
-									<attributes>
-										<attributes>
-											<entry>
-												<key>border-spacing</key>
-												<value xsi:type="xsd:string">2px 2px</value>
-											</entry>
-										</attributes>
-									</attributes>
+									<attributes/>
 								</containedComponents>
 								<containedComponents retestId="afterspace">
 									<identifyingAttributes>
@@ -1348,14 +1237,7 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 											<attribute key="type" xsi:type="stringAttribute">SPAN</attribute>
 										</attributes>
 									</identifyingAttributes>
-									<attributes>
-										<attributes>
-											<entry>
-												<key>border-spacing</key>
-												<value xsi:type="xsd:string">2px 2px</value>
-											</entry>
-										</attributes>
-									</attributes>
+									<attributes/>
 								</containedComponents>
 							</containedComponents>
 						</containedComponents>
@@ -1395,6 +1277,10 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 					<attributes/>
 				</containedComponents>
 			</containedComponents>
+			<screenshot>
+				<persistenceId>window_28cf475cece91d84ef7e883d8106baac7747419209c8218b6cd24aa0fb6750a3</persistenceId>
+				<type>PNG</type>
+			</screenshot>
 		</descriptors>
 	</data>
 </reTestXmlDataContainer>

--- a/src/test/resources/retest/recheck/de.retest.web.SimplePageIT/simple-page-FirefoxDriver.open.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.SimplePageIT/simple-page-FirefoxDriver.open.recheck/retest.xml
@@ -62,38 +62,7 @@
 						<attribute key="type" xsi:type="stringAttribute">BODY</attribute>
 					</attributes>
 				</identifyingAttributes>
-				<attributes>
-					<attributes>
-						<entry>
-							<key>background-size</key>
-							<value xsi:type="xsd:string">auto auto</value>
-						</entry>
-						<entry>
-							<key>border-image-outset</key>
-							<value xsi:type="xsd:string">0</value>
-						</entry>
-						<entry>
-							<key>border-image-repeat</key>
-							<value xsi:type="xsd:string">stretch stretch</value>
-						</entry>
-						<entry>
-							<key>font-family</key>
-							<value xsi:type="xsd:string">serif</value>
-						</entry>
-						<entry>
-							<key>line-height</key>
-							<value xsi:type="xsd:string">19px</value>
-						</entry>
-						<entry>
-							<key>quotes</key>
-							<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-						</entry>
-						<entry>
-							<key>unicode-bidi</key>
-							<value xsi:type="xsd:string">isolate</value>
-						</entry>
-					</attributes>
-				</attributes>
+				<attributes/>
 				<containedComponents retestId="a_link_to_an_icon">
 					<identifyingAttributes>
 						<attributes>
@@ -110,34 +79,7 @@
 							<attribute key="type" xsi:type="stringAttribute">A</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">19px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="div">
 					<identifyingAttributes>
@@ -154,38 +96,7 @@
 							<attribute key="type" xsi:type="stringAttribute">DIV</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">19px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>unicode-bidi</key>
-								<value xsi:type="xsd:string">isolate</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 					<containedComponents retestId="nested">
 						<identifyingAttributes>
 							<attributes>
@@ -202,38 +113,7 @@
 								<attribute key="type" xsi:type="stringAttribute">DIV</attribute>
 							</attributes>
 						</identifyingAttributes>
-						<attributes>
-							<attributes>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">serif</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">19px</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
-									<key>unicode-bidi</key>
-									<value xsi:type="xsd:string">isolate</value>
-								</entry>
-							</attributes>
-						</attributes>
+						<attributes/>
 					</containedComponents>
 				</containedComponents>
 				<containedComponents retestId="div">
@@ -251,38 +131,7 @@
 							<attribute key="type" xsi:type="stringAttribute">DIV</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">19px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>unicode-bidi</key>
-								<value xsi:type="xsd:string">isolate</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 					<containedComponents retestId="br">
 						<identifyingAttributes>
 							<attributes>
@@ -297,34 +146,7 @@
 								<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 							</attributes>
 						</identifyingAttributes>
-						<attributes>
-							<attributes>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">serif</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">19px</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-							</attributes>
-						</attributes>
+						<attributes/>
 					</containedComponents>
 					<containedComponents retestId="and_block_level">
 						<identifyingAttributes>
@@ -341,38 +163,7 @@
 								<attribute key="type" xsi:type="stringAttribute">DIV</attribute>
 							</attributes>
 						</identifyingAttributes>
-						<attributes>
-							<attributes>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">serif</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">19px</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
-									<key>unicode-bidi</key>
-									<value xsi:type="xsd:string">isolate</value>
-								</entry>
-							</attributes>
-						</attributes>
+						<attributes/>
 					</containedComponents>
 					<containedComponents retestId="a_div_containing">
 						<identifyingAttributes>
@@ -389,38 +180,7 @@
 								<attribute key="type" xsi:type="stringAttribute">P</attribute>
 							</attributes>
 						</identifyingAttributes>
-						<attributes>
-							<attributes>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">serif</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">19px</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
-									<key>unicode-bidi</key>
-									<value xsi:type="xsd:string">isolate</value>
-								</entry>
-							</attributes>
-						</attributes>
+						<attributes/>
 					</containedComponents>
 				</containedComponents>
 				<containedComponents retestId="div">
@@ -438,38 +198,7 @@
 							<attribute key="type" xsi:type="stringAttribute">DIV</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">19px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>unicode-bidi</key>
-								<value xsi:type="xsd:string">isolate</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 					<containedComponents retestId="this_section">
 						<identifyingAttributes>
 							<attributes>
@@ -491,18 +220,6 @@
 						<attributes>
 							<attributes>
 								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
 									<key>line-height</key>
 									<value xsi:type="xsd:string">15px</value>
 								</entry>
@@ -517,14 +234,6 @@
 								<entry>
 									<key>margin-top</key>
 									<value xsi:type="xsd:string">12px</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
-									<key>unicode-bidi</key>
-									<value xsi:type="xsd:string">isolate</value>
 								</entry>
 							</attributes>
 						</attributes>
@@ -544,38 +253,7 @@
 								<attribute key="type" xsi:type="stringAttribute">P</attribute>
 							</attributes>
 						</identifyingAttributes>
-						<attributes>
-							<attributes>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">serif</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">19px</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
-									<key>unicode-bidi</key>
-									<value xsi:type="xsd:string">isolate</value>
-								</entry>
-							</attributes>
-						</attributes>
+						<attributes/>
 					</containedComponents>
 					<containedComponents retestId="after_pre">
 						<identifyingAttributes>
@@ -592,38 +270,7 @@
 								<attribute key="type" xsi:type="stringAttribute">P</attribute>
 							</attributes>
 						</identifyingAttributes>
-						<attributes>
-							<attributes>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">serif</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">19px</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
-									<key>unicode-bidi</key>
-									<value xsi:type="xsd:string">isolate</value>
-								</entry>
-							</attributes>
-						</attributes>
+						<attributes/>
 					</containedComponents>
 				</containedComponents>
 				<containedComponents retestId="div">
@@ -641,38 +288,7 @@
 							<attribute key="type" xsi:type="stringAttribute">DIV</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">19px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>unicode-bidi</key>
-								<value xsi:type="xsd:string">isolate</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 					<containedComponents retestId="some_text">
 						<identifyingAttributes>
 							<attributes>
@@ -688,38 +304,7 @@
 								<attribute key="type" xsi:type="stringAttribute">P</attribute>
 							</attributes>
 						</identifyingAttributes>
-						<attributes>
-							<attributes>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">serif</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">19px</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
-									<key>unicode-bidi</key>
-									<value xsi:type="xsd:string">isolate</value>
-								</entry>
-							</attributes>
-						</attributes>
+						<attributes/>
 					</containedComponents>
 					<containedComponents retestId="some_more_text">
 						<identifyingAttributes>
@@ -736,38 +321,7 @@
 								<attribute key="type" xsi:type="stringAttribute">P</attribute>
 							</attributes>
 						</identifyingAttributes>
-						<attributes>
-							<attributes>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">serif</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">19px</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
-									<key>unicode-bidi</key>
-									<value xsi:type="xsd:string">isolate</value>
-								</entry>
-							</attributes>
-						</attributes>
+						<attributes/>
 					</containedComponents>
 				</containedComponents>
 				<containedComponents retestId="cheese">
@@ -786,38 +340,7 @@
 							<attribute key="type" xsi:type="stringAttribute">DIV</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">19px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>unicode-bidi</key>
-								<value xsi:type="xsd:string">isolate</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 					<containedComponents retestId="div">
 						<identifyingAttributes>
 							<attributes>
@@ -832,38 +355,7 @@
 								<attribute key="type" xsi:type="stringAttribute">DIV</attribute>
 							</attributes>
 						</identifyingAttributes>
-						<attributes>
-							<attributes>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">serif</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">19px</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
-									<key>unicode-bidi</key>
-									<value xsi:type="xsd:string">isolate</value>
-								</entry>
-							</attributes>
-						</attributes>
+						<attributes/>
 						<containedComponents retestId="div">
 							<identifyingAttributes>
 								<attributes>
@@ -878,38 +370,7 @@
 									<attribute key="type" xsi:type="stringAttribute">DIV</attribute>
 								</attributes>
 							</identifyingAttributes>
-							<attributes>
-								<attributes>
-									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">serif</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">19px</value>
-									</entry>
-									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
-										<key>unicode-bidi</key>
-										<value xsi:type="xsd:string">isolate</value>
-									</entry>
-								</attributes>
-							</attributes>
+							<attributes/>
 							<containedComponents retestId="some_more_text">
 								<identifyingAttributes>
 									<attributes>
@@ -925,38 +386,7 @@
 										<attribute key="type" xsi:type="stringAttribute">P</attribute>
 									</attributes>
 								</identifyingAttributes>
-								<attributes>
-									<attributes>
-										<entry>
-											<key>background-size</key>
-											<value xsi:type="xsd:string">auto auto</value>
-										</entry>
-										<entry>
-											<key>border-image-outset</key>
-											<value xsi:type="xsd:string">0</value>
-										</entry>
-										<entry>
-											<key>border-image-repeat</key>
-											<value xsi:type="xsd:string">stretch stretch</value>
-										</entry>
-										<entry>
-											<key>font-family</key>
-											<value xsi:type="xsd:string">serif</value>
-										</entry>
-										<entry>
-											<key>line-height</key>
-											<value xsi:type="xsd:string">19px</value>
-										</entry>
-										<entry>
-											<key>quotes</key>
-											<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-										</entry>
-										<entry>
-											<key>unicode-bidi</key>
-											<value xsi:type="xsd:string">isolate</value>
-										</entry>
-									</attributes>
-								</attributes>
+								<attributes/>
 							</containedComponents>
 							<containedComponents retestId="and_also">
 								<identifyingAttributes>
@@ -973,38 +403,7 @@
 										<attribute key="type" xsi:type="stringAttribute">P</attribute>
 									</attributes>
 								</identifyingAttributes>
-								<attributes>
-									<attributes>
-										<entry>
-											<key>background-size</key>
-											<value xsi:type="xsd:string">auto auto</value>
-										</entry>
-										<entry>
-											<key>border-image-outset</key>
-											<value xsi:type="xsd:string">0</value>
-										</entry>
-										<entry>
-											<key>border-image-repeat</key>
-											<value xsi:type="xsd:string">stretch stretch</value>
-										</entry>
-										<entry>
-											<key>font-family</key>
-											<value xsi:type="xsd:string">serif</value>
-										</entry>
-										<entry>
-											<key>line-height</key>
-											<value xsi:type="xsd:string">19px</value>
-										</entry>
-										<entry>
-											<key>quotes</key>
-											<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-										</entry>
-										<entry>
-											<key>unicode-bidi</key>
-											<value xsi:type="xsd:string">isolate</value>
-										</entry>
-									</attributes>
-								</attributes>
+								<attributes/>
 							</containedComponents>
 						</containedComponents>
 						<containedComponents retestId="some_text">
@@ -1022,38 +421,7 @@
 									<attribute key="type" xsi:type="stringAttribute">P</attribute>
 								</attributes>
 							</identifyingAttributes>
-							<attributes>
-								<attributes>
-									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">serif</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">19px</value>
-									</entry>
-									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
-										<key>unicode-bidi</key>
-										<value xsi:type="xsd:string">isolate</value>
-									</entry>
-								</attributes>
-							</attributes>
+							<attributes/>
 						</containedComponents>
 					</containedComponents>
 				</containedComponents>
@@ -1072,38 +440,7 @@
 							<attribute key="type" xsi:type="stringAttribute">DIV</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">19px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>unicode-bidi</key>
-								<value xsi:type="xsd:string">isolate</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 					<containedComponents retestId="hello_world">
 						<identifyingAttributes>
 							<attributes>
@@ -1119,38 +456,7 @@
 								<attribute key="type" xsi:type="stringAttribute">DIV</attribute>
 							</attributes>
 						</identifyingAttributes>
-						<attributes>
-							<attributes>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">serif</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">19px</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
-									<key>unicode-bidi</key>
-									<value xsi:type="xsd:string">isolate</value>
-								</entry>
-							</attributes>
-						</attributes>
+						<attributes/>
 					</containedComponents>
 					<containedComponents retestId="span">
 						<identifyingAttributes>
@@ -1166,34 +472,7 @@
 								<attribute key="type" xsi:type="stringAttribute">SPAN</attribute>
 							</attributes>
 						</identifyingAttributes>
-						<attributes>
-							<attributes>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">serif</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">19px</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-							</attributes>
-						</attributes>
+						<attributes/>
 					</containedComponents>
 					<containedComponents retestId="span">
 						<identifyingAttributes>
@@ -1209,34 +488,7 @@
 								<attribute key="type" xsi:type="stringAttribute">SPAN</attribute>
 							</attributes>
 						</identifyingAttributes>
-						<attributes>
-							<attributes>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">serif</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">19px</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-							</attributes>
-						</attributes>
+						<attributes/>
 					</containedComponents>
 				</containedComponents>
 				<containedComponents retestId="div">
@@ -1254,38 +506,7 @@
 							<attribute key="type" xsi:type="stringAttribute">DIV</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">19px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>unicode-bidi</key>
-								<value xsi:type="xsd:string">isolate</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 					<containedComponents retestId="documentwritewith">
 						<identifyingAttributes>
 							<attributes>
@@ -1302,34 +523,7 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 								<attribute key="type" xsi:type="stringAttribute">SCRIPT</attribute>
 							</attributes>
 						</identifyingAttributes>
-						<attributes>
-							<attributes>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">serif</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">19px</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-							</attributes>
-						</attributes>
+						<attributes/>
 					</containedComponents>
 				</containedComponents>
 				<containedComponents retestId="div">
@@ -1347,38 +541,7 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 							<attribute key="type" xsi:type="stringAttribute">DIV</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">19px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>unicode-bidi</key>
-								<value xsi:type="xsd:string">isolate</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 					<containedComponents retestId="link_with_leadi">
 						<identifyingAttributes>
 							<attributes>
@@ -1394,34 +557,7 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 								<attribute key="type" xsi:type="stringAttribute">A</attribute>
 							</attributes>
 						</identifyingAttributes>
-						<attributes>
-							<attributes>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">serif</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">19px</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-							</attributes>
-						</attributes>
+						<attributes/>
 					</containedComponents>
 					<containedComponents retestId="link_with_trail">
 						<identifyingAttributes>
@@ -1439,34 +575,7 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 								<attribute key="type" xsi:type="stringAttribute">A</attribute>
 							</attributes>
 						</identifyingAttributes>
-						<attributes>
-							<attributes>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">serif</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">19px</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-							</attributes>
-						</attributes>
+						<attributes/>
 					</containedComponents>
 					<containedComponents retestId="a">
 						<identifyingAttributes>
@@ -1482,34 +591,7 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 								<attribute key="type" xsi:type="stringAttribute">A</attribute>
 							</attributes>
 						</identifyingAttributes>
-						<attributes>
-							<attributes>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">serif</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">19px</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-							</attributes>
-						</attributes>
+						<attributes/>
 						<containedComponents retestId="link_with_forma">
 							<identifyingAttributes>
 								<attributes>
@@ -1528,68 +610,8 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 							<attributes>
 								<attributes>
 									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
-										<key>border-bottom-color</key>
-										<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>border-left-color</key>
-										<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-									</entry>
-									<entry>
-										<key>border-right-color</key>
-										<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-									</entry>
-									<entry>
-										<key>border-top-color</key>
-										<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-									</entry>
-									<entry>
-										<key>caret-color</key>
-										<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-									</entry>
-									<entry>
-										<key>color</key>
-										<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-									</entry>
-									<entry>
-										<key>column-rule-color</key>
-										<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">serif</value>
-									</entry>
-									<entry>
 										<key>line-height</key>
 										<value xsi:type="xsd:string">20px</value>
-									</entry>
-									<entry>
-										<key>outline-color</key>
-										<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-									</entry>
-									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
-										<key>text-decoration-color</key>
-										<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
 									</entry>
 								</attributes>
 							</attributes>
@@ -1611,34 +633,7 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 								<attribute key="type" xsi:type="stringAttribute">A</attribute>
 							</attributes>
 						</identifyingAttributes>
-						<attributes>
-							<attributes>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">serif</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">19px</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-							</attributes>
-						</attributes>
+						<attributes/>
 					</containedComponents>
 					<containedComponents retestId="link_with_single">
 						<identifyingAttributes>
@@ -1656,34 +651,7 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 								<attribute key="type" xsi:type="stringAttribute">A</attribute>
 							</attributes>
 						</identifyingAttributes>
-						<attributes>
-							<attributes>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">serif</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">19px</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-							</attributes>
-						</attributes>
+						<attributes/>
 					</containedComponents>
 					<containedComponents retestId="link_with_backs">
 						<identifyingAttributes>
@@ -1701,34 +669,7 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 								<attribute key="type" xsi:type="stringAttribute">A</attribute>
 							</attributes>
 						</identifyingAttributes>
-						<attributes>
-							<attributes>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">serif</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">19px</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-							</attributes>
-						</attributes>
+						<attributes/>
 					</containedComponents>
 				</containedComponents>
 				<containedComponents retestId="div">
@@ -1748,36 +689,8 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 					<attributes>
 						<attributes>
 							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">19px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
 								<key>text-indent</key>
 								<value xsi:type="xsd:string">80%</value>
-							</entry>
-							<entry>
-								<key>unicode-bidi</key>
-								<value xsi:type="xsd:string">isolate</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -1797,38 +710,7 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 								<attribute key="type" xsi:type="stringAttribute">A</attribute>
 							</attributes>
 						</identifyingAttributes>
-						<attributes>
-							<attributes>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">serif</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">19px</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
-									<key>text-indent</key>
-									<value xsi:type="xsd:string">80%</value>
-								</entry>
-							</attributes>
-						</attributes>
+						<attributes/>
 						<containedComponents retestId="br">
 							<identifyingAttributes>
 								<attributes>
@@ -1843,74 +725,7 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 									<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 								</attributes>
 							</identifyingAttributes>
-							<attributes>
-								<attributes>
-									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
-										<key>border-bottom-color</key>
-										<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>border-left-color</key>
-										<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-									</entry>
-									<entry>
-										<key>border-right-color</key>
-										<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-									</entry>
-									<entry>
-										<key>border-top-color</key>
-										<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-									</entry>
-									<entry>
-										<key>caret-color</key>
-										<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-									</entry>
-									<entry>
-										<key>color</key>
-										<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-									</entry>
-									<entry>
-										<key>column-rule-color</key>
-										<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">serif</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">19px</value>
-									</entry>
-									<entry>
-										<key>outline-color</key>
-										<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-									</entry>
-									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
-										<key>text-decoration-color</key>
-										<value xsi:type="xsd:string">rgb(0, 0, 238)</value>
-									</entry>
-									<entry>
-										<key>text-indent</key>
-										<value xsi:type="xsd:string">80%</value>
-									</entry>
-								</attributes>
-							</attributes>
+							<attributes/>
 						</containedComponents>
 					</containedComponents>
 				</containedComponents>
@@ -1930,38 +745,7 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 							<attribute key="type" xsi:type="stringAttribute">DIV</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">19px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>unicode-bidi</key>
-								<value xsi:type="xsd:string">isolate</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="form">
 					<identifyingAttributes>
@@ -1977,38 +761,7 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 							<attribute key="type" xsi:type="stringAttribute">FORM</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">19px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>unicode-bidi</key>
-								<value xsi:type="xsd:string">isolate</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 					<containedComponents retestId="p">
 						<identifyingAttributes>
 							<attributes>
@@ -2023,38 +776,7 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 								<attribute key="type" xsi:type="stringAttribute">P</attribute>
 							</attributes>
 						</identifyingAttributes>
-						<attributes>
-							<attributes>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">serif</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">19px</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
-									<key>unicode-bidi</key>
-									<value xsi:type="xsd:string">isolate</value>
-								</entry>
-							</attributes>
-						</attributes>
+						<attributes/>
 						<containedComponents retestId="input">
 							<identifyingAttributes>
 								<attributes>
@@ -2072,18 +794,6 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 							</identifyingAttributes>
 							<attributes>
 								<attributes>
-									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
 									<entry>
 										<key>font-family</key>
 										<value xsi:type="xsd:string">sans-serif</value>
@@ -2104,10 +814,6 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 										<key>margin-right</key>
 										<value xsi:type="xsd:string">3px</value>
 									</entry>
-									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
 								</attributes>
 							</attributes>
 						</containedComponents>
@@ -2127,34 +833,7 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 									<attribute key="type" xsi:type="stringAttribute">LABEL</attribute>
 								</attributes>
 							</identifyingAttributes>
-							<attributes>
-								<attributes>
-									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">serif</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">19px</value>
-									</entry>
-									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-								</attributes>
-							</attributes>
+							<attributes/>
 							<containedComponents retestId="br">
 								<identifyingAttributes>
 									<attributes>
@@ -2169,34 +848,7 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 										<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 									</attributes>
 								</identifyingAttributes>
-								<attributes>
-									<attributes>
-										<entry>
-											<key>background-size</key>
-											<value xsi:type="xsd:string">auto auto</value>
-										</entry>
-										<entry>
-											<key>border-image-outset</key>
-											<value xsi:type="xsd:string">0</value>
-										</entry>
-										<entry>
-											<key>border-image-repeat</key>
-											<value xsi:type="xsd:string">stretch stretch</value>
-										</entry>
-										<entry>
-											<key>font-family</key>
-											<value xsi:type="xsd:string">serif</value>
-										</entry>
-										<entry>
-											<key>line-height</key>
-											<value xsi:type="xsd:string">19px</value>
-										</entry>
-										<entry>
-											<key>quotes</key>
-											<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-										</entry>
-									</attributes>
-								</attributes>
+								<attributes/>
 							</containedComponents>
 						</containedComponents>
 					</containedComponents>
@@ -2219,22 +871,6 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 					<attributes>
 						<attributes>
 							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
 								<key>line-height</key>
 								<value xsi:type="xsd:string">39px</value>
 							</entry>
@@ -2245,14 +881,6 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 							<entry>
 								<key>margin-top</key>
 								<value xsi:type="xsd:string">0px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>unicode-bidi</key>
-								<value xsi:type="xsd:string">isolate</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -2272,34 +900,7 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 							<attribute key="type" xsi:type="stringAttribute">IMG</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">19px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="img">
 					<identifyingAttributes>
@@ -2316,34 +917,7 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 							<attribute key="type" xsi:type="stringAttribute">IMG</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">19px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="a_single_line">
 					<identifyingAttributes>
@@ -2361,38 +935,7 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 							<attribute key="type" xsi:type="stringAttribute">P</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">19px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>unicode-bidi</key>
-								<value xsi:type="xsd:string">isolate</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="a_hidden_line">
 					<identifyingAttributes>
@@ -2412,34 +955,6 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 					</identifyingAttributes>
 					<attributes>
 						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">19px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>unicode-bidi</key>
-								<value xsi:type="xsd:string">isolate</value>
-							</entry>
 							<entry>
 								<key>visibility</key>
 								<value xsi:type="xsd:string">hidden</value>
@@ -2465,38 +980,7 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 							<attribute key="type" xsi:type="stringAttribute">P</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">19px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>unicode-bidi</key>
-								<value xsi:type="xsd:string">isolate</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="this_line_has">
 					<identifyingAttributes>
@@ -2514,38 +998,7 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 							<attribute key="type" xsi:type="stringAttribute">P</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">19px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>unicode-bidi</key>
-								<value xsi:type="xsd:string">isolate</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="this_line_has">
 					<identifyingAttributes>
@@ -2563,38 +1016,7 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 							<attribute key="type" xsi:type="stringAttribute">P</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">19px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>unicode-bidi</key>
-								<value xsi:type="xsd:string">isolate</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="these_lines_">
 					<identifyingAttributes>
@@ -2612,38 +1034,7 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 							<attribute key="type" xsi:type="stringAttribute">P</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">19px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>unicode-bidi</key>
-								<value xsi:type="xsd:string">isolate</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 					<containedComponents retestId="br">
 						<identifyingAttributes>
 							<attributes>
@@ -2658,34 +1049,7 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 								<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 							</attributes>
 						</identifyingAttributes>
-						<attributes>
-							<attributes>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">serif</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">19px</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-							</attributes>
-						</attributes>
+						<attributes/>
 					</containedComponents>
 				</containedComponents>
 				<containedComponents retestId="this">
@@ -2704,38 +1068,7 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 							<attribute key="type" xsi:type="stringAttribute">P</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">19px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>unicode-bidi</key>
-								<value xsi:type="xsd:string">isolate</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 					<containedComponents retestId="line_has">
 						<identifyingAttributes>
 							<attributes>
@@ -2752,34 +1085,7 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 								<attribute key="type" xsi:type="stringAttribute">SPAN</attribute>
 							</attributes>
 						</identifyingAttributes>
-						<attributes>
-							<attributes>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">serif</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">19px</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-							</attributes>
-						</attributes>
+						<attributes/>
 						<containedComponents retestId="text">
 							<identifyingAttributes>
 								<attributes>
@@ -2795,34 +1101,7 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 									<attribute key="type" xsi:type="stringAttribute">EM</attribute>
 								</attributes>
 							</identifyingAttributes>
-							<attributes>
-								<attributes>
-									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">serif</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">19px</value>
-									</entry>
-									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-								</attributes>
-							</attributes>
+							<attributes/>
 						</containedComponents>
 					</containedComponents>
 				</containedComponents>
@@ -2842,34 +1121,7 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 							<attribute key="type" xsi:type="stringAttribute">SPAN</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">19px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="ab_c1_dtrue">
 					<identifyingAttributes>
@@ -2887,34 +1139,7 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 							<attribute key="type" xsi:type="stringAttribute">SPAN</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">19px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="ab">
 					<identifyingAttributes>
@@ -2932,34 +1157,7 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 							<attribute key="type" xsi:type="stringAttribute">SPAN</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">19px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="test_">
 					<identifyingAttributes>
@@ -2977,34 +1175,7 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 							<attribute key="type" xsi:type="stringAttribute">SPAN</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">19px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="table">
 					<identifyingAttributes>
@@ -3024,36 +1195,8 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 					<attributes>
 						<attributes>
 							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
 								<key>box-sizing</key>
 								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">19px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-							<entry>
-								<key>unicode-bidi</key>
-								<value xsi:type="xsd:string">isolate</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -3071,38 +1214,7 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 								<attribute key="type" xsi:type="stringAttribute">TBODY</attribute>
 							</attributes>
 						</identifyingAttributes>
-						<attributes>
-							<attributes>
-								<entry>
-									<key>background-size</key>
-									<value xsi:type="xsd:string">auto auto</value>
-								</entry>
-								<entry>
-									<key>border-image-outset</key>
-									<value xsi:type="xsd:string">0</value>
-								</entry>
-								<entry>
-									<key>border-image-repeat</key>
-									<value xsi:type="xsd:string">stretch stretch</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">serif</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">19px</value>
-								</entry>
-								<entry>
-									<key>quotes</key>
-									<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-								</entry>
-								<entry>
-									<key>unicode-bidi</key>
-									<value xsi:type="xsd:string">isolate</value>
-								</entry>
-							</attributes>
-						</attributes>
+						<attributes/>
 						<containedComponents retestId="tr">
 							<identifyingAttributes>
 								<attributes>
@@ -3117,38 +1229,7 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 									<attribute key="type" xsi:type="stringAttribute">TR</attribute>
 								</attributes>
 							</identifyingAttributes>
-							<attributes>
-								<attributes>
-									<entry>
-										<key>background-size</key>
-										<value xsi:type="xsd:string">auto auto</value>
-									</entry>
-									<entry>
-										<key>border-image-outset</key>
-										<value xsi:type="xsd:string">0</value>
-									</entry>
-									<entry>
-										<key>border-image-repeat</key>
-										<value xsi:type="xsd:string">stretch stretch</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">serif</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">19px</value>
-									</entry>
-									<entry>
-										<key>quotes</key>
-										<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-									</entry>
-									<entry>
-										<key>unicode-bidi</key>
-										<value xsi:type="xsd:string">isolate</value>
-									</entry>
-								</attributes>
-							</attributes>
+							<attributes/>
 							<containedComponents retestId="td">
 								<identifyingAttributes>
 									<attributes>
@@ -3166,42 +1247,6 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 								<attributes>
 									<attributes>
 										<entry>
-											<key>background-size</key>
-											<value xsi:type="xsd:string">auto auto</value>
-										</entry>
-										<entry>
-											<key>border-bottom-color</key>
-											<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-										</entry>
-										<entry>
-											<key>border-image-outset</key>
-											<value xsi:type="xsd:string">0</value>
-										</entry>
-										<entry>
-											<key>border-image-repeat</key>
-											<value xsi:type="xsd:string">stretch stretch</value>
-										</entry>
-										<entry>
-											<key>border-left-color</key>
-											<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-										</entry>
-										<entry>
-											<key>border-right-color</key>
-											<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-										</entry>
-										<entry>
-											<key>border-top-color</key>
-											<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-										</entry>
-										<entry>
-											<key>font-family</key>
-											<value xsi:type="xsd:string">serif</value>
-										</entry>
-										<entry>
-											<key>line-height</key>
-											<value xsi:type="xsd:string">19px</value>
-										</entry>
-										<entry>
 											<key>padding-bottom</key>
 											<value xsi:type="xsd:string">1px</value>
 										</entry>
@@ -3216,18 +1261,6 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 										<entry>
 											<key>padding-top</key>
 											<value xsi:type="xsd:string">1px</value>
-										</entry>
-										<entry>
-											<key>quotes</key>
-											<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-										</entry>
-										<entry>
-											<key>unicode-bidi</key>
-											<value xsi:type="xsd:string">isolate</value>
-										</entry>
-										<entry>
-											<key>vertical-align</key>
-											<value xsi:type="xsd:string">middle</value>
 										</entry>
 									</attributes>
 								</attributes>
@@ -3246,38 +1279,7 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 											<attribute key="type" xsi:type="stringAttribute">SPAN</attribute>
 										</attributes>
 									</identifyingAttributes>
-									<attributes>
-										<attributes>
-											<entry>
-												<key>background-size</key>
-												<value xsi:type="xsd:string">auto auto</value>
-											</entry>
-											<entry>
-												<key>border-image-outset</key>
-												<value xsi:type="xsd:string">0</value>
-											</entry>
-											<entry>
-												<key>border-image-repeat</key>
-												<value xsi:type="xsd:string">stretch stretch</value>
-											</entry>
-											<entry>
-												<key>border-spacing</key>
-												<value xsi:type="xsd:string">2px 2px</value>
-											</entry>
-											<entry>
-												<key>font-family</key>
-												<value xsi:type="xsd:string">serif</value>
-											</entry>
-											<entry>
-												<key>line-height</key>
-												<value xsi:type="xsd:string">19px</value>
-											</entry>
-											<entry>
-												<key>quotes</key>
-												<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-											</entry>
-										</attributes>
-									</attributes>
+									<attributes/>
 								</containedComponents>
 								<containedComponents retestId="span">
 									<identifyingAttributes>
@@ -3293,38 +1295,7 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 											<attribute key="type" xsi:type="stringAttribute">SPAN</attribute>
 										</attributes>
 									</identifyingAttributes>
-									<attributes>
-										<attributes>
-											<entry>
-												<key>background-size</key>
-												<value xsi:type="xsd:string">auto auto</value>
-											</entry>
-											<entry>
-												<key>border-image-outset</key>
-												<value xsi:type="xsd:string">0</value>
-											</entry>
-											<entry>
-												<key>border-image-repeat</key>
-												<value xsi:type="xsd:string">stretch stretch</value>
-											</entry>
-											<entry>
-												<key>border-spacing</key>
-												<value xsi:type="xsd:string">2px 2px</value>
-											</entry>
-											<entry>
-												<key>font-family</key>
-												<value xsi:type="xsd:string">serif</value>
-											</entry>
-											<entry>
-												<key>line-height</key>
-												<value xsi:type="xsd:string">19px</value>
-											</entry>
-											<entry>
-												<key>quotes</key>
-												<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-											</entry>
-										</attributes>
-									</attributes>
+									<attributes/>
 								</containedComponents>
 								<containedComponents retestId="afterspace">
 									<identifyingAttributes>
@@ -3341,38 +1312,7 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 											<attribute key="type" xsi:type="stringAttribute">SPAN</attribute>
 										</attributes>
 									</identifyingAttributes>
-									<attributes>
-										<attributes>
-											<entry>
-												<key>background-size</key>
-												<value xsi:type="xsd:string">auto auto</value>
-											</entry>
-											<entry>
-												<key>border-image-outset</key>
-												<value xsi:type="xsd:string">0</value>
-											</entry>
-											<entry>
-												<key>border-image-repeat</key>
-												<value xsi:type="xsd:string">stretch stretch</value>
-											</entry>
-											<entry>
-												<key>border-spacing</key>
-												<value xsi:type="xsd:string">2px 2px</value>
-											</entry>
-											<entry>
-												<key>font-family</key>
-												<value xsi:type="xsd:string">serif</value>
-											</entry>
-											<entry>
-												<key>line-height</key>
-												<value xsi:type="xsd:string">19px</value>
-											</entry>
-											<entry>
-												<key>quotes</key>
-												<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-											</entry>
-										</attributes>
-									</attributes>
+									<attributes/>
 								</containedComponents>
 							</containedComponents>
 						</containedComponents>
@@ -3393,34 +1333,7 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 						<attribute key="type" xsi:type="stringAttribute">HEAD</attribute>
 					</attributes>
 				</identifyingAttributes>
-				<attributes>
-					<attributes>
-						<entry>
-							<key>background-size</key>
-							<value xsi:type="xsd:string">auto auto</value>
-						</entry>
-						<entry>
-							<key>border-image-outset</key>
-							<value xsi:type="xsd:string">0</value>
-						</entry>
-						<entry>
-							<key>border-image-repeat</key>
-							<value xsi:type="xsd:string">stretch stretch</value>
-						</entry>
-						<entry>
-							<key>font-family</key>
-							<value xsi:type="xsd:string">serif</value>
-						</entry>
-						<entry>
-							<key>line-height</key>
-							<value xsi:type="xsd:string">19px</value>
-						</entry>
-						<entry>
-							<key>quotes</key>
-							<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-						</entry>
-					</attributes>
-				</attributes>
+				<attributes/>
 				<containedComponents retestId="hello_webdriver">
 					<identifyingAttributes>
 						<attributes>
@@ -3436,34 +1349,7 @@ document.write(&quot; and with document.write again&quot;);</attribute>
 							<attribute key="type" xsi:type="stringAttribute">TITLE</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-size</key>
-								<value xsi:type="xsd:string">auto auto</value>
-							</entry>
-							<entry>
-								<key>border-image-outset</key>
-								<value xsi:type="xsd:string">0</value>
-							</entry>
-							<entry>
-								<key>border-image-repeat</key>
-								<value xsi:type="xsd:string">stretch stretch</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">serif</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">19px</value>
-							</entry>
-							<entry>
-								<key>quotes</key>
-								<value xsi:type="xsd:string">“&quot; &quot;”&quot; &quot;‘&quot; &quot;’</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 			</containedComponents>
 			<screenshot>

--- a/src/test/resources/retest/recheck/de.retest.web.SimpleShowcaseIT/simple-showcase.index.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.SimpleShowcaseIT/simple-showcase.index.recheck/retest.xml
@@ -65,10 +65,6 @@
 							<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 						</entry>
 						<entry>
-							<key>box-sizing</key>
-							<value xsi:type="xsd:string">border-box</value>
-						</entry>
-						<entry>
 							<key>caret-color</key>
 							<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 						</entry>
@@ -91,22 +87,6 @@
 						<entry>
 							<key>line-height</key>
 							<value xsi:type="xsd:string">30px</value>
-						</entry>
-						<entry>
-							<key>margin-bottom</key>
-							<value xsi:type="xsd:string">0px</value>
-						</entry>
-						<entry>
-							<key>margin-left</key>
-							<value xsi:type="xsd:string">0px</value>
-						</entry>
-						<entry>
-							<key>margin-right</key>
-							<value xsi:type="xsd:string">0px</value>
-						</entry>
-						<entry>
-							<key>margin-top</key>
-							<value xsi:type="xsd:string">0px</value>
 						</entry>
 						<entry>
 							<key>outline-color</key>
@@ -135,68 +115,12 @@
 					<attributes>
 						<attributes>
 							<entry>
-								<key>background-color</key>
-								<value xsi:type="xsd:string">rgb(212, 218, 223)</value>
-							</entry>
-							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
 								<key>font-size</key>
 								<value xsi:type="xsd:string">14px</value>
 							</entry>
 							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
 								<key>padding-top</key>
 								<value xsi:type="xsd:string">66px</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -218,50 +142,6 @@
 						<attributes>
 							<attributes>
 								<entry>
-									<key>border-bottom-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-left-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-right-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-top-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>box-sizing</key>
-									<value xsi:type="xsd:string">border-box</value>
-								</entry>
-								<entry>
-									<key>caret-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>column-rule-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-								</entry>
-								<entry>
-									<key>font-size</key>
-									<value xsi:type="xsd:string">14px</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">30px</value>
-								</entry>
-								<entry>
 									<key>margin-left</key>
 									<value xsi:type="xsd:string">82.5px</value>
 								</entry>
@@ -272,14 +152,6 @@
 								<entry>
 									<key>max-width</key>
 									<value xsi:type="xsd:string">1020px</value>
-								</entry>
-								<entry>
-									<key>outline-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>text-decoration-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 								</entry>
 							</attributes>
 						</attributes>
@@ -301,60 +173,12 @@
 							<attributes>
 								<attributes>
 									<entry>
-										<key>border-bottom-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>border-left-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>border-right-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>border-top-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>box-sizing</key>
-										<value xsi:type="xsd:string">border-box</value>
-									</entry>
-									<entry>
-										<key>caret-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>column-rule-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
 										<key>float</key>
 										<value xsi:type="xsd:string">left</value>
 									</entry>
 									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">14px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">30px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">1px</value>
-									</entry>
-									<entry>
-										<key>outline-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 									</entry>
 									<entry>
 										<key>padding-left</key>
@@ -367,10 +191,6 @@
 									<entry>
 										<key>position</key>
 										<value xsi:type="xsd:string">relative</value>
-									</entry>
-									<entry>
-										<key>text-decoration-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 									</entry>
 								</attributes>
 							</attributes>
@@ -392,66 +212,6 @@
 								<attributes>
 									<attributes>
 										<entry>
-											<key>border-bottom-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-image-width</key>
-											<value xsi:type="xsd:string">1</value>
-										</entry>
-										<entry>
-											<key>border-left-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-right-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-top-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>box-sizing</key>
-											<value xsi:type="xsd:string">border-box</value>
-										</entry>
-										<entry>
-											<key>caret-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>column-rule-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>font-family</key>
-											<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-										</entry>
-										<entry>
-											<key>font-size</key>
-											<value xsi:type="xsd:string">14px</value>
-										</entry>
-										<entry>
-											<key>line-height</key>
-											<value xsi:type="xsd:string">30px</value>
-										</entry>
-										<entry>
-											<key>margin-bottom</key>
-											<value xsi:type="xsd:string">0px</value>
-										</entry>
-										<entry>
-											<key>margin-top</key>
-											<value xsi:type="xsd:string">0px</value>
-										</entry>
-										<entry>
-											<key>outline-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
 											<key>padding-left</key>
 											<value xsi:type="xsd:string">0px</value>
 										</entry>
@@ -462,10 +222,6 @@
 										<entry>
 											<key>text-align</key>
 											<value xsi:type="xsd:string">center</value>
-										</entry>
-										<entry>
-											<key>text-decoration-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 										</entry>
 									</attributes>
 								</attributes>
@@ -487,68 +243,12 @@
 									<attributes>
 										<attributes>
 											<entry>
-												<key>border-bottom-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-image-width</key>
-												<value xsi:type="xsd:string">1</value>
-											</entry>
-											<entry>
-												<key>border-left-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-right-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-top-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
-											</entry>
-											<entry>
-												<key>caret-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>column-rule-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
 												<key>display</key>
 												<value xsi:type="xsd:string">inline-block</value>
 											</entry>
 											<entry>
-												<key>font-family</key>
-												<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-											</entry>
-											<entry>
-												<key>font-size</key>
-												<value xsi:type="xsd:string">14px</value>
-											</entry>
-											<entry>
 												<key>line-height</key>
 												<value xsi:type="xsd:string">24px</value>
-											</entry>
-											<entry>
-												<key>outline-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>text-align</key>
-												<value xsi:type="xsd:string">center</value>
-											</entry>
-											<entry>
-												<key>text-decoration-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 											</entry>
 										</attributes>
 									</attributes>
@@ -571,68 +271,12 @@
 									<attributes>
 										<attributes>
 											<entry>
-												<key>border-bottom-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-image-width</key>
-												<value xsi:type="xsd:string">1</value>
-											</entry>
-											<entry>
-												<key>border-left-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-right-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-top-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
-											</entry>
-											<entry>
-												<key>caret-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>column-rule-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
 												<key>display</key>
 												<value xsi:type="xsd:string">inline-block</value>
 											</entry>
 											<entry>
-												<key>font-family</key>
-												<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-											</entry>
-											<entry>
-												<key>font-size</key>
-												<value xsi:type="xsd:string">14px</value>
-											</entry>
-											<entry>
 												<key>line-height</key>
 												<value xsi:type="xsd:string">24px</value>
-											</entry>
-											<entry>
-												<key>outline-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>text-align</key>
-												<value xsi:type="xsd:string">center</value>
-											</entry>
-											<entry>
-												<key>text-decoration-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 											</entry>
 										</attributes>
 									</attributes>
@@ -670,10 +314,6 @@
 													<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 												</entry>
 												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
 													<key>caret-color</key>
 													<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 												</entry>
@@ -686,32 +326,12 @@
 													<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 												</entry>
 												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">14px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">24px</value>
-												</entry>
-												<entry>
 													<key>outline-color</key>
 													<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 												</entry>
 												<entry>
-													<key>text-align</key>
-													<value xsi:type="xsd:string">center</value>
-												</entry>
-												<entry>
 													<key>text-decoration-color</key>
 													<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-												</entry>
-												<entry>
-													<key>text-decoration-line</key>
-													<value xsi:type="xsd:string">none</value>
 												</entry>
 												<entry>
 													<key>transition-duration</key>
@@ -747,70 +367,7 @@
 							<attribute key="type" xsi:type="stringAttribute">HEADER</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>background-color</key>
-								<value xsi:type="xsd:string">rgb(212, 218, 223)</value>
-							</entry>
-							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">15px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 					<containedComponents retestId="div">
 						<identifyingAttributes>
 							<attributes>
@@ -829,50 +386,6 @@
 						<attributes>
 							<attributes>
 								<entry>
-									<key>border-bottom-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-left-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-right-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-top-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>box-sizing</key>
-									<value xsi:type="xsd:string">border-box</value>
-								</entry>
-								<entry>
-									<key>caret-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>column-rule-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-								</entry>
-								<entry>
-									<key>font-size</key>
-									<value xsi:type="xsd:string">15px</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">30px</value>
-								</entry>
-								<entry>
 									<key>margin-left</key>
 									<value xsi:type="xsd:string">82.5px</value>
 								</entry>
@@ -883,14 +396,6 @@
 								<entry>
 									<key>max-width</key>
 									<value xsi:type="xsd:string">1020px</value>
-								</entry>
-								<entry>
-									<key>outline-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>text-decoration-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 								</entry>
 							</attributes>
 						</attributes>
@@ -912,60 +417,12 @@
 							<attributes>
 								<attributes>
 									<entry>
-										<key>border-bottom-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>border-left-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>border-right-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>border-top-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>box-sizing</key>
-										<value xsi:type="xsd:string">border-box</value>
-									</entry>
-									<entry>
-										<key>caret-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>column-rule-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
 										<key>float</key>
 										<value xsi:type="xsd:string">left</value>
 									</entry>
 									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">15px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">30px</value>
-									</entry>
-									<entry>
 										<key>min-height</key>
 										<value xsi:type="xsd:string">1px</value>
-									</entry>
-									<entry>
-										<key>outline-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 									</entry>
 									<entry>
 										<key>padding-left</key>
@@ -978,10 +435,6 @@
 									<entry>
 										<key>position</key>
 										<value xsi:type="xsd:string">relative</value>
-									</entry>
-									<entry>
-										<key>text-decoration-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 									</entry>
 								</attributes>
 							</attributes>
@@ -1003,60 +456,12 @@
 								<attributes>
 									<attributes>
 										<entry>
-											<key>border-bottom-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-left-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-right-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-top-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
 											<key>bottom</key>
 											<value xsi:type="xsd:string">50px</value>
 										</entry>
 										<entry>
-											<key>box-sizing</key>
-											<value xsi:type="xsd:string">border-box</value>
-										</entry>
-										<entry>
-											<key>caret-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>column-rule-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>font-family</key>
-											<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-										</entry>
-										<entry>
-											<key>font-size</key>
-											<value xsi:type="xsd:string">15px</value>
-										</entry>
-										<entry>
 											<key>left</key>
 											<value xsi:type="xsd:string">20px</value>
-										</entry>
-										<entry>
-											<key>line-height</key>
-											<value xsi:type="xsd:string">30px</value>
-										</entry>
-										<entry>
-											<key>outline-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 										</entry>
 										<entry>
 											<key>position</key>
@@ -1065,10 +470,6 @@
 										<entry>
 											<key>right</key>
 											<value xsi:type="xsd:string">820px</value>
-										</entry>
-										<entry>
-											<key>text-decoration-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 										</entry>
 										<entry>
 											<key>top</key>
@@ -1109,10 +510,6 @@
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 											</entry>
 											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
-											</entry>
-											<entry>
 												<key>caret-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 											</entry>
@@ -1125,32 +522,12 @@
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 											</entry>
 											<entry>
-												<key>display</key>
-												<value xsi:type="xsd:string">block</value>
-											</entry>
-											<entry>
-												<key>font-family</key>
-												<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-											</entry>
-											<entry>
-												<key>font-size</key>
-												<value xsi:type="xsd:string">15px</value>
-											</entry>
-											<entry>
-												<key>line-height</key>
-												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
 												<key>outline-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 											</entry>
 											<entry>
 												<key>text-decoration-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-											</entry>
-											<entry>
-												<key>text-decoration-line</key>
-												<value xsi:type="xsd:string">none</value>
 											</entry>
 											<entry>
 												<key>transition-duration</key>
@@ -1183,10 +560,6 @@
 										<attributes>
 											<attributes>
 												<entry>
-													<key>border-bottom-color</key>
-													<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-												</entry>
-												<entry>
 													<key>border-bottom-left-radius</key>
 													<value xsi:type="xsd:string">3px</value>
 												</entry>
@@ -1195,20 +568,8 @@
 													<value xsi:type="xsd:string">3px</value>
 												</entry>
 												<entry>
-													<key>border-left-color</key>
-													<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-												</entry>
-												<entry>
 													<key>border-radius</key>
 													<value xsi:type="xsd:string">3px</value>
-												</entry>
-												<entry>
-													<key>border-right-color</key>
-													<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-												</entry>
-												<entry>
-													<key>border-top-color</key>
-													<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 												</entry>
 												<entry>
 													<key>border-top-left-radius</key>
@@ -1219,44 +580,8 @@
 													<value xsi:type="xsd:string">3px</value>
 												</entry>
 												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
-													<key>caret-color</key>
-													<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-												</entry>
-												<entry>
-													<key>color</key>
-													<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-												</entry>
-												<entry>
-													<key>column-rule-color</key>
-													<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-												</entry>
-												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">15px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">30px</value>
-												</entry>
-												<entry>
 													<key>max-width</key>
 													<value xsi:type="xsd:string">100%</value>
-												</entry>
-												<entry>
-													<key>outline-color</key>
-													<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-												</entry>
-												<entry>
-													<key>text-decoration-color</key>
-													<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -1281,42 +606,6 @@
 								<attributes>
 									<attributes>
 										<entry>
-											<key>border-bottom-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-image-width</key>
-											<value xsi:type="xsd:string">1</value>
-										</entry>
-										<entry>
-											<key>border-left-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-right-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-top-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>box-sizing</key>
-											<value xsi:type="xsd:string">border-box</value>
-										</entry>
-										<entry>
-											<key>caret-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>column-rule-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
 											<key>float</key>
 											<value xsi:type="xsd:string">right</value>
 										</entry>
@@ -1335,18 +624,6 @@
 										<entry>
 											<key>margin-top</key>
 											<value xsi:type="xsd:string">36px</value>
-										</entry>
-										<entry>
-											<key>outline-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>position</key>
-											<value xsi:type="xsd:string">relative</value>
-										</entry>
-										<entry>
-											<key>text-decoration-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 										</entry>
 										<entry>
 											<key>z-index</key>
@@ -1409,10 +686,6 @@
 												<value xsi:type="xsd:string">3px</value>
 											</entry>
 											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
-											</entry>
-											<entry>
 												<key>caret-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 											</entry>
@@ -1429,24 +702,12 @@
 												<value xsi:type="xsd:string">none</value>
 											</entry>
 											<entry>
-												<key>font-family</key>
-												<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-											</entry>
-											<entry>
-												<key>font-size</key>
-												<value xsi:type="xsd:string">14px</value>
-											</entry>
-											<entry>
 												<key>outline-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 											</entry>
 											<entry>
 												<key>text-decoration-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-											</entry>
-											<entry>
-												<key>text-decoration-line</key>
-												<value xsi:type="xsd:string">none</value>
 											</entry>
 											<entry>
 												<key>transition-duration</key>
@@ -1518,10 +779,6 @@
 												<value xsi:type="xsd:string">3px</value>
 											</entry>
 											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
-											</entry>
-											<entry>
 												<key>caret-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 											</entry>
@@ -1538,24 +795,12 @@
 												<value xsi:type="xsd:string">none</value>
 											</entry>
 											<entry>
-												<key>font-family</key>
-												<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-											</entry>
-											<entry>
-												<key>font-size</key>
-												<value xsi:type="xsd:string">14px</value>
-											</entry>
-											<entry>
 												<key>outline-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 											</entry>
 											<entry>
 												<key>text-decoration-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-											</entry>
-											<entry>
-												<key>text-decoration-line</key>
-												<value xsi:type="xsd:string">none</value>
 											</entry>
 											<entry>
 												<key>transition-duration</key>
@@ -1591,56 +836,8 @@
 									<attributes>
 										<attributes>
 											<entry>
-												<key>border-bottom-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-image-width</key>
-												<value xsi:type="xsd:string">1</value>
-											</entry>
-											<entry>
-												<key>border-left-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-right-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-top-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
-											</entry>
-											<entry>
-												<key>caret-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>column-rule-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
 												<key>display</key>
 												<value xsi:type="xsd:string">inline</value>
-											</entry>
-											<entry>
-												<key>font-family</key>
-												<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-											</entry>
-											<entry>
-												<key>font-size</key>
-												<value xsi:type="xsd:string">14px</value>
-											</entry>
-											<entry>
-												<key>margin-bottom</key>
-												<value xsi:type="xsd:string">0px</value>
 											</entry>
 											<entry>
 												<key>margin-top</key>
@@ -1651,20 +848,8 @@
 												<value xsi:type="xsd:string">48px</value>
 											</entry>
 											<entry>
-												<key>outline-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>padding-left</key>
-												<value xsi:type="xsd:string">0px</value>
-											</entry>
-											<entry>
 												<key>text-align</key>
 												<value xsi:type="xsd:string">left</value>
-											</entry>
-											<entry>
-												<key>text-decoration-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 											</entry>
 										</attributes>
 									</attributes>
@@ -1685,72 +870,16 @@
 										<attributes>
 											<attributes>
 												<entry>
-													<key>border-bottom-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-image-width</key>
-													<value xsi:type="xsd:string">1</value>
-												</entry>
-												<entry>
-													<key>border-left-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-right-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-top-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
-													<key>caret-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>column-rule-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>display</key>
 													<value xsi:type="xsd:string">inline-block</value>
-												</entry>
-												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">14px</value>
 												</entry>
 												<entry>
 													<key>list-style-type</key>
 													<value xsi:type="xsd:string">none</value>
 												</entry>
 												<entry>
-													<key>outline-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>position</key>
 													<value xsi:type="xsd:string">relative</value>
-												</entry>
-												<entry>
-													<key>text-align</key>
-													<value xsi:type="xsd:string">left</value>
-												</entry>
-												<entry>
-													<key>text-decoration-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -1768,66 +897,7 @@
 													<attribute key="type" xsi:type="stringAttribute">SPAN</attribute>
 												</attributes>
 											</identifyingAttributes>
-											<attributes>
-												<attributes>
-													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">14px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-												</attributes>
-											</attributes>
+											<attributes/>
 											<containedComponents retestId="for_testers">
 												<identifyingAttributes>
 													<attributes>
@@ -1862,10 +932,6 @@
 															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 														</entry>
@@ -1882,20 +948,8 @@
 															<value xsi:type="xsd:string">inline-block</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
 															<key>line-height</key>
 															<value xsi:type="xsd:string">32px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
 														</entry>
 														<entry>
 															<key>outline-color</key>
@@ -1918,16 +972,8 @@
 															<value xsi:type="xsd:string">8px</value>
 														</entry>
 														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
 															<key>text-decoration-color</key>
 															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>text-decoration-line</key>
-															<value xsi:type="xsd:string">none</value>
 														</entry>
 														<entry>
 															<key>transition-duration</key>
@@ -1966,10 +1012,6 @@
 														<value xsi:type="xsd:string">rgb(212, 218, 223)</value>
 													</entry>
 													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>border-bottom-left-radius</key>
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
@@ -1978,60 +1020,12 @@
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
 													<entry>
-														<key>border-image-width</key>
-														<value xsi:type="xsd:string">1</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>border-radius</key>
 														<value xsi:type="xsd:string">0px 0px 3px 3px</value>
 													</entry>
 													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">14px</value>
-													</entry>
-													<entry>
 														<key>list-style-type</key>
 														<value xsi:type="xsd:string">circle</value>
-													</entry>
-													<entry>
-														<key>margin-bottom</key>
-														<value xsi:type="xsd:string">0px</value>
-													</entry>
-													<entry>
-														<key>margin-top</key>
-														<value xsi:type="xsd:string">0px</value>
 													</entry>
 													<entry>
 														<key>min-width</key>
@@ -2042,28 +1036,12 @@
 														<value xsi:type="xsd:string">0</value>
 													</entry>
 													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>padding-left</key>
-														<value xsi:type="xsd:string">0px</value>
-													</entry>
-													<entry>
 														<key>position</key>
 														<value xsi:type="xsd:string">absolute</value>
 													</entry>
 													<entry>
 														<key>right</key>
 														<value xsi:type="xsd:string">-122.188px</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 													</entry>
 													<entry>
 														<key>top</key>
@@ -2104,60 +1082,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
 															<key>list-style-type</key>
 															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
 															<key>overflow</key>
@@ -2174,22 +1100,6 @@
 														<entry>
 															<key>position</key>
 															<value xsi:type="xsd:string">relative</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
 														</entry>
 														<entry>
 															<key>transition-property</key>
@@ -2231,10 +1141,6 @@
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
@@ -2251,20 +1157,12 @@
 																<value xsi:type="xsd:string">inline-block</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
 																<key>font-size</key>
 																<value xsi:type="xsd:string">13px</value>
 															</entry>
 															<entry>
 																<key>line-height</key>
 																<value xsi:type="xsd:string">32px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>outline-color</key>
@@ -2287,16 +1185,8 @@
 																<value xsi:type="xsd:string">6px</value>
 															</entry>
 															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
 																<key>text-decoration-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>text-decoration-line</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>transition-duration</key>
@@ -2335,60 +1225,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
 															<key>list-style-type</key>
 															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
 															<key>overflow</key>
@@ -2405,22 +1243,6 @@
 														<entry>
 															<key>position</key>
 															<value xsi:type="xsd:string">relative</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
 														</entry>
 														<entry>
 															<key>transition-property</key>
@@ -2462,10 +1284,6 @@
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
@@ -2482,20 +1300,12 @@
 																<value xsi:type="xsd:string">inline-block</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
 																<key>font-size</key>
 																<value xsi:type="xsd:string">13px</value>
 															</entry>
 															<entry>
 																<key>line-height</key>
 																<value xsi:type="xsd:string">32px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>outline-color</key>
@@ -2518,16 +1328,8 @@
 																<value xsi:type="xsd:string">6px</value>
 															</entry>
 															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
 																<key>text-decoration-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>text-decoration-line</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>transition-duration</key>
@@ -2566,60 +1368,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
 															<key>list-style-type</key>
 															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
 															<key>overflow</key>
@@ -2636,22 +1386,6 @@
 														<entry>
 															<key>position</key>
 															<value xsi:type="xsd:string">relative</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
 														</entry>
 														<entry>
 															<key>transition-property</key>
@@ -2693,10 +1427,6 @@
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
@@ -2713,20 +1443,12 @@
 																<value xsi:type="xsd:string">inline-block</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
 																<key>font-size</key>
 																<value xsi:type="xsd:string">13px</value>
 															</entry>
 															<entry>
 																<key>line-height</key>
 																<value xsi:type="xsd:string">32px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>outline-color</key>
@@ -2749,16 +1471,8 @@
 																<value xsi:type="xsd:string">6px</value>
 															</entry>
 															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
 																<key>text-decoration-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>text-decoration-line</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>transition-duration</key>
@@ -2797,60 +1511,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
 															<key>list-style-type</key>
 															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
 															<key>overflow</key>
@@ -2867,22 +1529,6 @@
 														<entry>
 															<key>position</key>
 															<value xsi:type="xsd:string">relative</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
 														</entry>
 														<entry>
 															<key>transition-property</key>
@@ -2924,10 +1570,6 @@
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
@@ -2944,20 +1586,12 @@
 																<value xsi:type="xsd:string">inline-block</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
 																<key>font-size</key>
 																<value xsi:type="xsd:string">13px</value>
 															</entry>
 															<entry>
 																<key>line-height</key>
 																<value xsi:type="xsd:string">32px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>outline-color</key>
@@ -2980,16 +1614,8 @@
 																<value xsi:type="xsd:string">6px</value>
 															</entry>
 															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
 																<key>text-decoration-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>text-decoration-line</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>transition-duration</key>
@@ -3030,72 +1656,16 @@
 										<attributes>
 											<attributes>
 												<entry>
-													<key>border-bottom-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-image-width</key>
-													<value xsi:type="xsd:string">1</value>
-												</entry>
-												<entry>
-													<key>border-left-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-right-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-top-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
-													<key>caret-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>column-rule-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>display</key>
 													<value xsi:type="xsd:string">inline-block</value>
-												</entry>
-												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">14px</value>
 												</entry>
 												<entry>
 													<key>list-style-type</key>
 													<value xsi:type="xsd:string">none</value>
 												</entry>
 												<entry>
-													<key>outline-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>position</key>
 													<value xsi:type="xsd:string">relative</value>
-												</entry>
-												<entry>
-													<key>text-align</key>
-													<value xsi:type="xsd:string">left</value>
-												</entry>
-												<entry>
-													<key>text-decoration-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -3113,66 +1683,7 @@
 													<attribute key="type" xsi:type="stringAttribute">SPAN</attribute>
 												</attributes>
 											</identifyingAttributes>
-											<attributes>
-												<attributes>
-													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">14px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-												</attributes>
-											</attributes>
+											<attributes/>
 											<containedComponents retestId="for_developers">
 												<identifyingAttributes>
 													<attributes>
@@ -3207,10 +1718,6 @@
 															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 														</entry>
@@ -3227,20 +1734,8 @@
 															<value xsi:type="xsd:string">inline-block</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
 															<key>line-height</key>
 															<value xsi:type="xsd:string">32px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
 														</entry>
 														<entry>
 															<key>outline-color</key>
@@ -3263,16 +1758,8 @@
 															<value xsi:type="xsd:string">8px</value>
 														</entry>
 														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
 															<key>text-decoration-color</key>
 															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>text-decoration-line</key>
-															<value xsi:type="xsd:string">none</value>
 														</entry>
 														<entry>
 															<key>transition-duration</key>
@@ -3311,10 +1798,6 @@
 														<value xsi:type="xsd:string">rgb(212, 218, 223)</value>
 													</entry>
 													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>border-bottom-left-radius</key>
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
@@ -3323,60 +1806,12 @@
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
 													<entry>
-														<key>border-image-width</key>
-														<value xsi:type="xsd:string">1</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>border-radius</key>
 														<value xsi:type="xsd:string">0px 0px 3px 3px</value>
 													</entry>
 													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">14px</value>
-													</entry>
-													<entry>
 														<key>list-style-type</key>
 														<value xsi:type="xsd:string">circle</value>
-													</entry>
-													<entry>
-														<key>margin-bottom</key>
-														<value xsi:type="xsd:string">0px</value>
-													</entry>
-													<entry>
-														<key>margin-top</key>
-														<value xsi:type="xsd:string">0px</value>
 													</entry>
 													<entry>
 														<key>min-width</key>
@@ -3387,24 +1822,8 @@
 														<value xsi:type="xsd:string">0</value>
 													</entry>
 													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>padding-left</key>
-														<value xsi:type="xsd:string">0px</value>
-													</entry>
-													<entry>
 														<key>position</key>
 														<value xsi:type="xsd:string">absolute</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 													</entry>
 													<entry>
 														<key>top</key>
@@ -3445,60 +1864,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
 															<key>list-style-type</key>
 															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
 															<key>overflow</key>
@@ -3515,22 +1882,6 @@
 														<entry>
 															<key>position</key>
 															<value xsi:type="xsd:string">relative</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
 														</entry>
 														<entry>
 															<key>transition-property</key>
@@ -3572,10 +1923,6 @@
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
@@ -3592,20 +1939,12 @@
 																<value xsi:type="xsd:string">inline-block</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
 																<key>font-size</key>
 																<value xsi:type="xsd:string">13px</value>
 															</entry>
 															<entry>
 																<key>line-height</key>
 																<value xsi:type="xsd:string">32px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>outline-color</key>
@@ -3628,16 +1967,8 @@
 																<value xsi:type="xsd:string">6px</value>
 															</entry>
 															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
 																<key>text-decoration-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>text-decoration-line</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>transition-duration</key>
@@ -3676,60 +2007,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
 															<key>list-style-type</key>
 															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
 															<key>overflow</key>
@@ -3746,22 +2025,6 @@
 														<entry>
 															<key>position</key>
 															<value xsi:type="xsd:string">relative</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
 														</entry>
 														<entry>
 															<key>transition-property</key>
@@ -3803,10 +2066,6 @@
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
@@ -3823,20 +2082,12 @@
 																<value xsi:type="xsd:string">inline-block</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
 																<key>font-size</key>
 																<value xsi:type="xsd:string">13px</value>
 															</entry>
 															<entry>
 																<key>line-height</key>
 																<value xsi:type="xsd:string">32px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>outline-color</key>
@@ -3859,16 +2110,8 @@
 																<value xsi:type="xsd:string">6px</value>
 															</entry>
 															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
 																<key>text-decoration-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>text-decoration-line</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>transition-duration</key>
@@ -3907,60 +2150,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
 															<key>list-style-type</key>
 															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
 															<key>overflow</key>
@@ -3977,22 +2168,6 @@
 														<entry>
 															<key>position</key>
 															<value xsi:type="xsd:string">relative</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
 														</entry>
 														<entry>
 															<key>transition-property</key>
@@ -4034,10 +2209,6 @@
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
@@ -4054,20 +2225,12 @@
 																<value xsi:type="xsd:string">inline-block</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
 																<key>font-size</key>
 																<value xsi:type="xsd:string">13px</value>
 															</entry>
 															<entry>
 																<key>line-height</key>
 																<value xsi:type="xsd:string">32px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>outline-color</key>
@@ -4090,16 +2253,8 @@
 																<value xsi:type="xsd:string">6px</value>
 															</entry>
 															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
 																<key>text-decoration-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>text-decoration-line</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>transition-duration</key>
@@ -4140,72 +2295,16 @@
 										<attributes>
 											<attributes>
 												<entry>
-													<key>border-bottom-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-image-width</key>
-													<value xsi:type="xsd:string">1</value>
-												</entry>
-												<entry>
-													<key>border-left-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-right-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-top-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
-													<key>caret-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>column-rule-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>display</key>
 													<value xsi:type="xsd:string">inline-block</value>
-												</entry>
-												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">14px</value>
 												</entry>
 												<entry>
 													<key>list-style-type</key>
 													<value xsi:type="xsd:string">none</value>
 												</entry>
 												<entry>
-													<key>outline-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>position</key>
 													<value xsi:type="xsd:string">relative</value>
-												</entry>
-												<entry>
-													<key>text-align</key>
-													<value xsi:type="xsd:string">left</value>
-												</entry>
-												<entry>
-													<key>text-decoration-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -4223,66 +2322,7 @@
 													<attribute key="type" xsi:type="stringAttribute">SPAN</attribute>
 												</attributes>
 											</identifyingAttributes>
-											<attributes>
-												<attributes>
-													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">14px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-												</attributes>
-											</attributes>
+											<attributes/>
 											<containedComponents retestId="for_managers">
 												<identifyingAttributes>
 													<attributes>
@@ -4317,10 +2357,6 @@
 															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 														</entry>
@@ -4337,20 +2373,8 @@
 															<value xsi:type="xsd:string">inline-block</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
 															<key>line-height</key>
 															<value xsi:type="xsd:string">32px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
 														</entry>
 														<entry>
 															<key>outline-color</key>
@@ -4373,16 +2397,8 @@
 															<value xsi:type="xsd:string">8px</value>
 														</entry>
 														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
 															<key>text-decoration-color</key>
 															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>text-decoration-line</key>
-															<value xsi:type="xsd:string">none</value>
 														</entry>
 														<entry>
 															<key>transition-duration</key>
@@ -4421,10 +2437,6 @@
 														<value xsi:type="xsd:string">rgb(212, 218, 223)</value>
 													</entry>
 													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>border-bottom-left-radius</key>
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
@@ -4433,60 +2445,12 @@
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
 													<entry>
-														<key>border-image-width</key>
-														<value xsi:type="xsd:string">1</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>border-radius</key>
 														<value xsi:type="xsd:string">0px 0px 3px 3px</value>
 													</entry>
 													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">14px</value>
-													</entry>
-													<entry>
 														<key>list-style-type</key>
 														<value xsi:type="xsd:string">circle</value>
-													</entry>
-													<entry>
-														<key>margin-bottom</key>
-														<value xsi:type="xsd:string">0px</value>
-													</entry>
-													<entry>
-														<key>margin-top</key>
-														<value xsi:type="xsd:string">0px</value>
 													</entry>
 													<entry>
 														<key>min-width</key>
@@ -4497,28 +2461,12 @@
 														<value xsi:type="xsd:string">0</value>
 													</entry>
 													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>padding-left</key>
-														<value xsi:type="xsd:string">0px</value>
-													</entry>
-													<entry>
 														<key>position</key>
 														<value xsi:type="xsd:string">absolute</value>
 													</entry>
 													<entry>
 														<key>right</key>
 														<value xsi:type="xsd:string">-78.7812px</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 													</entry>
 													<entry>
 														<key>top</key>
@@ -4559,60 +2507,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
 															<key>list-style-type</key>
 															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
 															<key>overflow</key>
@@ -4629,22 +2525,6 @@
 														<entry>
 															<key>position</key>
 															<value xsi:type="xsd:string">relative</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
 														</entry>
 														<entry>
 															<key>transition-property</key>
@@ -4686,10 +2566,6 @@
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
@@ -4706,20 +2582,12 @@
 																<value xsi:type="xsd:string">inline-block</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
 																<key>font-size</key>
 																<value xsi:type="xsd:string">13px</value>
 															</entry>
 															<entry>
 																<key>line-height</key>
 																<value xsi:type="xsd:string">32px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>outline-color</key>
@@ -4742,16 +2610,8 @@
 																<value xsi:type="xsd:string">6px</value>
 															</entry>
 															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
 																<key>text-decoration-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>text-decoration-line</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>transition-duration</key>
@@ -4790,60 +2650,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
 															<key>list-style-type</key>
 															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
 															<key>overflow</key>
@@ -4860,22 +2668,6 @@
 														<entry>
 															<key>position</key>
 															<value xsi:type="xsd:string">relative</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
 														</entry>
 														<entry>
 															<key>transition-property</key>
@@ -4917,10 +2709,6 @@
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
@@ -4937,20 +2725,12 @@
 																<value xsi:type="xsd:string">inline-block</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
 																<key>font-size</key>
 																<value xsi:type="xsd:string">13px</value>
 															</entry>
 															<entry>
 																<key>line-height</key>
 																<value xsi:type="xsd:string">32px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>outline-color</key>
@@ -4973,16 +2753,8 @@
 																<value xsi:type="xsd:string">6px</value>
 															</entry>
 															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
 																<key>text-decoration-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>text-decoration-line</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>transition-duration</key>
@@ -5021,60 +2793,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
 															<key>list-style-type</key>
 															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
 															<key>overflow</key>
@@ -5091,22 +2811,6 @@
 														<entry>
 															<key>position</key>
 															<value xsi:type="xsd:string">relative</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
 														</entry>
 														<entry>
 															<key>transition-property</key>
@@ -5148,10 +2852,6 @@
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
@@ -5168,20 +2868,12 @@
 																<value xsi:type="xsd:string">inline-block</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
 																<key>font-size</key>
 																<value xsi:type="xsd:string">13px</value>
 															</entry>
 															<entry>
 																<key>line-height</key>
 																<value xsi:type="xsd:string">32px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>outline-color</key>
@@ -5204,16 +2896,8 @@
 																<value xsi:type="xsd:string">6px</value>
 															</entry>
 															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
 																<key>text-decoration-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>text-decoration-line</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>transition-duration</key>
@@ -5254,72 +2938,16 @@
 										<attributes>
 											<attributes>
 												<entry>
-													<key>border-bottom-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-image-width</key>
-													<value xsi:type="xsd:string">1</value>
-												</entry>
-												<entry>
-													<key>border-left-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-right-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-top-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
-													<key>caret-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>column-rule-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>display</key>
 													<value xsi:type="xsd:string">inline-block</value>
-												</entry>
-												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">14px</value>
 												</entry>
 												<entry>
 													<key>list-style-type</key>
 													<value xsi:type="xsd:string">none</value>
 												</entry>
 												<entry>
-													<key>outline-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>position</key>
 													<value xsi:type="xsd:string">relative</value>
-												</entry>
-												<entry>
-													<key>text-align</key>
-													<value xsi:type="xsd:string">left</value>
-												</entry>
-												<entry>
-													<key>text-decoration-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -5337,66 +2965,7 @@
 													<attribute key="type" xsi:type="stringAttribute">SPAN</attribute>
 												</attributes>
 											</identifyingAttributes>
-											<attributes>
-												<attributes>
-													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">14px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-												</attributes>
-											</attributes>
+											<attributes/>
 											<containedComponents retestId="about">
 												<identifyingAttributes>
 													<attributes>
@@ -5431,10 +3000,6 @@
 															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 														</entry>
@@ -5451,20 +3016,8 @@
 															<value xsi:type="xsd:string">inline-block</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
 															<key>line-height</key>
 															<value xsi:type="xsd:string">32px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
 														</entry>
 														<entry>
 															<key>outline-color</key>
@@ -5487,16 +3040,8 @@
 															<value xsi:type="xsd:string">8px</value>
 														</entry>
 														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
 															<key>text-decoration-color</key>
 															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>text-decoration-line</key>
-															<value xsi:type="xsd:string">none</value>
 														</entry>
 														<entry>
 															<key>transition-duration</key>
@@ -5535,10 +3080,6 @@
 														<value xsi:type="xsd:string">rgb(212, 218, 223)</value>
 													</entry>
 													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>border-bottom-left-radius</key>
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
@@ -5547,60 +3088,12 @@
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
 													<entry>
-														<key>border-image-width</key>
-														<value xsi:type="xsd:string">1</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>border-radius</key>
 														<value xsi:type="xsd:string">0px 0px 3px 3px</value>
 													</entry>
 													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">14px</value>
-													</entry>
-													<entry>
 														<key>list-style-type</key>
 														<value xsi:type="xsd:string">circle</value>
-													</entry>
-													<entry>
-														<key>margin-bottom</key>
-														<value xsi:type="xsd:string">0px</value>
-													</entry>
-													<entry>
-														<key>margin-top</key>
-														<value xsi:type="xsd:string">0px</value>
 													</entry>
 													<entry>
 														<key>min-width</key>
@@ -5611,28 +3104,12 @@
 														<value xsi:type="xsd:string">0</value>
 													</entry>
 													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>padding-left</key>
-														<value xsi:type="xsd:string">0px</value>
-													</entry>
-													<entry>
 														<key>position</key>
 														<value xsi:type="xsd:string">absolute</value>
 													</entry>
 													<entry>
 														<key>right</key>
 														<value xsi:type="xsd:string">-50.8594px</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 													</entry>
 													<entry>
 														<key>top</key>
@@ -5673,60 +3150,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
 															<key>list-style-type</key>
 															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
 															<key>overflow</key>
@@ -5743,22 +3168,6 @@
 														<entry>
 															<key>position</key>
 															<value xsi:type="xsd:string">relative</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
 														</entry>
 														<entry>
 															<key>transition-property</key>
@@ -5800,10 +3209,6 @@
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
@@ -5820,20 +3225,12 @@
 																<value xsi:type="xsd:string">inline-block</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
 																<key>font-size</key>
 																<value xsi:type="xsd:string">13px</value>
 															</entry>
 															<entry>
 																<key>line-height</key>
 																<value xsi:type="xsd:string">32px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>outline-color</key>
@@ -5856,16 +3253,8 @@
 																<value xsi:type="xsd:string">6px</value>
 															</entry>
 															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
 																<key>text-decoration-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>text-decoration-line</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>transition-duration</key>
@@ -5904,60 +3293,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
 															<key>list-style-type</key>
 															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
 															<key>overflow</key>
@@ -5974,22 +3311,6 @@
 														<entry>
 															<key>position</key>
 															<value xsi:type="xsd:string">relative</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
 														</entry>
 														<entry>
 															<key>transition-property</key>
@@ -6031,10 +3352,6 @@
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
@@ -6051,20 +3368,12 @@
 																<value xsi:type="xsd:string">inline-block</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
 																<key>font-size</key>
 																<value xsi:type="xsd:string">13px</value>
 															</entry>
 															<entry>
 																<key>line-height</key>
 																<value xsi:type="xsd:string">32px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>outline-color</key>
@@ -6087,16 +3396,8 @@
 																<value xsi:type="xsd:string">6px</value>
 															</entry>
 															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
 																<key>text-decoration-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>text-decoration-line</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>transition-duration</key>
@@ -6135,60 +3436,8 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
 															<key>list-style-type</key>
 															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
 															<key>overflow</key>
@@ -6205,22 +3454,6 @@
 														<entry>
 															<key>position</key>
 															<value xsi:type="xsd:string">relative</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
 														</entry>
 														<entry>
 															<key>transition-property</key>
@@ -6262,10 +3495,6 @@
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
@@ -6282,20 +3511,12 @@
 																<value xsi:type="xsd:string">inline-block</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
 																<key>font-size</key>
 																<value xsi:type="xsd:string">13px</value>
 															</entry>
 															<entry>
 																<key>line-height</key>
 																<value xsi:type="xsd:string">32px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>outline-color</key>
@@ -6318,16 +3539,8 @@
 																<value xsi:type="xsd:string">6px</value>
 															</entry>
 															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
 																<key>text-decoration-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>text-decoration-line</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>transition-duration</key>
@@ -6369,72 +3582,16 @@
 										<attributes>
 											<attributes>
 												<entry>
-													<key>border-bottom-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-image-width</key>
-													<value xsi:type="xsd:string">1</value>
-												</entry>
-												<entry>
-													<key>border-left-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-right-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-top-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
-													<key>caret-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>column-rule-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>display</key>
 													<value xsi:type="xsd:string">inline-block</value>
-												</entry>
-												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">14px</value>
 												</entry>
 												<entry>
 													<key>list-style-type</key>
 													<value xsi:type="xsd:string">none</value>
 												</entry>
 												<entry>
-													<key>outline-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>position</key>
 													<value xsi:type="xsd:string">relative</value>
-												</entry>
-												<entry>
-													<key>text-align</key>
-													<value xsi:type="xsd:string">left</value>
-												</entry>
-												<entry>
-													<key>text-decoration-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -6472,10 +3629,6 @@
 														<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 													</entry>
 													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
 														<key>caret-color</key>
 														<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 													</entry>
@@ -6488,24 +3641,8 @@
 														<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 													</entry>
 													<entry>
-														<key>display</key>
-														<value xsi:type="xsd:string">inline-block</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">14px</value>
-													</entry>
-													<entry>
 														<key>line-height</key>
 														<value xsi:type="xsd:string">32px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
 													</entry>
 													<entry>
 														<key>outline-color</key>
@@ -6528,16 +3665,8 @@
 														<value xsi:type="xsd:string">8px</value>
 													</entry>
 													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
 														<key>text-decoration-color</key>
 														<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-													</entry>
-													<entry>
-														<key>text-decoration-line</key>
-														<value xsi:type="xsd:string">none</value>
 													</entry>
 													<entry>
 														<key>transition-duration</key>
@@ -6571,76 +3700,12 @@
 												<attributes>
 													<attributes>
 														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
 															<key>display</key>
 															<value xsi:type="xsd:string">inline</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">32px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>margin-right</key>
 															<value xsi:type="xsd:string">5px</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 														</entry>
 													</attributes>
 												</attributes>
@@ -6660,70 +3725,7 @@
 														<attribute key="type" xsi:type="stringAttribute">SPAN</attribute>
 													</attributes>
 												</identifyingAttributes>
-												<attributes>
-													<attributes>
-														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">14px</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">32px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-														</entry>
-													</attributes>
-												</attributes>
+												<attributes/>
 											</containedComponents>
 										</containedComponents>
 										<containedComponents retestId="ul">
@@ -6767,10 +3769,6 @@
 													<entry>
 														<key>border-bottom-width</key>
 														<value xsi:type="xsd:string">1px</value>
-													</entry>
-													<entry>
-														<key>border-image-width</key>
-														<value xsi:type="xsd:string">1</value>
 													</entry>
 													<entry>
 														<key>border-left-color</key>
@@ -6829,36 +3827,8 @@
 														<value xsi:type="xsd:string">rgba(0, 0, 0, 0.176) 0px 6px 12px 0px</value>
 													</entry>
 													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-													</entry>
-													<entry>
 														<key>left</key>
 														<value xsi:type="xsd:string">-125px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
-														<key>margin-bottom</key>
-														<value xsi:type="xsd:string">0px</value>
 													</entry>
 													<entry>
 														<key>margin-top</key>
@@ -6873,16 +3843,8 @@
 														<value xsi:type="xsd:string">0</value>
 													</entry>
 													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>padding-bottom</key>
 														<value xsi:type="xsd:string">5px</value>
-													</entry>
-													<entry>
-														<key>padding-left</key>
-														<value xsi:type="xsd:string">0px</value>
 													</entry>
 													<entry>
 														<key>padding-top</key>
@@ -6891,14 +3853,6 @@
 													<entry>
 														<key>position</key>
 														<value xsi:type="xsd:string">absolute</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 													</entry>
 													<entry>
 														<key>top</key>
@@ -6943,10 +3897,6 @@
 															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
 															<key>border-left-color</key>
 															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
@@ -6956,38 +3906,6 @@
 														</entry>
 														<entry>
 															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 														</entry>
 														<entry>
@@ -7005,22 +3923,6 @@
 														<entry>
 															<key>position</key>
 															<value xsi:type="xsd:string">relative</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
 														</entry>
 														<entry>
 															<key>transition-property</key>
@@ -7061,10 +3963,6 @@
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 															</entry>
@@ -7081,20 +3979,12 @@
 																<value xsi:type="xsd:string">inline-block</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
 																<key>font-size</key>
 																<value xsi:type="xsd:string">15px</value>
 															</entry>
 															<entry>
 																<key>line-height</key>
 																<value xsi:type="xsd:string">32px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>outline-color</key>
@@ -7117,16 +4007,8 @@
 																<value xsi:type="xsd:string">5px</value>
 															</entry>
 															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
 																<key>text-decoration-color</key>
 																<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-															</entry>
-															<entry>
-																<key>text-decoration-line</key>
-																<value xsi:type="xsd:string">none</value>
 															</entry>
 															<entry>
 																<key>transition-duration</key>
@@ -7164,10 +4046,6 @@
 														<attributes>
 															<attributes>
 																<entry>
-																	<key>border-bottom-color</key>
-																	<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-																</entry>
-																<entry>
 																	<key>border-bottom-left-radius</key>
 																	<value xsi:type="xsd:string">3px</value>
 																</entry>
@@ -7176,20 +4054,8 @@
 																	<value xsi:type="xsd:string">3px</value>
 																</entry>
 																<entry>
-																	<key>border-left-color</key>
-																	<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-																</entry>
-																<entry>
 																	<key>border-radius</key>
 																	<value xsi:type="xsd:string">3px</value>
-																</entry>
-																<entry>
-																	<key>border-right-color</key>
-																	<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-																</entry>
-																<entry>
-																	<key>border-top-color</key>
-																	<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 																</entry>
 																<entry>
 																	<key>border-top-left-radius</key>
@@ -7200,60 +4066,12 @@
 																	<value xsi:type="xsd:string">3px</value>
 																</entry>
 																<entry>
-																	<key>box-sizing</key>
-																	<value xsi:type="xsd:string">border-box</value>
-																</entry>
-																<entry>
-																	<key>caret-color</key>
-																	<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-																</entry>
-																<entry>
-																	<key>color</key>
-																	<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-																</entry>
-																<entry>
-																	<key>column-rule-color</key>
-																	<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-																</entry>
-																<entry>
-																	<key>font-family</key>
-																	<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-																</entry>
-																<entry>
-																	<key>font-size</key>
-																	<value xsi:type="xsd:string">15px</value>
-																</entry>
-																<entry>
-																	<key>line-height</key>
-																	<value xsi:type="xsd:string">32px</value>
-																</entry>
-																<entry>
-																	<key>list-style-type</key>
-																	<value xsi:type="xsd:string">none</value>
-																</entry>
-																<entry>
 																	<key>margin-right</key>
 																	<value xsi:type="xsd:string">8px</value>
 																</entry>
 																<entry>
 																	<key>max-width</key>
 																	<value xsi:type="xsd:string">100%</value>
-																</entry>
-																<entry>
-																	<key>outline-color</key>
-																	<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-																</entry>
-																<entry>
-																	<key>text-align</key>
-																	<value xsi:type="xsd:string">left</value>
-																</entry>
-																<entry>
-																	<key>text-decoration-color</key>
-																	<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
-																</entry>
-																<entry>
-																	<key>white-space</key>
-																	<value xsi:type="xsd:string">nowrap</value>
 																</entry>
 															</attributes>
 														</attributes>
@@ -7286,18 +4104,6 @@
 															<value xsi:type="xsd:string">rgb(229, 229, 229)</value>
 														</entry>
 														<entry>
-															<key>border-bottom-style</key>
-															<value xsi:type="xsd:string">solid</value>
-														</entry>
-														<entry>
-															<key>border-bottom-width</key>
-															<value xsi:type="xsd:string">1px</value>
-														</entry>
-														<entry>
-															<key>border-image-width</key>
-															<value xsi:type="xsd:string">1</value>
-														</entry>
-														<entry>
 															<key>border-left-color</key>
 															<value xsi:type="xsd:string">rgb(63, 60, 57)</value>
 														</entry>
@@ -7322,10 +4128,6 @@
 															<value xsi:type="xsd:string">rgba(0, 0, 0, 0.03) 0px -2px 1px 0px inset</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(63, 60, 57)</value>
 														</entry>
@@ -7342,24 +4144,8 @@
 															<value xsi:type="xsd:string">rgb(63, 60, 57)</value>
 														</entry>
 														<entry>
-															<key>display</key>
-															<value xsi:type="xsd:string">block</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
 															<key>font-size</key>
 															<value xsi:type="xsd:string">15px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>margin-top</key>
-															<value xsi:type="xsd:string">-5px</value>
 														</entry>
 														<entry>
 															<key>outline-color</key>
@@ -7398,20 +4184,8 @@
 															<value xsi:type="xsd:string">relative</value>
 														</entry>
 														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
 															<key>text-decoration-color</key>
 															<value xsi:type="xsd:string">rgb(63, 60, 57)</value>
-														</entry>
-														<entry>
-															<key>transition-delay</key>
-															<value xsi:type="xsd:string">0.1s</value>
-														</entry>
-														<entry>
-															<key>transition-duration</key>
-															<value xsi:type="xsd:string">0.25s</value>
 														</entry>
 														<entry>
 															<key>transition-property</key>
@@ -7453,20 +4227,8 @@
 																<value xsi:type="xsd:string">3px</value>
 															</entry>
 															<entry>
-																<key>border-left-color</key>
-																<value xsi:type="xsd:string">rgb(63, 60, 57)</value>
-															</entry>
-															<entry>
 																<key>border-radius</key>
 																<value xsi:type="xsd:string">3px</value>
-															</entry>
-															<entry>
-																<key>border-right-color</key>
-																<value xsi:type="xsd:string">rgb(63, 60, 57)</value>
-															</entry>
-															<entry>
-																<key>border-top-color</key>
-																<value xsi:type="xsd:string">rgb(63, 60, 57)</value>
 															</entry>
 															<entry>
 																<key>border-top-left-radius</key>
@@ -7477,56 +4239,12 @@
 																<value xsi:type="xsd:string">3px</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
-																<key>caret-color</key>
-																<value xsi:type="xsd:string">rgb(63, 60, 57)</value>
-															</entry>
-															<entry>
-																<key>color</key>
-																<value xsi:type="xsd:string">rgb(63, 60, 57)</value>
-															</entry>
-															<entry>
-																<key>column-rule-color</key>
-																<value xsi:type="xsd:string">rgb(63, 60, 57)</value>
-															</entry>
-															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-															</entry>
-															<entry>
-																<key>font-size</key>
-																<value xsi:type="xsd:string">15px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
-															</entry>
-															<entry>
 																<key>margin-right</key>
 																<value xsi:type="xsd:string">8px</value>
 															</entry>
 															<entry>
 																<key>max-width</key>
 																<value xsi:type="xsd:string">100%</value>
-															</entry>
-															<entry>
-																<key>outline-color</key>
-																<value xsi:type="xsd:string">rgb(63, 60, 57)</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
-																<key>text-decoration-color</key>
-																<value xsi:type="xsd:string">rgb(63, 60, 57)</value>
-															</entry>
-															<entry>
-																<key>white-space</key>
-																<value xsi:type="xsd:string">nowrap</value>
 															</entry>
 														</attributes>
 													</attributes>
@@ -7553,62 +4271,7 @@
 							<attribute key="type" xsi:type="stringAttribute">SCRIPT</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">15px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="consolelogretest">
 					<identifyingAttributes>
@@ -7627,62 +4290,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">SCRIPT</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">15px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="script">
 					<identifyingAttributes>
@@ -7698,62 +4306,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">SCRIPT</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">15px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="windowjquery">
 					<identifyingAttributes>
@@ -7770,62 +4323,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">SCRIPT</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">15px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="script">
 					<identifyingAttributes>
@@ -7841,62 +4339,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">SCRIPT</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">15px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="script">
 					<identifyingAttributes>
@@ -7912,62 +4355,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">SCRIPT</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">15px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="script">
 					<identifyingAttributes>
@@ -7983,62 +4371,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">SCRIPT</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">15px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="script">
 					<identifyingAttributes>
@@ -8054,62 +4387,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">SCRIPT</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">15px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="script">
 					<identifyingAttributes>
@@ -8125,62 +4403,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">SCRIPT</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">15px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="script">
 					<identifyingAttributes>
@@ -8196,62 +4419,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">SCRIPT</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">15px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="script">
 					<identifyingAttributes>
@@ -8267,62 +4435,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">SCRIPT</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">15px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="section">
 					<identifyingAttributes>
@@ -8345,62 +4458,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<key>background-color</key>
 								<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
 							</entry>
-							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">15px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
 						</attributes>
 					</attributes>
 					<containedComponents retestId="div">
@@ -8422,60 +4479,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 						<attributes>
 							<attributes>
 								<entry>
-									<key>border-bottom-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-left-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-right-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-top-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
 									<key>bottom</key>
 									<value xsi:type="xsd:string">694px</value>
 								</entry>
 								<entry>
-									<key>box-sizing</key>
-									<value xsi:type="xsd:string">border-box</value>
-								</entry>
-								<entry>
-									<key>caret-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>column-rule-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-								</entry>
-								<entry>
-									<key>font-size</key>
-									<value xsi:type="xsd:string">15px</value>
-								</entry>
-								<entry>
 									<key>left</key>
 									<value xsi:type="xsd:string">875px</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">30px</value>
-								</entry>
-								<entry>
-									<key>outline-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 								</entry>
 								<entry>
 									<key>position</key>
@@ -8484,10 +4493,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<entry>
 									<key>right</key>
 									<value xsi:type="xsd:string">10px</value>
-								</entry>
-								<entry>
-									<key>text-decoration-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 								</entry>
 								<entry>
 									<key>top</key>
@@ -8515,62 +4520,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<attribute key="type" xsi:type="stringAttribute">DIV</attribute>
 							</attributes>
 						</identifyingAttributes>
-						<attributes>
-							<attributes>
-								<entry>
-									<key>border-bottom-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-left-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-right-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-top-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>box-sizing</key>
-									<value xsi:type="xsd:string">border-box</value>
-								</entry>
-								<entry>
-									<key>caret-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>column-rule-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-								</entry>
-								<entry>
-									<key>font-size</key>
-									<value xsi:type="xsd:string">15px</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">30px</value>
-								</entry>
-								<entry>
-									<key>outline-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>text-decoration-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-							</attributes>
-						</attributes>
+						<attributes/>
 						<containedComponents retestId="ul">
 							<identifyingAttributes>
 								<attributes>
@@ -8589,68 +4539,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attributes>
 								<attributes>
 									<entry>
-										<key>border-bottom-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>border-image-width</key>
-										<value xsi:type="xsd:string">1</value>
-									</entry>
-									<entry>
-										<key>border-left-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>border-right-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>border-top-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>box-sizing</key>
-										<value xsi:type="xsd:string">border-box</value>
-									</entry>
-									<entry>
-										<key>caret-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>column-rule-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">15px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">30px</value>
-									</entry>
-									<entry>
 										<key>list-style-type</key>
 										<value xsi:type="xsd:string">none</value>
-									</entry>
-									<entry>
-										<key>margin-bottom</key>
-										<value xsi:type="xsd:string">0px</value>
-									</entry>
-									<entry>
-										<key>margin-top</key>
-										<value xsi:type="xsd:string">0px</value>
-									</entry>
-									<entry>
-										<key>outline-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 									</entry>
 									<entry>
 										<key>overflow</key>
@@ -8665,16 +4555,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 										<value xsi:type="xsd:string">hidden</value>
 									</entry>
 									<entry>
-										<key>padding-left</key>
-										<value xsi:type="xsd:string">0px</value>
-									</entry>
-									<entry>
 										<key>position</key>
 										<value xsi:type="xsd:string">relative</value>
-									</entry>
-									<entry>
-										<key>text-decoration-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 									</entry>
 								</attributes>
 							</attributes>
@@ -8695,68 +4577,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<attributes>
 									<attributes>
 										<entry>
-											<key>border-bottom-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-image-width</key>
-											<value xsi:type="xsd:string">1</value>
-										</entry>
-										<entry>
-											<key>border-left-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-right-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-top-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>box-sizing</key>
-											<value xsi:type="xsd:string">border-box</value>
-										</entry>
-										<entry>
-											<key>caret-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>column-rule-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>font-family</key>
-											<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-										</entry>
-										<entry>
-											<key>font-size</key>
-											<value xsi:type="xsd:string">15px</value>
-										</entry>
-										<entry>
-											<key>line-height</key>
-											<value xsi:type="xsd:string">30px</value>
-										</entry>
-										<entry>
-											<key>list-style-type</key>
-											<value xsi:type="xsd:string">none</value>
-										</entry>
-										<entry>
-											<key>outline-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
 											<key>text-align</key>
 											<value xsi:type="xsd:string">left</value>
-										</entry>
-										<entry>
-											<key>text-decoration-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 										</entry>
 									</attributes>
 								</attributes>
@@ -8790,56 +4612,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<value xsi:type="xsd:string">1px</value>
 											</entry>
 											<entry>
-												<key>border-left-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-right-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
 												<key>border-style</key>
 												<value xsi:type="xsd:string">none none solid</value>
 											</entry>
 											<entry>
-												<key>border-top-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
 												<key>border-width</key>
 												<value xsi:type="xsd:string">0px 0px 1px</value>
-											</entry>
-											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
-											</entry>
-											<entry>
-												<key>caret-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>column-rule-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>font-family</key>
-												<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-											</entry>
-											<entry>
-												<key>font-size</key>
-												<value xsi:type="xsd:string">15px</value>
-											</entry>
-											<entry>
-												<key>line-height</key>
-												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
-												<key>list-style-type</key>
-												<value xsi:type="xsd:string">none</value>
 											</entry>
 											<entry>
 												<key>margin-left</key>
@@ -8854,20 +4632,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<value xsi:type="xsd:string">1020px</value>
 											</entry>
 											<entry>
-												<key>outline-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
 												<key>padding-bottom</key>
 												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
-												<key>text-align</key>
-												<value xsi:type="xsd:string">left</value>
-											</entry>
-											<entry>
-												<key>text-decoration-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 											</entry>
 										</attributes>
 									</attributes>
@@ -8905,10 +4671,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 												</entry>
 												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
 													<key>caret-color</key>
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 												</entry>
@@ -8919,22 +4681,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<entry>
 													<key>column-rule-color</key>
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-												</entry>
-												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">15px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">30px</value>
-												</entry>
-												<entry>
-													<key>list-style-type</key>
-													<value xsi:type="xsd:string">none</value>
 												</entry>
 												<entry>
 													<key>margin-bottom</key>
@@ -9000,10 +4746,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 													</entry>
 													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
 														<key>caret-color</key>
 														<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 													</entry>
@@ -9024,14 +4766,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">40px</value>
 													</entry>
 													<entry>
-														<key>font-weight</key>
-														<value xsi:type="xsd:string">400</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
 														<key>margin-bottom</key>
 														<value xsi:type="xsd:string">18px</value>
 													</entry>
@@ -9044,16 +4778,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 													</entry>
 													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">center</value>
-													</entry>
-													<entry>
 														<key>text-decoration-color</key>
 														<value xsi:type="xsd:string">rgb(0, 0, 51)</value>
 													</entry>
 												</attributes>
 											</attributes>
-											<containedComponents retestId="a5c39e39-87c3-4b1b-a3a6-b2fbf4bdd507">
+											<containedComponents retestId="0be6bd82-819c-4953-b2e6-d0e9c47d7b91">
 												<identifyingAttributes>
 													<attributes>
 														<attribute key="outline" xsi:type="outlineAttribute">
@@ -9087,10 +4817,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
@@ -9103,24 +4829,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">&quot;Gill Sans MT&quot;, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">40px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">center</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -9163,10 +4873,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
@@ -9179,24 +4885,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">&quot;Gill Sans MT&quot;, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">40px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">center</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -9239,10 +4929,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
@@ -9255,24 +4941,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">&quot;Gill Sans MT&quot;, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">40px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">center</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -9315,10 +4985,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
@@ -9331,24 +4997,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">&quot;Gill Sans MT&quot;, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">40px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">center</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -9357,7 +5007,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													</attributes>
 												</attributes>
 											</containedComponents>
-											<containedComponents retestId="c05ad958-8f87-4a5b-b667-78321a1a20db">
+											<containedComponents retestId="5faa0f17-606a-4668-9608-0e58310b6e91">
 												<identifyingAttributes>
 													<attributes>
 														<attribute key="outline" xsi:type="outlineAttribute">
@@ -9391,10 +5041,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
@@ -9407,24 +5053,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">&quot;Gill Sans MT&quot;, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">40px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">center</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -9457,60 +5087,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 												<entry>
-													<key>border-left-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-right-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-top-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
-													<key>caret-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>column-rule-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>float</key>
 													<value xsi:type="xsd:string">right</value>
 												</entry>
 												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">15px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">30px</value>
-												</entry>
-												<entry>
-													<key>list-style-type</key>
-													<value xsi:type="xsd:string">none</value>
-												</entry>
-												<entry>
 													<key>min-height</key>
 													<value xsi:type="xsd:string">1px</value>
-												</entry>
-												<entry>
-													<key>outline-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 												<entry>
 													<key>padding-left</key>
@@ -9523,14 +5105,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<entry>
 													<key>position</key>
 													<value xsi:type="xsd:string">relative</value>
-												</entry>
-												<entry>
-													<key>text-align</key>
-													<value xsi:type="xsd:string">left</value>
-												</entry>
-												<entry>
-													<key>text-decoration-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -9548,70 +5122,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 												</attributes>
 											</identifyingAttributes>
-											<attributes>
-												<attributes>
-													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-												</attributes>
-											</attributes>
+											<attributes/>
 										</containedComponents>
 										<containedComponents retestId="br">
 											<identifyingAttributes>
@@ -9627,70 +5138,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 												</attributes>
 											</identifyingAttributes>
-											<attributes>
-												<attributes>
-													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-												</attributes>
-											</attributes>
+											<attributes/>
 										</containedComponents>
 										<containedComponents retestId="br">
 											<identifyingAttributes>
@@ -9706,70 +5154,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 												</attributes>
 											</identifyingAttributes>
-											<attributes>
-												<attributes>
-													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-												</attributes>
-											</attributes>
+											<attributes/>
 										</containedComponents>
 										<containedComponents retestId="iframe">
 											<identifyingAttributes>
@@ -9789,72 +5174,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 											<attributes>
 												<attributes>
 													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-image-width</key>
-														<value xsi:type="xsd:string">1</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>display</key>
 														<value xsi:type="xsd:string">inline</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 													</entry>
 												</attributes>
 											</attributes>
@@ -9894,10 +5215,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 												</entry>
 												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
 													<key>caret-color</key>
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 												</entry>
@@ -9912,22 +5229,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<entry>
 													<key>float</key>
 													<value xsi:type="xsd:string">right</value>
-												</entry>
-												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">15px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">30px</value>
-												</entry>
-												<entry>
-													<key>list-style-type</key>
-													<value xsi:type="xsd:string">none</value>
 												</entry>
 												<entry>
 													<key>margin-bottom</key>
@@ -9980,52 +5281,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 											<attributes>
 												<attributes>
 													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
 														<key>font-size</key>
 														<value xsi:type="xsd:string">17px</value>
 													</entry>
 													<entry>
 														<key>line-height</key>
 														<value xsi:type="xsd:string">36px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
 													</entry>
 													<entry>
 														<key>margin-bottom</key>
@@ -10043,18 +5304,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<key>margin-top</key>
 														<value xsi:type="xsd:string">12px</value>
 													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">right</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-													</entry>
 												</attributes>
 											</attributes>
 											<containedComponents retestId="br">
@@ -10071,70 +5320,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 													</attributes>
 												</identifyingAttributes>
-												<attributes>
-													<attributes>
-														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">17px</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">36px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">right</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-													</attributes>
-												</attributes>
+												<attributes/>
 											</containedComponents>
 											<containedComponents retestId="br">
 												<identifyingAttributes>
@@ -10150,70 +5336,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 													</attributes>
 												</identifyingAttributes>
-												<attributes>
-													<attributes>
-														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">17px</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">36px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">right</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-													</attributes>
-												</attributes>
+												<attributes/>
 											</containedComponents>
 											<containedComponents retestId="have_you_had">
 												<identifyingAttributes>
@@ -10249,10 +5372,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 														</entry>
@@ -10265,32 +5384,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">17px</value>
-														</entry>
-														<entry>
-															<key>font-style</key>
-															<value xsi:type="xsd:string">normal</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">36px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">right</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -10312,70 +5407,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 														</attributes>
 													</identifyingAttributes>
-													<attributes>
-														<attributes>
-															<entry>
-																<key>border-bottom-color</key>
-																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-															</entry>
-															<entry>
-																<key>border-left-color</key>
-																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-															</entry>
-															<entry>
-																<key>border-right-color</key>
-																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-															</entry>
-															<entry>
-																<key>border-top-color</key>
-																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-															</entry>
-															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
-																<key>caret-color</key>
-																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-															</entry>
-															<entry>
-																<key>color</key>
-																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-															</entry>
-															<entry>
-																<key>column-rule-color</key>
-																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-															</entry>
-															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-															</entry>
-															<entry>
-																<key>font-size</key>
-																<value xsi:type="xsd:string">17px</value>
-															</entry>
-															<entry>
-																<key>line-height</key>
-																<value xsi:type="xsd:string">36px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
-															</entry>
-															<entry>
-																<key>outline-color</key>
-																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">right</value>
-															</entry>
-															<entry>
-																<key>text-decoration-color</key>
-																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-															</entry>
-														</attributes>
-													</attributes>
+													<attributes/>
 												</containedComponents>
 											</containedComponents>
 											<containedComponents retestId="use_an_artifici">
@@ -10412,10 +5444,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 														</entry>
@@ -10428,32 +5456,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">17px</value>
-														</entry>
-														<entry>
-															<key>font-style</key>
-															<value xsi:type="xsd:string">normal</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">36px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">right</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -10496,10 +5500,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 														</entry>
@@ -10512,32 +5512,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">17px</value>
-														</entry>
-														<entry>
-															<key>font-style</key>
-															<value xsi:type="xsd:string">normal</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">36px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">right</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -10546,7 +5522,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													</attributes>
 												</attributes>
 											</containedComponents>
-											<containedComponents retestId="42f9ca97-8596-4245-9114-12eb90729776">
+											<containedComponents retestId="07d66b1b-e4e4-4f5a-b396-cc7da88535f5">
 												<identifyingAttributes>
 													<attributes>
 														<attribute key="outline" xsi:type="outlineAttribute">
@@ -10580,10 +5556,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
@@ -10596,28 +5568,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">17px</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">36px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">right</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -10660,10 +5612,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
@@ -10676,28 +5624,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">17px</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">36px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">right</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -10727,68 +5655,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<attributes>
 									<attributes>
 										<entry>
-											<key>border-bottom-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-image-width</key>
-											<value xsi:type="xsd:string">1</value>
-										</entry>
-										<entry>
-											<key>border-left-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-right-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-top-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>box-sizing</key>
-											<value xsi:type="xsd:string">border-box</value>
-										</entry>
-										<entry>
-											<key>caret-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>column-rule-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>font-family</key>
-											<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-										</entry>
-										<entry>
-											<key>font-size</key>
-											<value xsi:type="xsd:string">15px</value>
-										</entry>
-										<entry>
-											<key>line-height</key>
-											<value xsi:type="xsd:string">30px</value>
-										</entry>
-										<entry>
-											<key>list-style-type</key>
-											<value xsi:type="xsd:string">none</value>
-										</entry>
-										<entry>
-											<key>outline-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
 											<key>text-align</key>
 											<value xsi:type="xsd:string">left</value>
-										</entry>
-										<entry>
-											<key>text-decoration-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 										</entry>
 									</attributes>
 								</attributes>
@@ -10822,56 +5690,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<value xsi:type="xsd:string">1px</value>
 											</entry>
 											<entry>
-												<key>border-left-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-right-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
 												<key>border-style</key>
 												<value xsi:type="xsd:string">none none solid</value>
 											</entry>
 											<entry>
-												<key>border-top-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
 												<key>border-width</key>
 												<value xsi:type="xsd:string">0px 0px 1px</value>
-											</entry>
-											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
-											</entry>
-											<entry>
-												<key>caret-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>column-rule-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>font-family</key>
-												<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-											</entry>
-											<entry>
-												<key>font-size</key>
-												<value xsi:type="xsd:string">15px</value>
-											</entry>
-											<entry>
-												<key>line-height</key>
-												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
-												<key>list-style-type</key>
-												<value xsi:type="xsd:string">none</value>
 											</entry>
 											<entry>
 												<key>margin-left</key>
@@ -10886,20 +5710,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<value xsi:type="xsd:string">1020px</value>
 											</entry>
 											<entry>
-												<key>outline-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
 												<key>padding-bottom</key>
 												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
-												<key>text-align</key>
-												<value xsi:type="xsd:string">left</value>
-											</entry>
-											<entry>
-												<key>text-decoration-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 											</entry>
 										</attributes>
 									</attributes>
@@ -10937,10 +5749,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 												</entry>
 												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
 													<key>caret-color</key>
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 												</entry>
@@ -10951,22 +5759,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<entry>
 													<key>column-rule-color</key>
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-												</entry>
-												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">15px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">30px</value>
-												</entry>
-												<entry>
-													<key>list-style-type</key>
-													<value xsi:type="xsd:string">none</value>
 												</entry>
 												<entry>
 													<key>margin-bottom</key>
@@ -11019,10 +5811,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
 													</entry>
 													<entry>
-														<key>border-image-width</key>
-														<value xsi:type="xsd:string">1</value>
-													</entry>
-													<entry>
 														<key>border-left-color</key>
 														<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
 													</entry>
@@ -11033,10 +5821,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<entry>
 														<key>border-top-color</key>
 														<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
 													</entry>
 													<entry>
 														<key>caret-color</key>
@@ -11067,10 +5851,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">42px</value>
 													</entry>
 													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
 														<key>margin-bottom</key>
 														<value xsi:type="xsd:string">6px</value>
 													</entry>
@@ -11081,10 +5861,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<entry>
 														<key>outline-color</key>
 														<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">center</value>
 													</entry>
 													<entry>
 														<key>text-decoration-color</key>
@@ -11110,10 +5886,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<attributes>
 													<attributes>
 														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
 															<key>border-bottom-left-radius</key>
 															<value xsi:type="xsd:string">3px</value>
 														</entry>
@@ -11122,20 +5894,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">3px</value>
 														</entry>
 														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
 															<key>border-radius</key>
 															<value xsi:type="xsd:string">3px</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
 														</entry>
 														<entry>
 															<key>border-top-left-radius</key>
@@ -11146,60 +5906,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">3px</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">30px</value>
-														</entry>
-														<entry>
-															<key>font-weight</key>
-															<value xsi:type="xsd:string">700</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">42px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>margin-right</key>
 															<value xsi:type="xsd:string">-30px</value>
 														</entry>
 														<entry>
 															<key>max-width</key>
 															<value xsi:type="xsd:string">100%</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">center</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
 														</entry>
 														<entry>
 															<key>vertical-align</key>
@@ -11242,10 +5954,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
@@ -11258,32 +5966,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">30px</value>
-														</entry>
-														<entry>
-															<key>font-weight</key>
-															<value xsi:type="xsd:string">700</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">42px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">center</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -11292,7 +5976,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													</attributes>
 												</attributes>
 											</containedComponents>
-											<containedComponents retestId="c93dafac-a43f-430c-a5e2-9e0594619bb3">
+											<containedComponents retestId="54c141e7-7f09-44a0-b701-6326510faf98">
 												<identifyingAttributes>
 													<attributes>
 														<attribute key="outline" xsi:type="outlineAttribute">
@@ -11326,10 +6010,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
@@ -11342,32 +6022,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">30px</value>
-														</entry>
-														<entry>
-															<key>font-weight</key>
-															<value xsi:type="xsd:string">700</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">42px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">center</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -11400,60 +6056,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 												<entry>
-													<key>border-left-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-right-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-top-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
-													<key>caret-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>column-rule-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>float</key>
 													<value xsi:type="xsd:string">left</value>
 												</entry>
 												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">15px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">30px</value>
-												</entry>
-												<entry>
-													<key>list-style-type</key>
-													<value xsi:type="xsd:string">none</value>
-												</entry>
-												<entry>
 													<key>min-height</key>
 													<value xsi:type="xsd:string">1px</value>
-												</entry>
-												<entry>
-													<key>outline-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 												<entry>
 													<key>padding-left</key>
@@ -11466,14 +6074,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<entry>
 													<key>position</key>
 													<value xsi:type="xsd:string">relative</value>
-												</entry>
-												<entry>
-													<key>text-align</key>
-													<value xsi:type="xsd:string">left</value>
-												</entry>
-												<entry>
-													<key>text-decoration-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -11494,10 +6094,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 											<attributes>
 												<attributes>
 													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>border-bottom-left-radius</key>
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
@@ -11506,20 +6102,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
 													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>border-radius</key>
 														<value xsi:type="xsd:string">3px</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 													</entry>
 													<entry>
 														<key>border-top-left-radius</key>
@@ -11530,60 +6114,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
 													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>display</key>
-														<value xsi:type="xsd:string">block</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
 														<key>max-height</key>
 														<value xsi:type="xsd:string">430px</value>
 													</entry>
 													<entry>
 														<key>max-width</key>
 														<value xsi:type="xsd:string">100%</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 													</entry>
 													<entry>
 														<key>vertical-align</key>
@@ -11615,60 +6151,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 												<entry>
-													<key>border-left-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-right-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-top-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
-													<key>caret-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>column-rule-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>float</key>
 													<value xsi:type="xsd:string">right</value>
 												</entry>
 												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">15px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">30px</value>
-												</entry>
-												<entry>
-													<key>list-style-type</key>
-													<value xsi:type="xsd:string">none</value>
-												</entry>
-												<entry>
 													<key>min-height</key>
 													<value xsi:type="xsd:string">1px</value>
-												</entry>
-												<entry>
-													<key>outline-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 												<entry>
 													<key>padding-left</key>
@@ -11681,14 +6169,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<entry>
 													<key>position</key>
 													<value xsi:type="xsd:string">relative</value>
-												</entry>
-												<entry>
-													<key>text-align</key>
-													<value xsi:type="xsd:string">left</value>
-												</entry>
-												<entry>
-													<key>text-decoration-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -11726,10 +6206,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 													</entry>
 													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
 														<key>caret-color</key>
 														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 													</entry>
@@ -11742,28 +6218,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 													</entry>
 													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
 														<key>outline-color</key>
 														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
 													</entry>
 													<entry>
 														<key>text-decoration-color</key>
@@ -11788,56 +6244,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<attributes>
 													<attributes>
 														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-														</entry>
-														<entry>
 															<key>font-size</key>
 															<value xsi:type="xsd:string">17px</value>
 														</entry>
 														<entry>
 															<key>line-height</key>
 															<value xsi:type="xsd:string">36px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>margin-bottom</key>
-															<value xsi:type="xsd:string">0px</value>
 														</entry>
 														<entry>
 															<key>margin-left</key>
@@ -11850,18 +6262,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<entry>
 															<key>margin-top</key>
 															<value xsi:type="xsd:string">12px</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 														</entry>
 													</attributes>
 												</attributes>
@@ -11879,70 +6279,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 														</attributes>
 													</identifyingAttributes>
-													<attributes>
-														<attributes>
-															<entry>
-																<key>border-bottom-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>border-left-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>border-right-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>border-top-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
-																<key>caret-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>column-rule-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-															</entry>
-															<entry>
-																<key>font-size</key>
-																<value xsi:type="xsd:string">17px</value>
-															</entry>
-															<entry>
-																<key>line-height</key>
-																<value xsi:type="xsd:string">36px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
-															</entry>
-															<entry>
-																<key>outline-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
-																<key>text-decoration-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-														</attributes>
-													</attributes>
+													<attributes/>
 												</containedComponents>
 												<containedComponents retestId="no_need_to_crea">
 													<identifyingAttributes>
@@ -11978,10 +6315,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 															</entry>
@@ -11994,32 +6327,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-															</entry>
-															<entry>
-																<key>font-size</key>
-																<value xsi:type="xsd:string">17px</value>
-															</entry>
-															<entry>
-																<key>font-style</key>
-																<value xsi:type="xsd:string">normal</value>
-															</entry>
-															<entry>
-																<key>line-height</key>
-																<value xsi:type="xsd:string">36px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
-															</entry>
-															<entry>
 																<key>outline-color</key>
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
 															</entry>
 															<entry>
 																<key>text-decoration-color</key>
@@ -12028,7 +6337,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														</attributes>
 													</attributes>
 												</containedComponents>
-												<containedComponents retestId="5dfdf25c-7e0f-4a16-9e84-90e0ce1f7e80">
+												<containedComponents retestId="2cd78440-ceb0-4877-a0bb-e70d6da15844">
 													<identifyingAttributes>
 														<attributes>
 															<attribute key="outline" xsi:type="outlineAttribute">
@@ -12062,10 +6371,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 															</entry>
@@ -12078,28 +6383,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-															</entry>
-															<entry>
-																<key>font-size</key>
-																<value xsi:type="xsd:string">17px</value>
-															</entry>
-															<entry>
-																<key>line-height</key>
-																<value xsi:type="xsd:string">36px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
-															</entry>
-															<entry>
 																<key>outline-color</key>
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
 															</entry>
 															<entry>
 																<key>text-decoration-color</key>
@@ -12142,10 +6427,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 															</entry>
@@ -12158,28 +6439,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-															</entry>
-															<entry>
-																<key>font-size</key>
-																<value xsi:type="xsd:string">17px</value>
-															</entry>
-															<entry>
-																<key>line-height</key>
-																<value xsi:type="xsd:string">36px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
-															</entry>
-															<entry>
 																<key>outline-color</key>
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
 															</entry>
 															<entry>
 																<key>text-decoration-color</key>
@@ -12222,10 +6483,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 															</entry>
@@ -12238,28 +6495,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-															</entry>
-															<entry>
-																<key>font-size</key>
-																<value xsi:type="xsd:string">17px</value>
-															</entry>
-															<entry>
-																<key>line-height</key>
-																<value xsi:type="xsd:string">36px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
-															</entry>
-															<entry>
 																<key>outline-color</key>
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
 															</entry>
 															<entry>
 																<key>text-decoration-color</key>
@@ -12290,68 +6527,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<attributes>
 									<attributes>
 										<entry>
-											<key>border-bottom-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-image-width</key>
-											<value xsi:type="xsd:string">1</value>
-										</entry>
-										<entry>
-											<key>border-left-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-right-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-top-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>box-sizing</key>
-											<value xsi:type="xsd:string">border-box</value>
-										</entry>
-										<entry>
-											<key>caret-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>column-rule-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>font-family</key>
-											<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-										</entry>
-										<entry>
-											<key>font-size</key>
-											<value xsi:type="xsd:string">15px</value>
-										</entry>
-										<entry>
-											<key>line-height</key>
-											<value xsi:type="xsd:string">30px</value>
-										</entry>
-										<entry>
-											<key>list-style-type</key>
-											<value xsi:type="xsd:string">none</value>
-										</entry>
-										<entry>
-											<key>outline-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
 											<key>text-align</key>
 											<value xsi:type="xsd:string">left</value>
-										</entry>
-										<entry>
-											<key>text-decoration-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 										</entry>
 									</attributes>
 								</attributes>
@@ -12385,56 +6562,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<value xsi:type="xsd:string">1px</value>
 											</entry>
 											<entry>
-												<key>border-left-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-right-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
 												<key>border-style</key>
 												<value xsi:type="xsd:string">none none solid</value>
 											</entry>
 											<entry>
-												<key>border-top-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
 												<key>border-width</key>
 												<value xsi:type="xsd:string">0px 0px 1px</value>
-											</entry>
-											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
-											</entry>
-											<entry>
-												<key>caret-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>column-rule-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>font-family</key>
-												<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-											</entry>
-											<entry>
-												<key>font-size</key>
-												<value xsi:type="xsd:string">15px</value>
-											</entry>
-											<entry>
-												<key>line-height</key>
-												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
-												<key>list-style-type</key>
-												<value xsi:type="xsd:string">none</value>
 											</entry>
 											<entry>
 												<key>margin-left</key>
@@ -12449,20 +6582,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<value xsi:type="xsd:string">1020px</value>
 											</entry>
 											<entry>
-												<key>outline-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
 												<key>padding-bottom</key>
 												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
-												<key>text-align</key>
-												<value xsi:type="xsd:string">left</value>
-											</entry>
-											<entry>
-												<key>text-decoration-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 											</entry>
 										</attributes>
 									</attributes>
@@ -12500,10 +6621,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 												</entry>
 												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
 													<key>caret-color</key>
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 												</entry>
@@ -12514,22 +6631,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<entry>
 													<key>column-rule-color</key>
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-												</entry>
-												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">15px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">30px</value>
-												</entry>
-												<entry>
-													<key>list-style-type</key>
-													<value xsi:type="xsd:string">none</value>
 												</entry>
 												<entry>
 													<key>margin-bottom</key>
@@ -12582,10 +6683,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
 													</entry>
 													<entry>
-														<key>border-image-width</key>
-														<value xsi:type="xsd:string">1</value>
-													</entry>
-													<entry>
 														<key>border-left-color</key>
 														<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
 													</entry>
@@ -12596,10 +6693,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<entry>
 														<key>border-top-color</key>
 														<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
 													</entry>
 													<entry>
 														<key>caret-color</key>
@@ -12630,10 +6723,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">42px</value>
 													</entry>
 													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
 														<key>margin-bottom</key>
 														<value xsi:type="xsd:string">6px</value>
 													</entry>
@@ -12644,10 +6733,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<entry>
 														<key>outline-color</key>
 														<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">center</value>
 													</entry>
 													<entry>
 														<key>text-decoration-color</key>
@@ -12673,10 +6758,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<attributes>
 													<attributes>
 														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
 															<key>border-bottom-left-radius</key>
 															<value xsi:type="xsd:string">3px</value>
 														</entry>
@@ -12685,20 +6766,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">3px</value>
 														</entry>
 														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
 															<key>border-radius</key>
 															<value xsi:type="xsd:string">3px</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
 														</entry>
 														<entry>
 															<key>border-top-left-radius</key>
@@ -12709,60 +6778,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">3px</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">30px</value>
-														</entry>
-														<entry>
-															<key>font-weight</key>
-															<value xsi:type="xsd:string">700</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">42px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>margin-right</key>
 															<value xsi:type="xsd:string">-30px</value>
 														</entry>
 														<entry>
 															<key>max-width</key>
 															<value xsi:type="xsd:string">100%</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">center</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
 														</entry>
 														<entry>
 															<key>vertical-align</key>
@@ -12805,10 +6826,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
@@ -12821,32 +6838,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">30px</value>
-														</entry>
-														<entry>
-															<key>font-weight</key>
-															<value xsi:type="xsd:string">700</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">42px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">center</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -12855,7 +6848,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													</attributes>
 												</attributes>
 											</containedComponents>
-											<containedComponents retestId="d367de9e-2baf-467f-9c63-1b4b9e78ff73">
+											<containedComponents retestId="282e58f3-b07f-4f2a-84b3-86a6bb84fdf3">
 												<identifyingAttributes>
 													<attributes>
 														<attribute key="outline" xsi:type="outlineAttribute">
@@ -12889,10 +6882,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
@@ -12905,32 +6894,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">30px</value>
-														</entry>
-														<entry>
-															<key>font-weight</key>
-															<value xsi:type="xsd:string">700</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">42px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">center</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -12963,60 +6928,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 												<entry>
-													<key>border-left-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-right-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-top-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
-													<key>caret-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>column-rule-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>float</key>
 													<value xsi:type="xsd:string">left</value>
 												</entry>
 												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">15px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">30px</value>
-												</entry>
-												<entry>
-													<key>list-style-type</key>
-													<value xsi:type="xsd:string">none</value>
-												</entry>
-												<entry>
 													<key>min-height</key>
 													<value xsi:type="xsd:string">1px</value>
-												</entry>
-												<entry>
-													<key>outline-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 												<entry>
 													<key>padding-left</key>
@@ -13029,14 +6946,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<entry>
 													<key>position</key>
 													<value xsi:type="xsd:string">relative</value>
-												</entry>
-												<entry>
-													<key>text-align</key>
-													<value xsi:type="xsd:string">left</value>
-												</entry>
-												<entry>
-													<key>text-decoration-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -13074,10 +6983,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 													</entry>
 													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
 														<key>caret-color</key>
 														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 													</entry>
@@ -13088,22 +6993,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<entry>
 														<key>column-rule-color</key>
 														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
 													</entry>
 													<entry>
 														<key>outline-color</key>
@@ -13142,56 +7031,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<attributes>
 													<attributes>
 														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-														</entry>
-														<entry>
 															<key>font-size</key>
 															<value xsi:type="xsd:string">17px</value>
 														</entry>
 														<entry>
 															<key>line-height</key>
 															<value xsi:type="xsd:string">36px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>margin-bottom</key>
-															<value xsi:type="xsd:string">0px</value>
 														</entry>
 														<entry>
 															<key>margin-left</key>
@@ -13204,18 +7049,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<entry>
 															<key>margin-top</key>
 															<value xsi:type="xsd:string">12px</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">right</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 														</entry>
 													</attributes>
 												</attributes>
@@ -13233,70 +7066,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 														</attributes>
 													</identifyingAttributes>
-													<attributes>
-														<attributes>
-															<entry>
-																<key>border-bottom-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>border-left-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>border-right-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>border-top-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
-																<key>caret-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>column-rule-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-															</entry>
-															<entry>
-																<key>font-size</key>
-																<value xsi:type="xsd:string">17px</value>
-															</entry>
-															<entry>
-																<key>line-height</key>
-																<value xsi:type="xsd:string">36px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
-															</entry>
-															<entry>
-																<key>outline-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">right</value>
-															</entry>
-															<entry>
-																<key>text-decoration-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-														</attributes>
-													</attributes>
+													<attributes/>
 												</containedComponents>
 												<containedComponents retestId="retest_compares">
 													<identifyingAttributes>
@@ -13332,10 +7102,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 															</entry>
@@ -13348,32 +7114,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-															</entry>
-															<entry>
-																<key>font-size</key>
-																<value xsi:type="xsd:string">17px</value>
-															</entry>
-															<entry>
-																<key>font-style</key>
-																<value xsi:type="xsd:string">normal</value>
-															</entry>
-															<entry>
-																<key>line-height</key>
-																<value xsi:type="xsd:string">36px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
-															</entry>
-															<entry>
 																<key>outline-color</key>
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">right</value>
 															</entry>
 															<entry>
 																<key>text-decoration-color</key>
@@ -13407,60 +7149,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 												<entry>
-													<key>border-left-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-right-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-top-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
-													<key>caret-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>column-rule-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>float</key>
 													<value xsi:type="xsd:string">right</value>
 												</entry>
 												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">15px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">30px</value>
-												</entry>
-												<entry>
-													<key>list-style-type</key>
-													<value xsi:type="xsd:string">none</value>
-												</entry>
-												<entry>
 													<key>min-height</key>
 													<value xsi:type="xsd:string">1px</value>
-												</entry>
-												<entry>
-													<key>outline-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 												<entry>
 													<key>padding-left</key>
@@ -13473,14 +7167,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<entry>
 													<key>position</key>
 													<value xsi:type="xsd:string">relative</value>
-												</entry>
-												<entry>
-													<key>text-align</key>
-													<value xsi:type="xsd:string">left</value>
-												</entry>
-												<entry>
-													<key>text-decoration-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -13498,70 +7184,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 												</attributes>
 											</identifyingAttributes>
-											<attributes>
-												<attributes>
-													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-												</attributes>
-											</attributes>
+											<attributes/>
 										</containedComponents>
 										<containedComponents retestId="img">
 											<identifyingAttributes>
@@ -13580,10 +7203,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 											<attributes>
 												<attributes>
 													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>border-bottom-left-radius</key>
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
@@ -13592,20 +7211,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
 													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>border-radius</key>
 														<value xsi:type="xsd:string">3px</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 													</entry>
 													<entry>
 														<key>border-top-left-radius</key>
@@ -13616,60 +7223,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
 													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>display</key>
-														<value xsi:type="xsd:string">block</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
 														<key>max-height</key>
 														<value xsi:type="xsd:string">200px</value>
 													</entry>
 													<entry>
 														<key>max-width</key>
 														<value xsi:type="xsd:string">100%</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 													</entry>
 													<entry>
 														<key>vertical-align</key>
@@ -13695,10 +7254,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 											<attributes>
 												<attributes>
 													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>border-bottom-left-radius</key>
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
@@ -13707,20 +7262,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
 													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>border-radius</key>
 														<value xsi:type="xsd:string">3px</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 													</entry>
 													<entry>
 														<key>border-top-left-radius</key>
@@ -13731,60 +7274,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
 													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>display</key>
-														<value xsi:type="xsd:string">block</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
 														<key>max-height</key>
 														<value xsi:type="xsd:string">200px</value>
 													</entry>
 													<entry>
 														<key>max-width</key>
 														<value xsi:type="xsd:string">100%</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 													</entry>
 													<entry>
 														<key>vertical-align</key>
@@ -13813,68 +7308,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<attributes>
 									<attributes>
 										<entry>
-											<key>border-bottom-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-image-width</key>
-											<value xsi:type="xsd:string">1</value>
-										</entry>
-										<entry>
-											<key>border-left-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-right-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-top-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>box-sizing</key>
-											<value xsi:type="xsd:string">border-box</value>
-										</entry>
-										<entry>
-											<key>caret-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>column-rule-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>font-family</key>
-											<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-										</entry>
-										<entry>
-											<key>font-size</key>
-											<value xsi:type="xsd:string">15px</value>
-										</entry>
-										<entry>
-											<key>line-height</key>
-											<value xsi:type="xsd:string">30px</value>
-										</entry>
-										<entry>
-											<key>list-style-type</key>
-											<value xsi:type="xsd:string">none</value>
-										</entry>
-										<entry>
-											<key>outline-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
 											<key>text-align</key>
 											<value xsi:type="xsd:string">left</value>
-										</entry>
-										<entry>
-											<key>text-decoration-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 										</entry>
 									</attributes>
 								</attributes>
@@ -13908,56 +7343,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<value xsi:type="xsd:string">1px</value>
 											</entry>
 											<entry>
-												<key>border-left-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-right-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
 												<key>border-style</key>
 												<value xsi:type="xsd:string">none none solid</value>
 											</entry>
 											<entry>
-												<key>border-top-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
 												<key>border-width</key>
 												<value xsi:type="xsd:string">0px 0px 1px</value>
-											</entry>
-											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
-											</entry>
-											<entry>
-												<key>caret-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>column-rule-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>font-family</key>
-												<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-											</entry>
-											<entry>
-												<key>font-size</key>
-												<value xsi:type="xsd:string">15px</value>
-											</entry>
-											<entry>
-												<key>line-height</key>
-												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
-												<key>list-style-type</key>
-												<value xsi:type="xsd:string">none</value>
 											</entry>
 											<entry>
 												<key>margin-left</key>
@@ -13972,20 +7363,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<value xsi:type="xsd:string">1020px</value>
 											</entry>
 											<entry>
-												<key>outline-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
 												<key>padding-bottom</key>
 												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
-												<key>text-align</key>
-												<value xsi:type="xsd:string">left</value>
-											</entry>
-											<entry>
-												<key>text-decoration-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 											</entry>
 										</attributes>
 									</attributes>
@@ -14023,10 +7402,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 												</entry>
 												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
 													<key>caret-color</key>
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 												</entry>
@@ -14037,22 +7412,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<entry>
 													<key>column-rule-color</key>
 													<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-												</entry>
-												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">15px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">30px</value>
-												</entry>
-												<entry>
-													<key>list-style-type</key>
-													<value xsi:type="xsd:string">none</value>
 												</entry>
 												<entry>
 													<key>margin-bottom</key>
@@ -14105,10 +7464,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
 													</entry>
 													<entry>
-														<key>border-image-width</key>
-														<value xsi:type="xsd:string">1</value>
-													</entry>
-													<entry>
 														<key>border-left-color</key>
 														<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
 													</entry>
@@ -14119,10 +7474,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<entry>
 														<key>border-top-color</key>
 														<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
 													</entry>
 													<entry>
 														<key>caret-color</key>
@@ -14153,10 +7504,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">42px</value>
 													</entry>
 													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
 														<key>margin-bottom</key>
 														<value xsi:type="xsd:string">6px</value>
 													</entry>
@@ -14167,10 +7514,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<entry>
 														<key>outline-color</key>
 														<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">center</value>
 													</entry>
 													<entry>
 														<key>text-decoration-color</key>
@@ -14196,10 +7539,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<attributes>
 													<attributes>
 														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
 															<key>border-bottom-left-radius</key>
 															<value xsi:type="xsd:string">3px</value>
 														</entry>
@@ -14208,20 +7547,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">3px</value>
 														</entry>
 														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
 															<key>border-radius</key>
 															<value xsi:type="xsd:string">3px</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
 														</entry>
 														<entry>
 															<key>border-top-left-radius</key>
@@ -14232,60 +7559,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">3px</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">30px</value>
-														</entry>
-														<entry>
-															<key>font-weight</key>
-															<value xsi:type="xsd:string">700</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">42px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>margin-right</key>
 															<value xsi:type="xsd:string">-30px</value>
 														</entry>
 														<entry>
 															<key>max-width</key>
 															<value xsi:type="xsd:string">100%</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">center</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(49, 49, 49)</value>
 														</entry>
 														<entry>
 															<key>vertical-align</key>
@@ -14328,10 +7607,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
@@ -14344,32 +7619,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">30px</value>
-														</entry>
-														<entry>
-															<key>font-weight</key>
-															<value xsi:type="xsd:string">700</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">42px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">center</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -14378,7 +7629,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													</attributes>
 												</attributes>
 											</containedComponents>
-											<containedComponents retestId="78c0a5e6-92e0-4df6-8eca-42fc4bde7f2c">
+											<containedComponents retestId="bb3e4be9-364d-4200-9458-a3dd73328a4d">
 												<identifyingAttributes>
 													<attributes>
 														<attribute key="outline" xsi:type="outlineAttribute">
@@ -14412,10 +7663,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
 															<key>caret-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
@@ -14428,32 +7675,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 														</entry>
 														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">raleway-bold, sans-serif</value>
-														</entry>
-														<entry>
-															<key>font-size</key>
-															<value xsi:type="xsd:string">30px</value>
-														</entry>
-														<entry>
-															<key>font-weight</key>
-															<value xsi:type="xsd:string">700</value>
-														</entry>
-														<entry>
-															<key>line-height</key>
-															<value xsi:type="xsd:string">42px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
 															<key>outline-color</key>
 															<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">center</value>
 														</entry>
 														<entry>
 															<key>text-decoration-color</key>
@@ -14486,60 +7709,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 												<entry>
-													<key>border-left-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-right-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-top-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
-													<key>caret-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>column-rule-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>float</key>
 													<value xsi:type="xsd:string">left</value>
 												</entry>
 												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">15px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">30px</value>
-												</entry>
-												<entry>
-													<key>list-style-type</key>
-													<value xsi:type="xsd:string">none</value>
-												</entry>
-												<entry>
 													<key>min-height</key>
 													<value xsi:type="xsd:string">1px</value>
-												</entry>
-												<entry>
-													<key>outline-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 												<entry>
 													<key>padding-left</key>
@@ -14552,14 +7727,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<entry>
 													<key>position</key>
 													<value xsi:type="xsd:string">relative</value>
-												</entry>
-												<entry>
-													<key>text-align</key>
-													<value xsi:type="xsd:string">left</value>
-												</entry>
-												<entry>
-													<key>text-decoration-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -14577,70 +7744,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 												</attributes>
 											</identifyingAttributes>
-											<attributes>
-												<attributes>
-													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-												</attributes>
-											</attributes>
+											<attributes/>
 										</containedComponents>
 										<containedComponents retestId="br">
 											<identifyingAttributes>
@@ -14656,70 +7760,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 												</attributes>
 											</identifyingAttributes>
-											<attributes>
-												<attributes>
-													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-												</attributes>
-											</attributes>
+											<attributes/>
 										</containedComponents>
 										<containedComponents retestId="br">
 											<identifyingAttributes>
@@ -14735,70 +7776,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 												</attributes>
 											</identifyingAttributes>
-											<attributes>
-												<attributes>
-													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-												</attributes>
-											</attributes>
+											<attributes/>
 										</containedComponents>
 										<containedComponents retestId="img">
 											<identifyingAttributes>
@@ -14817,10 +7795,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 											<attributes>
 												<attributes>
 													<entry>
-														<key>border-bottom-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>border-bottom-left-radius</key>
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
@@ -14829,20 +7803,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
 													<entry>
-														<key>border-left-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
 														<key>border-radius</key>
 														<value xsi:type="xsd:string">3px</value>
-													</entry>
-													<entry>
-														<key>border-right-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>border-top-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 													</entry>
 													<entry>
 														<key>border-top-left-radius</key>
@@ -14853,60 +7815,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">3px</value>
 													</entry>
 													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
-														<key>caret-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>column-rule-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>display</key>
-														<value xsi:type="xsd:string">block</value>
-													</entry>
-													<entry>
 														<key>float</key>
 														<value xsi:type="xsd:string">right</value>
 													</entry>
 													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
 														<key>max-width</key>
 														<value xsi:type="xsd:string">400px</value>
-													</entry>
-													<entry>
-														<key>outline-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
-													</entry>
-													<entry>
-														<key>text-decoration-color</key>
-														<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 													</entry>
 													<entry>
 														<key>vertical-align</key>
@@ -14938,60 +7852,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 												<entry>
-													<key>border-left-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-right-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-top-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
-													<key>caret-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>column-rule-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
 													<key>float</key>
 													<value xsi:type="xsd:string">right</value>
 												</entry>
 												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">15px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">30px</value>
-												</entry>
-												<entry>
-													<key>list-style-type</key>
-													<value xsi:type="xsd:string">none</value>
-												</entry>
-												<entry>
 													<key>min-height</key>
 													<value xsi:type="xsd:string">1px</value>
-												</entry>
-												<entry>
-													<key>outline-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 												<entry>
 													<key>padding-left</key>
@@ -15004,14 +7870,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<entry>
 													<key>position</key>
 													<value xsi:type="xsd:string">relative</value>
-												</entry>
-												<entry>
-													<key>text-align</key>
-													<value xsi:type="xsd:string">left</value>
-												</entry>
-												<entry>
-													<key>text-decoration-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 												</entry>
 											</attributes>
 										</attributes>
@@ -15049,10 +7907,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 													</entry>
 													<entry>
-														<key>box-sizing</key>
-														<value xsi:type="xsd:string">border-box</value>
-													</entry>
-													<entry>
 														<key>caret-color</key>
 														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 													</entry>
@@ -15065,28 +7919,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 													</entry>
 													<entry>
-														<key>font-family</key>
-														<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-													</entry>
-													<entry>
-														<key>font-size</key>
-														<value xsi:type="xsd:string">15px</value>
-													</entry>
-													<entry>
-														<key>line-height</key>
-														<value xsi:type="xsd:string">30px</value>
-													</entry>
-													<entry>
-														<key>list-style-type</key>
-														<value xsi:type="xsd:string">none</value>
-													</entry>
-													<entry>
 														<key>outline-color</key>
 														<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-													</entry>
-													<entry>
-														<key>text-align</key>
-														<value xsi:type="xsd:string">left</value>
 													</entry>
 													<entry>
 														<key>text-decoration-color</key>
@@ -15111,56 +7945,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<attributes>
 													<attributes>
 														<entry>
-															<key>border-bottom-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-left-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-right-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>border-top-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>box-sizing</key>
-															<value xsi:type="xsd:string">border-box</value>
-														</entry>
-														<entry>
-															<key>caret-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>column-rule-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>font-family</key>
-															<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-														</entry>
-														<entry>
 															<key>font-size</key>
 															<value xsi:type="xsd:string">17px</value>
 														</entry>
 														<entry>
 															<key>line-height</key>
 															<value xsi:type="xsd:string">36px</value>
-														</entry>
-														<entry>
-															<key>list-style-type</key>
-															<value xsi:type="xsd:string">none</value>
-														</entry>
-														<entry>
-															<key>margin-bottom</key>
-															<value xsi:type="xsd:string">0px</value>
 														</entry>
 														<entry>
 															<key>margin-left</key>
@@ -15173,18 +7963,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														<entry>
 															<key>margin-top</key>
 															<value xsi:type="xsd:string">12px</value>
-														</entry>
-														<entry>
-															<key>outline-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-														</entry>
-														<entry>
-															<key>text-align</key>
-															<value xsi:type="xsd:string">left</value>
-														</entry>
-														<entry>
-															<key>text-decoration-color</key>
-															<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
 														</entry>
 													</attributes>
 												</attributes>
@@ -15202,70 +7980,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 														</attributes>
 													</identifyingAttributes>
-													<attributes>
-														<attributes>
-															<entry>
-																<key>border-bottom-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>border-left-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>border-right-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>border-top-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
-																<key>caret-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>column-rule-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-															</entry>
-															<entry>
-																<key>font-size</key>
-																<value xsi:type="xsd:string">17px</value>
-															</entry>
-															<entry>
-																<key>line-height</key>
-																<value xsi:type="xsd:string">36px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
-															</entry>
-															<entry>
-																<key>outline-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
-																<key>text-decoration-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-														</attributes>
-													</attributes>
+													<attributes/>
 												</containedComponents>
 												<containedComponents retestId="br">
 													<identifyingAttributes>
@@ -15281,70 +7996,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 															<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 														</attributes>
 													</identifyingAttributes>
-													<attributes>
-														<attributes>
-															<entry>
-																<key>border-bottom-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>border-left-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>border-right-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>border-top-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
-																<key>caret-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>column-rule-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-															</entry>
-															<entry>
-																<key>font-size</key>
-																<value xsi:type="xsd:string">17px</value>
-															</entry>
-															<entry>
-																<key>line-height</key>
-																<value xsi:type="xsd:string">36px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
-															</entry>
-															<entry>
-																<key>outline-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
-															</entry>
-															<entry>
-																<key>text-decoration-color</key>
-																<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
-															</entry>
-														</attributes>
-													</attributes>
+													<attributes/>
 												</containedComponents>
 												<containedComponents retestId="the_future_of">
 													<identifyingAttributes>
@@ -15380,10 +8032,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 															</entry>
@@ -15396,32 +8044,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-															</entry>
-															<entry>
-																<key>font-size</key>
-																<value xsi:type="xsd:string">17px</value>
-															</entry>
-															<entry>
-																<key>font-style</key>
-																<value xsi:type="xsd:string">normal</value>
-															</entry>
-															<entry>
-																<key>line-height</key>
-																<value xsi:type="xsd:string">36px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
-															</entry>
-															<entry>
 																<key>outline-color</key>
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
 															</entry>
 															<entry>
 																<key>text-decoration-color</key>
@@ -15464,10 +8088,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 															</entry>
@@ -15480,32 +8100,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-															</entry>
-															<entry>
-																<key>font-size</key>
-																<value xsi:type="xsd:string">17px</value>
-															</entry>
-															<entry>
-																<key>font-style</key>
-																<value xsi:type="xsd:string">normal</value>
-															</entry>
-															<entry>
-																<key>line-height</key>
-																<value xsi:type="xsd:string">36px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
-															</entry>
-															<entry>
 																<key>outline-color</key>
 																<value xsi:type="xsd:string">rgb(65, 65, 65)</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
 															</entry>
 															<entry>
 																<key>text-decoration-color</key>
@@ -15514,7 +8110,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 														</attributes>
 													</attributes>
 												</containedComponents>
-												<containedComponents retestId="5061947d-5421-4701-96b1-61bf6d8c22b0">
+												<containedComponents retestId="9b1b1b6b-e04e-4ab2-90cf-31dd41502f79">
 													<identifyingAttributes>
 														<attributes>
 															<attribute key="outline" xsi:type="outlineAttribute">
@@ -15548,10 +8144,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 															</entry>
 															<entry>
-																<key>box-sizing</key>
-																<value xsi:type="xsd:string">border-box</value>
-															</entry>
-															<entry>
 																<key>caret-color</key>
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 															</entry>
@@ -15564,28 +8156,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 															</entry>
 															<entry>
-																<key>font-family</key>
-																<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-															</entry>
-															<entry>
-																<key>font-size</key>
-																<value xsi:type="xsd:string">17px</value>
-															</entry>
-															<entry>
-																<key>line-height</key>
-																<value xsi:type="xsd:string">36px</value>
-															</entry>
-															<entry>
-																<key>list-style-type</key>
-																<value xsi:type="xsd:string">none</value>
-															</entry>
-															<entry>
 																<key>outline-color</key>
 																<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-															</entry>
-															<entry>
-																<key>text-align</key>
-																<value xsi:type="xsd:string">left</value>
 															</entry>
 															<entry>
 																<key>text-decoration-color</key>
@@ -15624,68 +8196,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
 							</entry>
 							<entry>
-								<key>border-bottom-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>border-left-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-right-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>border-top-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>caret-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>column-rule-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
-								<key>font-family</key>
-								<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">15px</value>
-							</entry>
-							<entry>
-								<key>line-height</key>
-								<value xsi:type="xsd:string">30px</value>
-							</entry>
-							<entry>
-								<key>outline-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-							</entry>
-							<entry>
 								<key>padding-bottom</key>
 								<value xsi:type="xsd:string">42px</value>
 							</entry>
 							<entry>
 								<key>padding-top</key>
 								<value xsi:type="xsd:string">60px</value>
-							</entry>
-							<entry>
-								<key>text-decoration-color</key>
-								<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -15707,50 +8223,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 						<attributes>
 							<attributes>
 								<entry>
-									<key>border-bottom-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-left-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-right-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>border-top-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>box-sizing</key>
-									<value xsi:type="xsd:string">border-box</value>
-								</entry>
-								<entry>
-									<key>caret-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>column-rule-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>font-family</key>
-									<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-								</entry>
-								<entry>
-									<key>font-size</key>
-									<value xsi:type="xsd:string">15px</value>
-								</entry>
-								<entry>
-									<key>line-height</key>
-									<value xsi:type="xsd:string">30px</value>
-								</entry>
-								<entry>
 									<key>margin-left</key>
 									<value xsi:type="xsd:string">82.5px</value>
 								</entry>
@@ -15761,14 +8233,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<entry>
 									<key>max-width</key>
 									<value xsi:type="xsd:string">1020px</value>
-								</entry>
-								<entry>
-									<key>outline-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-								</entry>
-								<entry>
-									<key>text-decoration-color</key>
-									<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 								</entry>
 							</attributes>
 						</attributes>
@@ -15787,62 +8251,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 									<attribute key="type" xsi:type="stringAttribute">DIV</attribute>
 								</attributes>
 							</identifyingAttributes>
-							<attributes>
-								<attributes>
-									<entry>
-										<key>border-bottom-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>border-left-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>border-right-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>border-top-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>box-sizing</key>
-										<value xsi:type="xsd:string">border-box</value>
-									</entry>
-									<entry>
-										<key>caret-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>column-rule-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>font-family</key>
-										<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-									</entry>
-									<entry>
-										<key>font-size</key>
-										<value xsi:type="xsd:string">15px</value>
-									</entry>
-									<entry>
-										<key>line-height</key>
-										<value xsi:type="xsd:string">30px</value>
-									</entry>
-									<entry>
-										<key>outline-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-									<entry>
-										<key>text-decoration-color</key>
-										<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-									</entry>
-								</attributes>
-							</attributes>
+							<attributes/>
 							<containedComponents retestId="div">
 								<identifyingAttributes>
 									<attributes>
@@ -15861,60 +8270,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<attributes>
 									<attributes>
 										<entry>
-											<key>border-bottom-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-left-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-right-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-top-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>box-sizing</key>
-											<value xsi:type="xsd:string">border-box</value>
-										</entry>
-										<entry>
-											<key>caret-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>column-rule-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
 											<key>float</key>
 											<value xsi:type="xsd:string">left</value>
 										</entry>
 										<entry>
-											<key>font-family</key>
-											<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-										</entry>
-										<entry>
-											<key>font-size</key>
-											<value xsi:type="xsd:string">15px</value>
-										</entry>
-										<entry>
-											<key>line-height</key>
-											<value xsi:type="xsd:string">30px</value>
-										</entry>
-										<entry>
 											<key>min-height</key>
 											<value xsi:type="xsd:string">1px</value>
-										</entry>
-										<entry>
-											<key>outline-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 										</entry>
 										<entry>
 											<key>padding-left</key>
@@ -15927,10 +8288,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 										<entry>
 											<key>position</key>
 											<value xsi:type="xsd:string">relative</value>
-										</entry>
-										<entry>
-											<key>text-decoration-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 										</entry>
 									</attributes>
 								</attributes>
@@ -15956,10 +8313,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 											</entry>
 											<entry>
-												<key>border-image-width</key>
-												<value xsi:type="xsd:string">1</value>
-											</entry>
-											<entry>
 												<key>border-left-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 											</entry>
@@ -15970,10 +8323,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 											<entry>
 												<key>border-top-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-											</entry>
-											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
 											</entry>
 											<entry>
 												<key>caret-color</key>
@@ -15996,20 +8345,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<value xsi:type="xsd:string">18px</value>
 											</entry>
 											<entry>
-												<key>font-weight</key>
-												<value xsi:type="xsd:string">400</value>
-											</entry>
-											<entry>
-												<key>line-height</key>
-												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
 												<key>margin-bottom</key>
 												<value xsi:type="xsd:string">6px</value>
-											</entry>
-											<entry>
-												<key>margin-top</key>
-												<value xsi:type="xsd:string">0px</value>
 											</entry>
 											<entry>
 												<key>outline-color</key>
@@ -16041,64 +8378,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 									<attributes>
 										<attributes>
 											<entry>
-												<key>border-bottom-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-left-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-right-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-top-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
-											</entry>
-											<entry>
-												<key>caret-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>column-rule-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>font-family</key>
-												<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-											</entry>
-											<entry>
-												<key>font-size</key>
-												<value xsi:type="xsd:string">15px</value>
-											</entry>
-											<entry>
-												<key>line-height</key>
-												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
 												<key>margin-bottom</key>
 												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
-												<key>margin-top</key>
-												<value xsi:type="xsd:string">0px</value>
-											</entry>
-											<entry>
-												<key>outline-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>text-decoration-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 											</entry>
 										</attributes>
 									</attributes>
@@ -16116,62 +8397,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<attribute key="type" xsi:type="stringAttribute">BR</attribute>
 											</attributes>
 										</identifyingAttributes>
-										<attributes>
-											<attributes>
-												<entry>
-													<key>border-bottom-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-left-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-right-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>border-top-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>box-sizing</key>
-													<value xsi:type="xsd:string">border-box</value>
-												</entry>
-												<entry>
-													<key>caret-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>column-rule-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>font-family</key>
-													<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-												</entry>
-												<entry>
-													<key>font-size</key>
-													<value xsi:type="xsd:string">15px</value>
-												</entry>
-												<entry>
-													<key>line-height</key>
-													<value xsi:type="xsd:string">30px</value>
-												</entry>
-												<entry>
-													<key>outline-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-												<entry>
-													<key>text-decoration-color</key>
-													<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-												</entry>
-											</attributes>
-										</attributes>
+										<attributes/>
 									</containedComponents>
 								</containedComponents>
 							</containedComponents>
@@ -16193,60 +8419,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<attributes>
 									<attributes>
 										<entry>
-											<key>border-bottom-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-left-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-right-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-top-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>box-sizing</key>
-											<value xsi:type="xsd:string">border-box</value>
-										</entry>
-										<entry>
-											<key>caret-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>column-rule-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
 											<key>float</key>
 											<value xsi:type="xsd:string">left</value>
 										</entry>
 										<entry>
-											<key>font-family</key>
-											<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-										</entry>
-										<entry>
-											<key>font-size</key>
-											<value xsi:type="xsd:string">15px</value>
-										</entry>
-										<entry>
-											<key>line-height</key>
-											<value xsi:type="xsd:string">30px</value>
-										</entry>
-										<entry>
 											<key>min-height</key>
 											<value xsi:type="xsd:string">1px</value>
-										</entry>
-										<entry>
-											<key>outline-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 										</entry>
 										<entry>
 											<key>padding-left</key>
@@ -16259,10 +8437,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 										<entry>
 											<key>position</key>
 											<value xsi:type="xsd:string">relative</value>
-										</entry>
-										<entry>
-											<key>text-decoration-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 										</entry>
 									</attributes>
 								</attributes>
@@ -16288,10 +8462,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 											</entry>
 											<entry>
-												<key>border-image-width</key>
-												<value xsi:type="xsd:string">1</value>
-											</entry>
-											<entry>
 												<key>border-left-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 											</entry>
@@ -16302,10 +8472,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 											<entry>
 												<key>border-top-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-											</entry>
-											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
 											</entry>
 											<entry>
 												<key>caret-color</key>
@@ -16328,20 +8494,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<value xsi:type="xsd:string">18px</value>
 											</entry>
 											<entry>
-												<key>font-weight</key>
-												<value xsi:type="xsd:string">400</value>
-											</entry>
-											<entry>
-												<key>line-height</key>
-												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
 												<key>margin-bottom</key>
 												<value xsi:type="xsd:string">6px</value>
-											</entry>
-											<entry>
-												<key>margin-top</key>
-												<value xsi:type="xsd:string">0px</value>
 											</entry>
 											<entry>
 												<key>outline-color</key>
@@ -16374,64 +8528,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 									<attributes>
 										<attributes>
 											<entry>
-												<key>border-bottom-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-left-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-right-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-top-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
-											</entry>
-											<entry>
-												<key>caret-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>column-rule-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>font-family</key>
-												<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-											</entry>
-											<entry>
-												<key>font-size</key>
-												<value xsi:type="xsd:string">15px</value>
-											</entry>
-											<entry>
-												<key>line-height</key>
-												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
 												<key>margin-bottom</key>
 												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
-												<key>margin-top</key>
-												<value xsi:type="xsd:string">0px</value>
-											</entry>
-											<entry>
-												<key>outline-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>text-decoration-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 											</entry>
 										</attributes>
 									</attributes>
@@ -16455,60 +8553,12 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 								<attributes>
 									<attributes>
 										<entry>
-											<key>border-bottom-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-left-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-right-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>border-top-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>box-sizing</key>
-											<value xsi:type="xsd:string">border-box</value>
-										</entry>
-										<entry>
-											<key>caret-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
-											<key>column-rule-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-										</entry>
-										<entry>
 											<key>float</key>
 											<value xsi:type="xsd:string">left</value>
 										</entry>
 										<entry>
-											<key>font-family</key>
-											<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-										</entry>
-										<entry>
-											<key>font-size</key>
-											<value xsi:type="xsd:string">15px</value>
-										</entry>
-										<entry>
-											<key>line-height</key>
-											<value xsi:type="xsd:string">30px</value>
-										</entry>
-										<entry>
 											<key>min-height</key>
 											<value xsi:type="xsd:string">1px</value>
-										</entry>
-										<entry>
-											<key>outline-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 										</entry>
 										<entry>
 											<key>padding-left</key>
@@ -16521,10 +8571,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 										<entry>
 											<key>position</key>
 											<value xsi:type="xsd:string">relative</value>
-										</entry>
-										<entry>
-											<key>text-decoration-color</key>
-											<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 										</entry>
 									</attributes>
 								</attributes>
@@ -16550,10 +8596,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 											</entry>
 											<entry>
-												<key>border-image-width</key>
-												<value xsi:type="xsd:string">1</value>
-											</entry>
-											<entry>
 												<key>border-left-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
 											</entry>
@@ -16564,10 +8606,6 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 											<entry>
 												<key>border-top-color</key>
 												<value xsi:type="xsd:string">rgb(193, 216, 47)</value>
-											</entry>
-											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
 											</entry>
 											<entry>
 												<key>caret-color</key>
@@ -16590,20 +8628,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 												<value xsi:type="xsd:string">18px</value>
 											</entry>
 											<entry>
-												<key>font-weight</key>
-												<value xsi:type="xsd:string">400</value>
-											</entry>
-											<entry>
-												<key>line-height</key>
-												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
 												<key>margin-bottom</key>
 												<value xsi:type="xsd:string">6px</value>
-											</entry>
-											<entry>
-												<key>margin-top</key>
-												<value xsi:type="xsd:string">0px</value>
 											</entry>
 											<entry>
 												<key>outline-color</key>
@@ -16638,64 +8664,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 									<attributes>
 										<attributes>
 											<entry>
-												<key>border-bottom-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-left-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-right-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>border-top-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>box-sizing</key>
-												<value xsi:type="xsd:string">border-box</value>
-											</entry>
-											<entry>
-												<key>caret-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>column-rule-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>font-family</key>
-												<value xsi:type="xsd:string">notosans-regular, sans-serif</value>
-											</entry>
-											<entry>
-												<key>font-size</key>
-												<value xsi:type="xsd:string">15px</value>
-											</entry>
-											<entry>
-												<key>line-height</key>
-												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
 												<key>margin-bottom</key>
 												<value xsi:type="xsd:string">30px</value>
-											</entry>
-											<entry>
-												<key>margin-top</key>
-												<value xsi:type="xsd:string">0px</value>
-											</entry>
-											<entry>
-												<key>outline-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
-											</entry>
-											<entry>
-												<key>text-decoration-color</key>
-												<value xsi:type="xsd:string">rgb(131, 140, 149)</value>
 											</entry>
 										</attributes>
 									</attributes>
@@ -16719,18 +8689,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 						<attribute key="type" xsi:type="stringAttribute">HEAD</attribute>
 					</attributes>
 				</identifyingAttributes>
-				<attributes>
-					<attributes>
-						<entry>
-							<key>box-sizing</key>
-							<value xsi:type="xsd:string">border-box</value>
-						</entry>
-						<entry>
-							<key>font-size</key>
-							<value xsi:type="xsd:string">10px</value>
-						</entry>
-					</attributes>
-				</attributes>
+				<attributes/>
 				<containedComponents retestId="link">
 					<identifyingAttributes>
 						<attributes>
@@ -16745,22 +8704,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">LINK</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="link">
 					<identifyingAttributes>
@@ -16776,22 +8720,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">LINK</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="link">
 					<identifyingAttributes>
@@ -16807,22 +8736,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">LINK</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="link">
 					<identifyingAttributes>
@@ -16838,22 +8752,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">LINK</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="link">
 					<identifyingAttributes>
@@ -16869,22 +8768,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">LINK</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="link">
 					<identifyingAttributes>
@@ -16900,22 +8784,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">LINK</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="link">
 					<identifyingAttributes>
@@ -16931,22 +8800,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">LINK</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="link">
 					<identifyingAttributes>
@@ -16962,22 +8816,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">LINK</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 				<containedComponents retestId="meta">
 					<identifyingAttributes>
@@ -16997,24 +8836,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">Initial informations about retest</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -17037,24 +8860,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">2018</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -17077,24 +8884,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">© 2018 Jeremias Rößler</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -17116,24 +8907,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">retest</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -17155,24 +8930,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">website</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -17194,24 +8953,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">https://www.retest.de</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -17233,24 +8976,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">https://www.retest.de/images/logo.png</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -17273,24 +9000,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">width=device-width, initial-scale=1, maximum-scale=1</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -17312,24 +9023,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">text/html; charset=UTF-8</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -17352,24 +9047,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">retest - Java Swing GUI Testing. An innovative approach with artificially intelligent monkey testing.</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -17392,24 +9071,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">Jeremias Rößler</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -17432,24 +9095,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">index, follow</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -17471,24 +9118,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">no-cache</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -17510,24 +9141,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">3600</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -17549,24 +9164,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">3600</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -17588,24 +9187,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">de_DE</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -17628,24 +9211,8 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 					<attributes>
 						<attributes>
 							<entry>
-								<key>border-image-width</key>
-								<value xsi:type="xsd:string">1</value>
-							</entry>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
 								<key>content</key>
 								<value xsi:type="xsd:string">Jeremias Rößler</value>
-							</entry>
-							<entry>
-								<key>display</key>
-								<value xsi:type="xsd:string">none</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
 							</entry>
 						</attributes>
 					</attributes>
@@ -17665,18 +9232,7 @@ console.log(&quot;For more info, please go to https://www.retest.de/karriere.&qu
 							<attribute key="type" xsi:type="stringAttribute">TITLE</attribute>
 						</attributes>
 					</identifyingAttributes>
-					<attributes>
-						<attributes>
-							<entry>
-								<key>box-sizing</key>
-								<value xsi:type="xsd:string">border-box</value>
-							</entry>
-							<entry>
-								<key>font-size</key>
-								<value xsi:type="xsd:string">10px</value>
-							</entry>
-						</attributes>
-					</attributes>
+					<attributes/>
 				</containedComponents>
 			</containedComponents>
 			<screenshot>


### PR DESCRIPTION
Thread.sleep is needed because otherwise some integration tests are flaky. There is a switch between Firefox and Chrome and one of the drivers reacts slowly.