### PR TITLE
Remove property

### DIFF
--- a/src/test/resources/retest/retest.properties
+++ b/src/test/resources/retest/retest.properties
@@ -3,4 +3,3 @@ de.retest.sut.applicationPath=target/
 de.retest.sut.applicationClassPath=${de.retest.sut.applicationPath}/classes/de/retest/web/
 de.retest.testresults.reportsDir=${de.retest.sut.applicationPath}/test-classes/retest/recheck/
 de.retest.feedback.disabled=true
-de.retest.recheckDir=src/test/resources/retest/


### PR DESCRIPTION
We don't have to set this. The property from `CheckAccessFileImpl` is only used internally to see if a custom recheck directory is desired. If we need the property generally is separate discussion. However, for now, less properties mean less confusion.