### PR TITLE
Improve Javadoc

### DIFF
--- a/src/main/java/de/retest/web/YamlAttributesConfig.java
+++ b/src/main/java/de/retest/web/YamlAttributesConfig.java
@@ -16,21 +16,21 @@ public class YamlAttributesConfig {
 	}
 
 	/**
-	 * @see YamlAttributesConfig#getCssAttributes()
+	 * @return See {@link AttributesProvider#getCssAttributes()}.
 	 */
 	public Set<String> getCssAttributes() {
 		return cssAttributes;
 	}
 
 	/**
-	 * @see YamlAttributesConfig#getHtmlAttributes()
+	 * @return See {@link AttributesProvider#getHtmlAttributes()}.
 	 */
 	public Set<String> getHtmlAttributes() {
 		return htmlAttributes;
 	}
 
 	/**
-	 * @see YamlAttributesConfig#allHtmlAttributes()
+	 * @return See {@link AttributesProvider#allHtmlAttributes()}.
 	 */
 	public boolean allHtmlAttributes() {
 		return htmlAttributes == null;

--- a/src/main/java/de/retest/web/selenium/AutocheckingCheckNamingStrategy.java
+++ b/src/main/java/de/retest/web/selenium/AutocheckingCheckNamingStrategy.java
@@ -17,6 +17,7 @@ public interface AutocheckingCheckNamingStrategy {
 	 *            The target of the action or <code>null</code>.
 	 * @param params
 	 *            Optional params of the action, like the URL for a "get" or the text for a "enter".
+	 * @return The unique identifier.
 	 */
 	String getUniqueCheckName( String action, WebElement target, Object... params );
 

--- a/src/main/java/de/retest/web/selenium/AutocheckingRecheckDriver.java
+++ b/src/main/java/de/retest/web/selenium/AutocheckingRecheckDriver.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.RemoteWebDriver;
 
@@ -11,9 +12,10 @@ import de.retest.recheck.RecheckOptions;
 import de.retest.web.RecheckWebImpl;
 
 /**
- * This class is a wrapper of any given Selenium driver, i.e. can be used e.g. both with ChromeDriver, GeckoDriver, or
- * any other. It automagically creates a check _after_ any executed action (usually starting with "get"). It utilizes
- * the given {@link AutocheckingCheckNamingStrategy} to create names for the checks.
+ * Extends {@link UnbreakableDriver} and automagically creates a check <em>after</em> any executed action (usually
+ * starting with {@link WebDriver#get(String)}). Consequently, you can omit using a {@code Recheck} instance such as
+ * {@code RecheckImpl} or {@code RecheckWebImpl} instance. It utilizes the given {@link AutocheckingCheckNamingStrategy}
+ * to create names for the checks.
  */
 public class AutocheckingRecheckDriver extends UnbreakableDriver {
 

--- a/src/main/java/de/retest/web/selenium/RecheckDriver.java
+++ b/src/main/java/de/retest/web/selenium/RecheckDriver.java
@@ -5,9 +5,9 @@ import org.openqa.selenium.remote.RemoteWebDriver;
 import de.retest.recheck.RecheckOptions;
 
 /**
- * Extends both {@link AutocheckingDriver} and {@link UnbreakableDriver} to combine all recheck-web features. Use this
- * class if you automatically want to incorporate new features without changing your recheck-web driver implementation
- * explicitly.
+ * Extends both {@link AutocheckingRecheckDriver} and {@link UnbreakableDriver} to combine all recheck-web features. Use
+ * this class if you automatically want to incorporate new features without changing your recheck-web driver
+ * implementation explicitly.
  */
 public class RecheckDriver extends AutocheckingRecheckDriver {
 

--- a/src/main/java/de/retest/web/selenium/RecheckDriver.java
+++ b/src/main/java/de/retest/web/selenium/RecheckDriver.java
@@ -1,19 +1,13 @@
 package de.retest.web.selenium;
 
-import org.openqa.selenium.chrome.ChromeDriver;
-import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.remote.RemoteWebDriver;
 
-import de.retest.recheck.Recheck;
 import de.retest.recheck.RecheckOptions;
 
 /**
- * This is a wrapper for different {@link RemoteWebDriver} implementations, such as {@link ChromeDriver} or
- * {@link FirefoxDriver}.
- *
- * The {@code RecheckDriver} extends {@code AutocheckingDriver}, such that it is unnecessary to call
- * {@link Recheck#check(Object, String)} explicitly. It also extends {@link UnbreakableDriver}, such that it will not
- * break on otherwise breaking changes until these changes are also applied to the Golden Master.
+ * Extends both {@link AutocheckingDriver} and {@link UnbreakableDriver} to combine all recheck-web features. Use this
+ * class if you automatically want to incorporate new features without changing your recheck-web driver implementation
+ * explicitly.
  */
 public class RecheckDriver extends AutocheckingRecheckDriver {
 

--- a/src/main/java/de/retest/web/selenium/UnbreakableDriver.java
+++ b/src/main/java/de/retest/web/selenium/UnbreakableDriver.java
@@ -31,6 +31,11 @@ import de.retest.recheck.ui.descriptors.Element;
 import de.retest.recheck.ui.descriptors.RootElement;
 import de.retest.web.RecheckWebImpl;
 
+/**
+ * A wrapper for a given {@code RemoteWebDriver}, which can be used with e.g. {@code ChromeDriver}, {@code GeckoDriver},
+ * or any other. It enables recheck-web's "Unbreakable Selenium" feature, where it must be used along with
+ * {@link RecheckWebImpl}.
+ */
 public class UnbreakableDriver implements WebDriver, JavascriptExecutor, FindsById, FindsByClassName, FindsByLinkText,
 		FindsByName, FindsByCssSelector, FindsByTagName, FindsByXPath, HasInputDevices, HasCapabilities, Interactive,
 		TakesScreenshot {


### PR DESCRIPTION
Document all main driver classes and avoid redundancy.

Resolves #262 along with https://github.com/retest/docs/pull/27.