### PR TITLE
The problem - some attribute changes show up twice no longer occurs

### DIFF
--- a/src/main/java/de/retest/web/WebElementPeer.java
+++ b/src/main/java/de/retest/web/WebElementPeer.java
@@ -93,6 +93,7 @@ public class WebElementPeer {
 		webData.getKeys().stream() //
 				.filter( Objects::nonNull ) //
 				.filter( AttributesUtil::isStateAttribute ) //
+				.filter( key -> !AttributesProvider.getInstance().getHtmlAttributes().contains( key ) ) //
 				.filter( key -> !defaultValueFinder.isDefaultValue( identifyingAttributes, key,
 						webData.getAsString( key ) ) ) //
 				.forEach( key -> state.put( key, webData.getAsString( key ) ) );

--- a/src/test/java/de/retest/web/WebElementPeerTest.java
+++ b/src/test/java/de/retest/web/WebElementPeerTest.java
@@ -5,10 +5,15 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import de.retest.recheck.ui.DefaultValueFinder;
 import de.retest.recheck.ui.descriptors.Element;
+import de.retest.recheck.ui.descriptors.IdentifyingAttributes;
 
 class WebElementPeerTest {
 
@@ -39,4 +44,12 @@ class WebElementPeerTest {
 		assertThat( cut.convertChildren( null ) ).isEmpty();
 	}
 
+	@Test
+	void retrieveStateAttributes_should_not_contain_IdentifyingAttributes() {
+		final Map<String, Object> wrappedData = new HashMap<>();
+		wrappedData.put( "id", "someId" );
+		final WebElementPeer cut =
+				new WebElementPeer( new WebData( wrappedData ), "path", mock( DefaultValueFinder.class ) );
+		assertThat( cut.retrieveStateAttributes( mock( IdentifyingAttributes.class ) ).get( "id" ) ).isNull();
+	}
 }


### PR DESCRIPTION
I tested different sites and html files and i saw, that the attribute changes are shown twice when we only test the "retest.de" site. Actually the attributes are the same and one of them is not showed in the attribute field.
![zweimalAngezeigt](https://user-images.githubusercontent.com/27949268/55227118-e702f680-5216-11e9-8660-7f98e7504c75.PNG)
![theSameAttribute](https://user-images.githubusercontent.com/27949268/55227128-ec604100-5216-11e9-93fc-c889ab419299.PNG)
With the filter in the WebElementPeer.java class  i fixed that and the attribute occurs only one time:
![AttributeOnce](https://user-images.githubusercontent.com/27949268/55227150-fb46f380-5216-11e9-8c04-b28560fc5dfe.PNG)
![done](https://user-images.githubusercontent.com/27949268/55227158-00a43e00-5217-11e9-8df0-0221691cba3b.PNG)


