### PR TITLE
Creating a screenshot is not so critical, so it shouldn't break the test

### DIFF
--- a/src/main/java/de/retest/web/ScreenshotProvider.java
+++ b/src/main/java/de/retest/web/ScreenshotProvider.java
@@ -7,6 +7,8 @@ import java.awt.image.BufferedImage;
 
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.assertthat.selenium_shutterbug.core.Shutterbug;
 import com.assertthat.selenium_shutterbug.utils.web.ScrollStrategy;
@@ -19,11 +21,18 @@ public class ScreenshotProvider {
 
 	public static final int SCALE = extractScale();
 
+	private static final Logger logger = LoggerFactory.getLogger( ScreenshotProvider.class );
+
 	private ScreenshotProvider() {}
 
 	public static BufferedImage shoot( final WebDriver driver ) {
-		final boolean viewportOnly = Boolean.getBoolean( VIEWPORT_ONLY_SCREENSHOT_PROPERTY );
-		return viewportOnly ? shootViewportOnly( driver ) : shootFullPage( driver );
+		try {
+			final boolean viewportOnly = Boolean.getBoolean( VIEWPORT_ONLY_SCREENSHOT_PROPERTY );
+			return viewportOnly ? shootViewportOnly( driver ) : shootFullPage( driver );
+		} catch ( final Exception e ) {
+			logger.error( "Exception creating screenshot for check.", e );
+			return null;
+		}
 	}
 
 	private static BufferedImage shootFullPage( final WebDriver driver ) {

--- a/src/test/java/de/retest/web/ScreenshotProviderTest.java
+++ b/src/test/java/de/retest/web/ScreenshotProviderTest.java
@@ -1,0 +1,24 @@
+package de.retest.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.remote.CommandExecutor;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+class ScreenshotProviderTest {
+
+	@Test
+	void failingDriver_should_return_null() {
+		final RemoteWebDriver exceptionCausingDriver = mock( ChromeDriver.class );
+		when( exceptionCausingDriver.executeScript( Mockito.anyString() ) ).thenReturn( 1.0 );
+		when( exceptionCausingDriver.getCommandExecutor() ).thenReturn( mock( CommandExecutor.class ) );
+
+		assertThat( ScreenshotProvider.shoot( exceptionCausingDriver ) ).isNull();
+	}
+
+}


### PR DESCRIPTION
java.lang.RuntimeException: java.lang.reflect.InvocationTargetException
	at com.assertthat.selenium_shutterbug.utils.web.Browser.sendCommand(Browser.java:276)
	at com.assertthat.selenium_shutterbug.utils.web.Browser.evaluate(Browser.java:281)
	at com.assertthat.selenium_shutterbug.utils.web.Browser.takeScreenshotEntirePageUsingChromeCommand(Browser.java:187)
	at com.assertthat.selenium_shutterbug.utils.web.Browser.takeScreenshotEntirePage(Browser.java:119)
	at com.assertthat.selenium_shutterbug.core.Shutterbug.shootPage(Shutterbug.java:110)
	at de.retest.web.ScreenshotProvider.shootFullPage(ScreenshotProvider.java:31)
	at de.retest.web.ScreenshotProvider.shoot(ScreenshotProvider.java:26)
	at de.retest.web.RecheckSeleniumAdapter.convert(RecheckSeleniumAdapter.java:74)
	at de.retest.recheck.persistence.RecheckSutState.convert(RecheckSutState.java:25)
	at de.retest.recheck.RecheckImpl.createActionReplayResult(RecheckImpl.java:142)
	at de.retest.recheck.RecheckImpl.check(RecheckImpl.java:129)
	at de.retest.recheck.RecheckImpl.check(RecheckImpl.java:119)
	at de.retest.recheck.example.BrowserStackExample.checkWindows10(BrowserStackExample.java:41)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.eclipse.jdt.internal.junit4.runner.JUnit4TestReference.run(JUnit4TestReference.java:89)
	at org.eclipse.jdt.internal.junit.runner.TestExecution.run(TestExecution.java:41)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:541)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:763)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:463)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.main(RemoteTestRunner.java:209)
Caused by: java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.assertthat.selenium_shutterbug.utils.web.Browser.sendCommand(Browser.java:273)
	... 37 more
Caused by: org.openqa.selenium.WebDriverException: POST /session/aa55a62acd867a899b76b9bda5587491905488e7/chromium/send_command_and_get_result
Build info: version: '2.53.0', revision: '35ae25b', time: '2016-03-15 17:00:58'
System info: host: '185-129-71-137', ip: '185.129.71.137', os.name: 'windows', os.arch: 'x86', os.version: '10.0', java.version: '1.8.0_181'
Driver info: driver.version: unknown
Command duration or timeout: 0 milliseconds
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at org.openqa.selenium.remote.ErrorHandler.createThrowable(ErrorHandler.java:214)
	at org.openqa.selenium.remote.ErrorHandler.throwIfResponseFailed(ErrorHandler.java:166)
	at org.openqa.selenium.remote.http.JsonHttpResponseCodec.reconstructValue(JsonHttpResponseCodec.java:40)
	at org.openqa.selenium.remote.http.AbstractHttpResponseCodec.decode(AbstractHttpResponseCodec.java:80)
	at org.openqa.selenium.remote.http.AbstractHttpResponseCodec.decode(AbstractHttpResponseCodec.java:44)
	at org.openqa.selenium.remote.HttpCommandExecutor.execute(HttpCommandExecutor.java:158)
	at org.openqa.selenium.remote.RemoteWebDriver.execute(RemoteWebDriver.java:552)
	... 42 more
Caused by: org.openqa.selenium.UnsupportedCommandException: POST /session/aa55a62acd867a899b76b9bda5587491905488e7/chromium/send_command_and_get_result
Build info: version: '2.53.0', revision: '35ae25b', time: '2016-03-15 17:00:58'
System info: host: '185-129-71-137', ip: '185.129.71.137', os.name: 'windows', os.arch: 'x86', os.version: '10.0', java.version: '1.8.0_181'
Driver info: driver.version: unknown
Build info: version: '3.141.59', revision: 'e82be7d358', time: '2018-11-14T08:17:03'
System info: host: 'MacBook-Pro.fritz.box', ip: 'fe80:0:0:0:828:eec9:2e37:d61%en0', os.name: 'Mac OS X', os.arch: 'x86_64', os.version: '10.14.6', java.version: '1.8.0_121'
Driver info: driver.version: unknown