### PR TITLE
Move options to root package

### DIFF
--- a/src/main/java/de/retest/web/RecheckWebOptions.java
+++ b/src/main/java/de/retest/web/RecheckWebOptions.java
@@ -1,6 +1,8 @@
-package de.retest.web.selenium;
+package de.retest.web;
 
 import de.retest.recheck.RecheckOptions;
+import de.retest.web.selenium.AutocheckingCheckNamingStrategy;
+import de.retest.web.selenium.CounterCheckNamingStrategy;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;

--- a/src/main/java/de/retest/web/selenium/AutocheckingRecheckDriver.java
+++ b/src/main/java/de/retest/web/selenium/AutocheckingRecheckDriver.java
@@ -10,6 +10,7 @@ import org.openqa.selenium.remote.RemoteWebDriver;
 
 import de.retest.recheck.RecheckOptions;
 import de.retest.web.RecheckWebImpl;
+import de.retest.web.RecheckWebOptions;
 
 /**
  * Extends {@link UnbreakableDriver} and automagically creates a check <em>after</em> any executed action (usually

--- a/src/main/java/de/retest/web/selenium/RecheckDriver.java
+++ b/src/main/java/de/retest/web/selenium/RecheckDriver.java
@@ -3,6 +3,7 @@ package de.retest.web.selenium;
 import org.openqa.selenium.remote.RemoteWebDriver;
 
 import de.retest.recheck.RecheckOptions;
+import de.retest.web.RecheckWebOptions;
 
 /**
  * Extends both {@link AutocheckingRecheckDriver} and {@link UnbreakableDriver} to combine all recheck-web features. Use


### PR DESCRIPTION
Just like `RecheckImpl` and `RecheckOptions` reside in the same package `de.retest.recheck`, `RecheckWebImpl` and `RecheckWebOptions` should do the same.