### PR TITLE
Rethrow exception on getWrapped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,12 +27,22 @@ Table of Contents
 
 ### Bug Fixes
 
+* Fix `StackOverflowError` if a `WrapsElement` (e.g. `@FindBy`) is checked that throws an exception.
+
 ### New Features
 
 ### Improvements
 
 
 --------------------------------------------------------------------------------
+
+
+[1.5.1] (2019-09-23)
+--------------------
+
+### Bug Fixes
+
+* Fix [#355](https://github.com/retest/recheck-web/issues/355) when an exception is thrown in JavaScript if the element has no parent. 
 
 
 [1.5.0] (2019-09-12)

--- a/src/main/java/de/retest/web/util/SeleniumWrapperUtil.java
+++ b/src/main/java/de/retest/web/util/SeleniumWrapperUtil.java
@@ -44,12 +44,20 @@ public class SeleniumWrapperUtil {
 	}
 
 	/**
+	 * Extracts the wrapped element or driver from a given object while implementing backwards compatibility to the
+	 * internal Selenium API. It is advised to call {@link #isWrapper(WrapperOf, Object)} before calling this method.
+	 * 
 	 * @param w
 	 *            The wrapper type.
 	 * @param o
 	 *            The object to be used.
-	 * @return The wrapped element or driver from the given object if it is instance of the selected type, otherwise the
-	 *         object itself.
+	 * @return The wrapped element or driver from the given object if it is instance of the selected type.
+	 * 
+	 * @throws RuntimeException
+	 *             If the <code>getWrapped</code> method throws an exception.
+	 * @throws UnsupportedOperationException
+	 *             If the <code>getWrapped</code> method cannot be invoked or the object does not wrap an instance of
+	 *             the selected type.
 	 */
 	public static Object getWrapped( final WrapperOf w, final Object o ) {
 		final Class<?> clazz = getWrapperClass( w, o );

--- a/src/main/java/de/retest/web/util/SeleniumWrapperUtil.java
+++ b/src/main/java/de/retest/web/util/SeleniumWrapperUtil.java
@@ -1,5 +1,8 @@
 package de.retest.web.util;
 
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+
 import lombok.Getter;
 
 /**
@@ -50,12 +53,20 @@ public class SeleniumWrapperUtil {
 	 */
 	public static Object getWrapped( final WrapperOf w, final Object o ) {
 		final Class<?> clazz = getWrapperClass( w, o );
-		if ( clazz != null ) {
-			try {
-				return clazz.getMethod( w.getWrapperMethodName() ).invoke( o );
-			} catch ( final ReflectiveOperationException e ) {}
+		if ( clazz == null ) {
+			throw new IllegalArgumentException( "Type '" + o.getClass() + "' is not instance of any of "
+					+ Arrays.toString( w.getWrapperClassNames() ) + "." );
 		}
-		return o;
+		try {
+			return clazz.getMethod( w.getWrapperMethodName() ).invoke( o );
+		} catch ( final InvocationTargetException e ) {
+			throw new RuntimeException(
+					"Failed to invoke " + o.getClass().getSimpleName() + "#" + w.getWrapperMethodName() + ".",
+					e.getTargetException() );
+		} catch ( final NoSuchMethodException | IllegalAccessException e ) {
+			throw new UnsupportedOperationException(
+					"Failed to invoke " + o.getClass().getSimpleName() + "#" + w.getWrapperMethodName() + ".", e );
+		}
 	}
 
 	private static Class<?> getWrapperClass( final WrapperOf w, final Object o ) {

--- a/src/test/java/de/retest/web/util/SeleniumWrapperUtilTest.java
+++ b/src/test/java/de/retest/web/util/SeleniumWrapperUtilTest.java
@@ -1,10 +1,12 @@
 package de.retest.web.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.internal.WrapsDriver;
@@ -29,7 +31,6 @@ class SeleniumWrapperUtilTest {
 	@Test
 	void should_get_wrapped_element() throws Exception {
 		final WebElement wrapped = mock( WebElement.class );
-		assertThat( SeleniumWrapperUtil.getWrapped( WrapperOf.ELEMENT, wrapped ) ).isSameAs( wrapped );
 
 		final org.openqa.selenium.WrapsElement newWrapper = mock( org.openqa.selenium.WrapsElement.class );
 		when( newWrapper.getWrappedElement() ).thenReturn( wrapped );
@@ -55,7 +56,6 @@ class SeleniumWrapperUtilTest {
 	@Test
 	void should_get_wrapped_driver() throws Exception {
 		final WebDriver wrapped = mock( WebDriver.class );
-		assertThat( SeleniumWrapperUtil.getWrapped( WrapperOf.DRIVER, wrapped ) ).isSameAs( wrapped );
 
 		final org.openqa.selenium.WrapsDriver newWrapper = mock( org.openqa.selenium.WrapsDriver.class );
 		when( newWrapper.getWrappedDriver() ).thenReturn( wrapped );
@@ -66,4 +66,28 @@ class SeleniumWrapperUtilTest {
 		assertThat( SeleniumWrapperUtil.getWrapped( WrapperOf.DRIVER, oldWrapper ) ).isSameAs( wrapped );
 	}
 
+	@Test
+	void getWrapped_should_not_silently_ignore_exceptions_thrown_by_method() {
+		final WrapsElement elementThrows = mock( WrapsElement.class );
+		when( elementThrows.getWrappedElement() ).thenThrow( new NoSuchElementException( "No element found" ) );
+
+		assertThatThrownBy( () -> SeleniumWrapperUtil.getWrapped( WrapperOf.ELEMENT, elementThrows ) )
+				.hasCauseInstanceOf( NoSuchElementException.class );
+	}
+
+	@Test
+	void getWrapped_should_not_loop_element_with_same_object() {
+		final Object notElement = mock( Object.class );
+
+		assertThatThrownBy( () -> SeleniumWrapperUtil.getWrapped( WrapperOf.ELEMENT, notElement ) )
+				.isInstanceOf( IllegalArgumentException.class );
+	}
+
+	@Test
+	void getWrapped_should_not_loop_driver_with_same_object() {
+		final Object notElement = mock( Object.class );
+
+		assertThatThrownBy( () -> SeleniumWrapperUtil.getWrapped( WrapperOf.DRIVER, notElement ) )
+				.isInstanceOf( IllegalArgumentException.class );
+	}
 }


### PR DESCRIPTION
since it causes Stackoverflow through loop if the same element is returned every time.

This is an issue when working with PageObjects (i.e. `@FindBy`) which do the evaluation of the actual element lazy (via [`Proxy`](https://docs.oracle.com/javase/8/docs/api/java/lang/reflect/Proxy.html)) in `getWrapped`. Thus the construction of the PageObject is fine, until you access the object and its `WrapsElement` and a `NoSuchElementException` or similar is thrown.

However, the current implementation just silences this exception and instead returns the same element, which results in a recursion with no exit, and thus ultimately a `StackOverFlowError`.

This PR addresses this issue by rethrowing any potential exception from `getWrapped` with a `RuntimeException` and breaking the loop if the method could not be called resulting in an `UnsupportedOperationException`.