### PR TITLE
Fix retest ID provider usage

### DIFF
--- a/src/main/java/de/retest/web/PeerConverter.java
+++ b/src/main/java/de/retest/web/PeerConverter.java
@@ -66,10 +66,11 @@ class PeerConverter {
 
 		if ( isRoot( parentPath ) ) {
 			assert root == null : "We can only have one root element!";
-			root = new RootElementPeer( attributesProvider, webData, path, title, screenshot, defaultValueFinder );
+			root = new RootElementPeer( idProvider, attributesProvider, webData, path, title, screenshot,
+					defaultValueFinder );
 			peer = root;
 		} else {
-			peer = new WebElementPeer( attributesProvider, webData, path, defaultValueFinder );
+			peer = new WebElementPeer( idProvider, attributesProvider, webData, path, defaultValueFinder );
 			WebElementPeer parent = converted.get( parentPath );
 			if ( parent == null ) {
 				parent = convertToPeer( parentPath, mapping.getWebData( parentPath ) );

--- a/src/main/java/de/retest/web/PeerConverter.java
+++ b/src/main/java/de/retest/web/PeerConverter.java
@@ -14,23 +14,21 @@ import de.retest.web.mapping.WebDataFilter;
 
 class PeerConverter {
 
-	private final RetestIdProvider idProvider;
-
-	private final AttributesProvider attributesProvider;
-
-	private final PathsToWebDataMapping mapping;
-	private final BufferedImage screenshot;
-	private final String title;
-
 	private final Map<String, WebElementPeer> converted = new HashMap<>();
-	private RootElementPeer root = null;
 
+	private final RetestIdProvider retestIdProvider;
+	private final AttributesProvider attributesProvider;
+	private final PathsToWebDataMapping mapping;
+	private final String title;
+	private final BufferedImage screenshot;
 	private final DefaultValueFinder defaultValueFinder;
 
-	public PeerConverter( final RetestIdProvider idProvider, final AttributesProvider attributesProvider,
+	private RootElementPeer root = null;
+
+	public PeerConverter( final RetestIdProvider retestIdProvider, final AttributesProvider attributesProvider,
 			final PathsToWebDataMapping mapping, final String title, final BufferedImage screenshot,
 			final DefaultValueFinder defaultValueFinder ) {
-		this.idProvider = idProvider;
+		this.retestIdProvider = retestIdProvider;
 		this.attributesProvider = attributesProvider;
 		this.mapping = mapping;
 		this.title = title;
@@ -39,7 +37,7 @@ class PeerConverter {
 	}
 
 	public RootElement convertToPeers() {
-		idProvider.reset();
+		retestIdProvider.reset();
 		for ( final Entry<String, WebData> entry : mapping ) {
 			final String path = entry.getKey();
 			final WebData webData = entry.getValue();
@@ -66,11 +64,11 @@ class PeerConverter {
 
 		if ( isRoot( parentPath ) ) {
 			assert root == null : "We can only have one root element!";
-			root = new RootElementPeer( idProvider, attributesProvider, webData, path, title, screenshot,
+			root = new RootElementPeer( retestIdProvider, attributesProvider, webData, path, title, screenshot,
 					defaultValueFinder );
 			peer = root;
 		} else {
-			peer = new WebElementPeer( idProvider, attributesProvider, webData, path, defaultValueFinder );
+			peer = new WebElementPeer( retestIdProvider, attributesProvider, webData, path, defaultValueFinder );
 			WebElementPeer parent = converted.get( parentPath );
 			if ( parent == null ) {
 				parent = convertToPeer( parentPath, mapping.getWebData( parentPath ) );

--- a/src/main/java/de/retest/web/RecheckSeleniumAdapter.java
+++ b/src/main/java/de/retest/web/RecheckSeleniumAdapter.java
@@ -2,7 +2,6 @@ package de.retest.web;
 
 import static de.retest.web.ScreenshotProvider.shoot;
 
-import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -31,8 +30,6 @@ import de.retest.web.selenium.UnbreakableDriver;
 
 public class RecheckSeleniumAdapter implements RecheckAdapter {
 
-	public static final RetestIdProvider idProvider = RetestIdProviderUtil.getConfiguredRetestIdProvider();
-
 	private static final String GET_ALL_ELEMENTS_BY_PATH_JS_PATH = "/javascript/getAllElementsByPath.js";
 	private final Predicate<Element> isFrame = element -> {
 		final String type = element.getIdentifyingAttributes().getType();
@@ -55,7 +52,7 @@ public class RecheckSeleniumAdapter implements RecheckAdapter {
 	}
 
 	public RecheckSeleniumAdapter() {
-		this( idProvider, YamlAttributesProvider.getInstance() );
+		this( RetestIdProviderUtil.getConfiguredRetestIdProvider(), YamlAttributesProvider.getInstance() );
 	}
 
 	@Override

--- a/src/main/java/de/retest/web/RecheckSeleniumAdapter.java
+++ b/src/main/java/de/retest/web/RecheckSeleniumAdapter.java
@@ -31,18 +31,17 @@ import de.retest.web.selenium.UnbreakableDriver;
 public class RecheckSeleniumAdapter implements RecheckAdapter {
 
 	private static final String GET_ALL_ELEMENTS_BY_PATH_JS_PATH = "/javascript/getAllElementsByPath.js";
+
+	private static final Logger logger = LoggerFactory.getLogger( RecheckSeleniumAdapter.class );
+
+	private final DefaultValueFinder defaultValueFinder = new DefaultWebValueFinder();
 	private final Predicate<Element> isFrame = element -> {
 		final String type = element.getIdentifyingAttributes().getType();
 		return Stream.of( "iframe", "frame" ).anyMatch( type::equalsIgnoreCase );
 	};
 
-	private static final Logger logger = LoggerFactory.getLogger( RecheckSeleniumAdapter.class );
-
 	private final RetestIdProvider retestIdProvider;
-
 	private final AttributesProvider attributesProvider;
-
-	private final DefaultValueFinder defaultValueFinder = new DefaultWebValueFinder();
 
 	public RecheckSeleniumAdapter( final RetestIdProvider retestIdProvider,
 			final AttributesProvider attributesProvider ) {

--- a/src/main/java/de/retest/web/RootElementPeer.java
+++ b/src/main/java/de/retest/web/RootElementPeer.java
@@ -7,6 +7,7 @@ import de.retest.recheck.ui.descriptors.Element;
 import de.retest.recheck.ui.descriptors.IdentifyingAttributes;
 import de.retest.recheck.ui.descriptors.MutableAttributes;
 import de.retest.recheck.ui.descriptors.RootElement;
+import de.retest.recheck.ui.descriptors.idproviders.RetestIdProvider;
 import de.retest.recheck.ui.image.ImageUtils;
 import de.retest.recheck.ui.image.Screenshot;
 import de.retest.web.mapping.WebData;
@@ -16,10 +17,10 @@ public class RootElementPeer extends WebElementPeer {
 	private final String title;
 	private final BufferedImage screenshot;
 
-	public RootElementPeer( final AttributesProvider attributesProvider, final WebData webData, final String path,
-			final String title,
-			final BufferedImage screenshot, final DefaultValueFinder defaultValueFinder ) {
-		super( attributesProvider, webData, path, defaultValueFinder );
+	public RootElementPeer( final RetestIdProvider retestIdProvider, final AttributesProvider attributesProvider,
+			final WebData webData, final String path, final String title, final BufferedImage screenshot,
+			final DefaultValueFinder defaultValueFinder ) {
+		super( retestIdProvider, attributesProvider, webData, path, defaultValueFinder );
 		this.screenshot = screenshot;
 		this.title = title;
 	}
@@ -31,7 +32,7 @@ public class RootElementPeer extends WebElementPeer {
 		}
 		final IdentifyingAttributes identifyingAttributes = retrieveIdentifyingAttributes();
 		final MutableAttributes stateAttributes = retrieveStateAttributes( identifyingAttributes );
-		final String retestId = RecheckSeleniumAdapter.idProvider.getRetestId( identifyingAttributes );
+		final String retestId = retestIdProvider.getRetestId( identifyingAttributes );
 		final Screenshot ss = ImageUtils.image2Screenshot( retestId, screenshot );
 		final RootElement rootElement =
 				new RootElement( retestId, identifyingAttributes, stateAttributes.immutable(), ss, title, 1, title );

--- a/src/main/java/de/retest/web/WebElementPeer.java
+++ b/src/main/java/de/retest/web/WebElementPeer.java
@@ -19,11 +19,13 @@ import de.retest.recheck.ui.descriptors.OutlineAttribute;
 import de.retest.recheck.ui.descriptors.PathAttribute;
 import de.retest.recheck.ui.descriptors.StringAttribute;
 import de.retest.recheck.ui.descriptors.SuffixAttribute;
+import de.retest.recheck.ui.descriptors.idproviders.RetestIdProvider;
 import de.retest.web.mapping.WebData;
 import de.retest.web.util.TextAttributeUtil;
 
 public class WebElementPeer {
 
+	protected final RetestIdProvider retestIdProvider;
 	protected final AttributesProvider attributesProvider;
 	protected final List<WebElementPeer> children = new ArrayList<>();
 	protected final WebData webData;
@@ -31,8 +33,9 @@ public class WebElementPeer {
 
 	private final DefaultValueFinder defaultValueFinder;
 
-	public WebElementPeer( final AttributesProvider attributesProvider, final WebData webData, final String path,
-			final DefaultValueFinder defaultValueFinder ) {
+	public WebElementPeer( final RetestIdProvider retestIdProvider, final AttributesProvider attributesProvider,
+			final WebData webData, final String path, final DefaultValueFinder defaultValueFinder ) {
+		this.retestIdProvider = retestIdProvider;
 		this.attributesProvider = attributesProvider;
 		this.webData = webData;
 		this.path = path;
@@ -49,7 +52,7 @@ public class WebElementPeer {
 		}
 		final IdentifyingAttributes identifyingAttributes = retrieveIdentifyingAttributes();
 		final MutableAttributes stateAttributes = retrieveStateAttributes( identifyingAttributes );
-		final String retestId = RecheckSeleniumAdapter.idProvider.getRetestId( identifyingAttributes );
+		final String retestId = retestIdProvider.getRetestId( identifyingAttributes );
 		final Element element = Element.create( retestId, parent, identifyingAttributes, stateAttributes.immutable() );
 		element.addChildren( convertChildren( element ) );
 		return element;

--- a/src/main/java/de/retest/web/WebElementPeer.java
+++ b/src/main/java/de/retest/web/WebElementPeer.java
@@ -25,12 +25,13 @@ import de.retest.web.util.TextAttributeUtil;
 
 public class WebElementPeer {
 
-	protected final RetestIdProvider retestIdProvider;
-	protected final AttributesProvider attributesProvider;
 	protected final List<WebElementPeer> children = new ArrayList<>();
-	protected final WebData webData;
-	protected final String path;
 
+	protected final RetestIdProvider retestIdProvider;
+	protected final WebData webData;
+
+	private final AttributesProvider attributesProvider;
+	private final String path;
 	private final DefaultValueFinder defaultValueFinder;
 
 	public WebElementPeer( final RetestIdProvider retestIdProvider, final AttributesProvider attributesProvider,

--- a/src/test/java/de/retest/web/WebElementPeerTest.java
+++ b/src/test/java/de/retest/web/WebElementPeerTest.java
@@ -15,6 +15,7 @@ import de.retest.recheck.ui.DefaultValueFinder;
 import de.retest.recheck.ui.descriptors.Attributes;
 import de.retest.recheck.ui.descriptors.Element;
 import de.retest.recheck.ui.descriptors.IdentifyingAttributes;
+import de.retest.recheck.ui.descriptors.idproviders.RetestIdProvider;
 import de.retest.web.mapping.WebData;
 
 class WebElementPeerTest {
@@ -25,7 +26,7 @@ class WebElementPeerTest {
 	@BeforeEach
 	void setUp() {
 		attributesProvider = YamlAttributesProvider.getTestInstance();
-		cut = new WebElementPeer( attributesProvider, null, null, null );
+		cut = new WebElementPeer( mock( RetestIdProvider.class ), attributesProvider, null, null, null );
 	}
 
 	@Test
@@ -53,8 +54,8 @@ class WebElementPeerTest {
 	void retrieveStateAttributes_should_not_contain_null() {
 		final Map<String, Object> wrappedData = new HashMap<>();
 		wrappedData.put( null, null );
-		final WebElementPeer cut = new WebElementPeer( attributesProvider, new WebData( wrappedData ), "path",
-				mock( DefaultValueFinder.class ) );
+		final WebElementPeer cut = new WebElementPeer( mock( RetestIdProvider.class ), attributesProvider,
+				new WebData( wrappedData ), "path", mock( DefaultValueFinder.class ) );
 
 		final Attributes attributes = cut.retrieveStateAttributes( mock( IdentifyingAttributes.class ) ).immutable();
 
@@ -77,8 +78,8 @@ class WebElementPeerTest {
 		wrappedData.put( AttributesUtil.ID, "someValue" );
 		wrappedData.put( AttributesUtil.NAME, "someValue" );
 		wrappedData.put( AttributesUtil.TAG_NAME, "someValue" );
-		final WebElementPeer cut = new WebElementPeer( attributesProvider, new WebData( wrappedData ), "path",
-				mock( DefaultValueFinder.class ) );
+		final WebElementPeer cut = new WebElementPeer( mock( RetestIdProvider.class ), attributesProvider,
+				new WebData( wrappedData ), "path", mock( DefaultValueFinder.class ) );
 
 		final Attributes attributes = cut.retrieveStateAttributes( mock( IdentifyingAttributes.class ) ).immutable();
 
@@ -99,8 +100,8 @@ class WebElementPeerTest {
 		when( defaultValueFinder.isDefaultValue( identifyingAttributes, attributeKey, attributeValue ) )
 				.thenReturn( true );
 
-		final WebElementPeer cut =
-				new WebElementPeer( attributesProvider, new WebData( wrappedData ), "path", defaultValueFinder );
+		final WebElementPeer cut = new WebElementPeer( mock( RetestIdProvider.class ), attributesProvider,
+				new WebData( wrappedData ), "path", defaultValueFinder );
 
 		final Attributes attributes = cut.retrieveStateAttributes( identifyingAttributes ).immutable();
 
@@ -115,8 +116,8 @@ class WebElementPeerTest {
 		final Map<String, Object> wrappedData = new HashMap<>();
 		wrappedData.put( attributeKey, attributeValue );
 
-		final WebElementPeer cut = new WebElementPeer( attributesProvider, new WebData( wrappedData ), "path",
-				mock( DefaultValueFinder.class ) );
+		final WebElementPeer cut = new WebElementPeer( mock( RetestIdProvider.class ), attributesProvider,
+				new WebData( wrappedData ), "path", mock( DefaultValueFinder.class ) );
 
 		final Attributes attributes = cut.retrieveStateAttributes( mock( IdentifyingAttributes.class ) ).immutable();
 


### PR DESCRIPTION
We cannot use a static reference, this causes e.g. in surili that two different retest ID providers are being used—the one being passed to `RecheckSeleniumAdapter` and the globally configured.

Thinking about a hotfix for this … waiting for yet another release slows surili development down. Or we finally start with nightlies.

Oh and better look at it commit-wise, second commit produces ugly diffs due to formatting changes.