### PR TITLE
Check if critical `window.getComputedStyle` returned null and throw a better error

### DIFF
--- a/src/main/resources/javascript/getAllElementsByPath.js
+++ b/src/main/resources/javascript/getAllElementsByPath.js
@@ -95,6 +95,9 @@ function transform(node) {
 
 	// extract *given* CSS style attributes
 	var style = window.getComputedStyle(node);
+	if (style == null) {
+		throw new Error("window.getComputedStyle() returned null for node " + node);
+	}
 	var parentStyle = [];
 	try {
 		parentStyle = window.getComputedStyle(node.parentNode);


### PR DESCRIPTION
Improvement (but no fix) for #355 .

According to https://github.com/ganlanyuan/tiny-slider/issues/199, only an old Firefox instance returned null in rare situations. According to https://idiallo.com/javascript/uncaught-typeerror-cannot-read-property-of-null either the DOM is not ready, or the object not valid. So we need more information to understand what is going on. And I don't even know what to do then...