### PR TITLE
Use workaround for mockito issue 1606

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,9 +156,13 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<!-- see https://github.com/mockito/mockito/issues/1606 -->
 			<version>2.23.4</version>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+    		<groupId>net.bytebuddy</groupId>
+   			<artifactId>byte-buddy</artifactId>
+    		<version>1.9.13</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Mockito-Core version 2.28.2 requires at least ByteBuddy version 1.9.7 to work properly.
A workaround would be to set the ByteBuddy dependency explicitly in our pom. 
I am not sure if there would be any side effects, because Selenium uses ByteBuddy version 1.8.15, which probably caused the problem in the first place.