### PR TITLE
Feature/recheck cap

### DIFF
--- a/src/main/java/de/retest/web/selenium/AutocheckingRecheckDriver.java
+++ b/src/main/java/de/retest/web/selenium/AutocheckingRecheckDriver.java
@@ -77,8 +77,7 @@ public class AutocheckingRecheckDriver extends UnbreakableDriver {
 	@Override
 	public void close() {
 		// Is this sensible? What about tests using separate sessions?
-		namingStrategy.nextTest();
-		re.cap();
+		cap();
 		super.close();
 	}
 
@@ -86,8 +85,7 @@ public class AutocheckingRecheckDriver extends UnbreakableDriver {
 	public void quit() {
 		try {
 			// Is this sensible? What about tests using separate sessions?
-			namingStrategy.nextTest();
-			re.cap();
+			cap();
 		} finally {
 			super.quit();
 		}

--- a/src/test/java/de/retest/web/it/ShowcaseIT.java
+++ b/src/test/java/de/retest/web/it/ShowcaseIT.java
@@ -1,7 +1,8 @@
 package de.retest.web.it;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.openqa.selenium.WebDriver;
@@ -13,11 +14,11 @@ import de.retest.web.testutils.PageFactory.Page;
 
 class ShowcaseIT {
 
+	static Recheck re;
 	WebDriver driver;
-	Recheck re;
 
-	@BeforeEach
-	void setUp() {
+	@BeforeAll
+	static void setUp() {
 		re = new RecheckImpl();
 	}
 
@@ -39,7 +40,10 @@ class ShowcaseIT {
 	@AfterEach
 	void tearDown() {
 		driver.quit();
-		re.cap();
 	}
 
+	@AfterAll
+	static void tearDownAll() {
+		re.cap();
+	}
 }

--- a/src/test/java/de/retest/web/it/SimpleAutocheckingDriverShowcaseIT.java
+++ b/src/test/java/de/retest/web/it/SimpleAutocheckingDriverShowcaseIT.java
@@ -55,7 +55,6 @@ public class SimpleAutocheckingDriverShowcaseIT {
 
 	@After
 	public void tearDown() {
-		driver.cap();
 		driver.quit();
 	}
 


### PR DESCRIPTION
Reports get uploaded after every single test because cap() is called after each test. Maybe change the lifecyle of recheck so cap() gets only called after every test was executed. That requires a recheck instance to create only once.
There is also the issue with AutocheckingRecheckDriver to execute re.cap() in the quit() method, which may need to be changed as well.
[See this ticket](https://retest.atlassian.net/browse/RET-1798)