### PR TITLE
Update jackson-databind

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.9.9.2</version>
+			<version>2.9.10</version>
 		</dependency>
 
 		<!-- test dependencies -->


### PR DESCRIPTION
Also fixes the security issue.

According to [this alert](https://github.com/retest/recheck-web/network/alert/pom.xml/com.fasterxml.jackson.core:jackson-databind/open/update-errors/1659061):

>Dependabot cannot create a pull request as one or more other dependencies require a version that is incompatible with this update.