### PR TITLE
Fix .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,7 @@ addons:
       - chromium-chromedriver
   sonarcloud:
     organization: retest
-    token:
-      secure: "${SONAR_CLOUD_TOKEN}"
+    token: "${SONAR_CLOUD_TOKEN}"
 
 notifications:
   email: false


### PR DESCRIPTION
See https://travis-ci.community/t/sonarcloud-fails-to-authorize/5845/4.