### PR TITLE
Feature/ret 1899 web specific metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ Table of Contents
 
 ### New Features
 
+* As recheck gathers metadata, recheck-web will provide additional metadata:
+    * Browser name and version.
+    * Driver width and height.
+    * Operating system and version if specified in the driver.
+
 ### Improvements
 
 * `AutocheckingRecheckDriver` and thus the `RecheckDriver` now implement the `RecheckLifecycle`, meaning that they can be used with the JUnit extensions.

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
 		<dependency>
 			<groupId>de.retest</groupId>
 			<artifactId>recheck</artifactId>
-			<version>a707ce5d27</version>
+			<version>4de68be</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/de/retest/web/RecheckSeleniumAdapter.java
+++ b/src/main/java/de/retest/web/RecheckSeleniumAdapter.java
@@ -21,10 +21,12 @@ import org.slf4j.LoggerFactory;
 
 import de.retest.recheck.RecheckAdapter;
 import de.retest.recheck.RecheckOptions;
+import de.retest.recheck.meta.MetadataProvider;
 import de.retest.recheck.ui.DefaultValueFinder;
 import de.retest.recheck.ui.descriptors.RootElement;
 import de.retest.recheck.ui.descriptors.idproviders.RetestIdProvider;
 import de.retest.web.mapping.PathsToWebDataMapping;
+import de.retest.web.meta.SeleniumMetadataProvider;
 import de.retest.web.screenshot.ScreenshotProvider;
 import de.retest.web.selenium.UnbreakableDriver;
 import de.retest.web.util.SeleniumWrapperUtil;
@@ -145,6 +147,12 @@ public class RecheckSeleniumAdapter implements RecheckAdapter {
 		} catch ( final IOException e ) {
 			throw new UncheckedIOException( "Exception reading '" + GET_ALL_ELEMENTS_BY_PATH_JS_PATH + "'.", e );
 		}
+	}
+
+	@Override
+	public Map<String, String> retrieveMetadata( final Object toCheck ) {
+		final MetadataProvider provider = SeleniumMetadataProvider.of( toCheck );
+		return provider.retrieve();
 	}
 
 	@Override

--- a/src/main/java/de/retest/web/meta/SeleniumMetadata.java
+++ b/src/main/java/de/retest/web/meta/SeleniumMetadata.java
@@ -1,0 +1,22 @@
+package de.retest.web.meta;
+
+import de.retest.recheck.meta.global.OSMetadataProvider;
+
+public final class SeleniumMetadata {
+
+	// Generic
+
+	public static final String CHECK_TYPE = "check.type";
+
+	// Driver
+
+	public static final String BROWSER_NAME = "browser.name";
+	public static final String BROWSER_VERSION = "browser.version";
+
+	public static final String OS_NAME = OSMetadataProvider.OS_NAME;
+	public static final String OS_VERSION = OSMetadataProvider.OS_VERSION;
+
+	public static final String DRIVER_TYPE = "driver.type";
+	public static final String DRIVER_WINDOW_WIDTH = "driver.window.width";
+	public static final String DRIVER_WINDOW_HEIGHT = "driver.window.height";
+}

--- a/src/main/java/de/retest/web/meta/SeleniumMetadataProvider.java
+++ b/src/main/java/de/retest/web/meta/SeleniumMetadataProvider.java
@@ -1,0 +1,65 @@
+package de.retest.web.meta;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import de.retest.recheck.meta.MetadataProvider;
+import de.retest.recheck.meta.MultiMetadataProvider;
+import de.retest.web.meta.driver.WebDriverMetadataProvider;
+import de.retest.web.meta.element.WebElementMetadataProvider;
+import de.retest.web.util.SeleniumWrapperUtil;
+import de.retest.web.util.SeleniumWrapperUtil.WrapperOf;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor( access = AccessLevel.PACKAGE )
+public final class SeleniumMetadataProvider implements MetadataProvider {
+
+	public static final String TYPE_DRIVER = "driver";
+	public static final String TYPE_ELEMENT = "element";
+
+	private final String type;
+
+	public static MetadataProvider of( final Object object ) {
+		if ( object instanceof WebElement ) {
+			return of( (WebElement) object );
+		}
+		if ( SeleniumWrapperUtil.isWrapper( WrapperOf.ELEMENT, object ) ) {
+			return of( SeleniumWrapperUtil.getWrapped( WrapperOf.ELEMENT, object ) );
+		}
+		if ( object instanceof WebDriver ) {
+			return of( (WebDriver) object );
+		}
+		if ( SeleniumWrapperUtil.isWrapper( WrapperOf.DRIVER, object ) ) {
+			return of( SeleniumWrapperUtil.getWrapped( WrapperOf.DRIVER, object ) );
+		}
+		throw new IllegalArgumentException(
+				String.format( "Cannot retrieve metadata from objects of type '%s'.", object.getClass().getName() ) );
+	}
+
+	private static MetadataProvider of( final WebDriver object ) {
+		return MultiMetadataProvider.of( // 
+				WebDriverMetadataProvider.of( object ), //
+				new SeleniumMetadataProvider( TYPE_DRIVER ) //
+		);
+	}
+
+	private static MetadataProvider of( final WebElement object ) {
+		return MultiMetadataProvider.of( //
+				WebElementMetadataProvider.of( object ), //
+				new SeleniumMetadataProvider( TYPE_ELEMENT ) //
+		);
+	}
+
+	@Override
+	public Map<String, String> retrieve() {
+		final Map<String, String> map = new HashMap<>();
+
+		map.put( SeleniumMetadata.CHECK_TYPE, type );
+
+		return map;
+	}
+}

--- a/src/main/java/de/retest/web/meta/driver/WebDriverMetadataProvider.java
+++ b/src/main/java/de/retest/web/meta/driver/WebDriverMetadataProvider.java
@@ -1,0 +1,40 @@
+package de.retest.web.meta.driver;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.openqa.selenium.Dimension;
+import org.openqa.selenium.WebDriver;
+
+import de.retest.recheck.meta.MetadataProvider;
+import de.retest.recheck.meta.MultiMetadataProvider;
+import de.retest.web.meta.SeleniumMetadata;
+import de.retest.web.meta.driver.capabilities.CapabilityMetadataProvider;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor( access = AccessLevel.PACKAGE )
+public final class WebDriverMetadataProvider implements MetadataProvider {
+
+	private final WebDriver driver;
+
+	public static MetadataProvider of( final WebDriver driver ) {
+		return MultiMetadataProvider.of( // 
+				CapabilityMetadataProvider.of( driver ), //
+				new WebDriverMetadataProvider( driver ) //
+		);
+	}
+
+	@Override
+	public Map<String, String> retrieve() {
+		final Map<String, String> map = new HashMap<>();
+
+		map.put( SeleniumMetadata.DRIVER_TYPE, driver.getClass().getSimpleName() );
+
+		final Dimension size = driver.manage().window().getSize();
+		map.put( SeleniumMetadata.DRIVER_WINDOW_WIDTH, String.valueOf( size.getWidth() ) );
+		map.put( SeleniumMetadata.DRIVER_WINDOW_HEIGHT, String.valueOf( size.getHeight() ) );
+
+		return map;
+	}
+}

--- a/src/main/java/de/retest/web/meta/driver/capabilities/BrowserMetadataProvider.java
+++ b/src/main/java/de/retest/web/meta/driver/capabilities/BrowserMetadataProvider.java
@@ -1,0 +1,27 @@
+package de.retest.web.meta.driver.capabilities;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.openqa.selenium.Capabilities;
+
+import de.retest.recheck.meta.MetadataProvider;
+import de.retest.web.meta.SeleniumMetadata;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor( access = AccessLevel.PACKAGE )
+public final class BrowserMetadataProvider implements MetadataProvider {
+
+	private final Capabilities capabilities;
+
+	@Override
+	public Map<String, String> retrieve() {
+		final Map<String, String> map = new HashMap<>();
+
+		map.put( SeleniumMetadata.BROWSER_NAME, capabilities.getBrowserName() );
+		map.put( SeleniumMetadata.BROWSER_VERSION, capabilities.getVersion() );
+
+		return map;
+	}
+}

--- a/src/main/java/de/retest/web/meta/driver/capabilities/CapabilityMetadataProvider.java
+++ b/src/main/java/de/retest/web/meta/driver/capabilities/CapabilityMetadataProvider.java
@@ -1,0 +1,51 @@
+package de.retest.web.meta.driver.capabilities;
+
+import java.util.Map;
+
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import de.retest.recheck.meta.MetadataProvider;
+import de.retest.recheck.meta.MultiMetadataProvider;
+import de.retest.web.util.SeleniumWrapperUtil;
+import de.retest.web.util.SeleniumWrapperUtil.WrapperOf;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public final class CapabilityMetadataProvider implements MetadataProvider {
+
+	private final MetadataProvider provider;
+
+	CapabilityMetadataProvider( final Capabilities capabilities ) {
+		provider = MultiMetadataProvider.of( //
+				new BrowserMetadataProvider( capabilities ), //
+				new PlatformMetadataProvider( capabilities ) // 
+		);
+	}
+
+	public static MetadataProvider of( final WebDriver driver ) {
+		if ( SeleniumWrapperUtil.isWrapper( WrapperOf.DRIVER, driver ) ) {
+			return of( (WebDriver) SeleniumWrapperUtil.getWrapped( WrapperOf.DRIVER, driver ) );
+		}
+		if ( driver instanceof RemoteWebDriver ) {
+			return of( (RemoteWebDriver) driver );
+		}
+		log.warn( "Cannot retrieve capabilities from driver {}. Driver must be of '{}'. Returning empty metadata.",
+				driver, RemoteWebDriver.class.getSimpleName() );
+		return MetadataProvider.empty();
+	}
+
+	public static CapabilityMetadataProvider of( final RemoteWebDriver driver ) {
+		return of( driver.getCapabilities() );
+	}
+
+	public static CapabilityMetadataProvider of( final Capabilities capabilities ) {
+		return new CapabilityMetadataProvider( capabilities );
+	}
+
+	@Override
+	public Map<String, String> retrieve() {
+		return provider.retrieve();
+	}
+}

--- a/src/main/java/de/retest/web/meta/driver/capabilities/PlatformMetadataProvider.java
+++ b/src/main/java/de/retest/web/meta/driver/capabilities/PlatformMetadataProvider.java
@@ -1,0 +1,44 @@
+package de.retest.web.meta.driver.capabilities;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.Platform;
+import org.openqa.selenium.WebDriverException;
+
+import de.retest.recheck.meta.MetadataProvider;
+import de.retest.web.meta.SeleniumMetadata;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor( access = AccessLevel.PACKAGE )
+public final class PlatformMetadataProvider implements MetadataProvider {
+
+	private final Capabilities capabilities;
+
+	@Override
+	public Map<String, String> retrieve() {
+		final Map<String, String> map = new HashMap<>();
+
+		final Platform platform = retrievePlatformSilently();
+		if ( platform != null ) {
+			map.put( SeleniumMetadata.OS_NAME, platform.toString() );
+			final Object version = capabilities.getCapability( "platformVersion" );
+			if ( version != null ) {
+				map.put( SeleniumMetadata.OS_VERSION, version.toString() );
+			}
+		}
+
+		return map;
+	}
+
+	private Platform retrievePlatformSilently() {
+		try {
+			return capabilities.getPlatform();
+		} catch ( final IllegalArgumentException | WebDriverException e ) {
+			// failed
+			return null;
+		}
+	}
+}

--- a/src/main/java/de/retest/web/meta/element/WebElementMetadataProvider.java
+++ b/src/main/java/de/retest/web/meta/element/WebElementMetadataProvider.java
@@ -1,0 +1,33 @@
+package de.retest.web.meta.element;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.RemoteWebElement;
+
+import de.retest.recheck.meta.MetadataProvider;
+import de.retest.web.meta.driver.WebDriverMetadataProvider;
+import de.retest.web.util.SeleniumWrapperUtil;
+import de.retest.web.util.SeleniumWrapperUtil.WrapperOf;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public final class WebElementMetadataProvider {
+
+	public static MetadataProvider of( final WebElement element ) {
+		return extractDriverMetadataProvider( element );
+	}
+
+	private static MetadataProvider extractDriverMetadataProvider( final WebElement element ) {
+		if ( SeleniumWrapperUtil.isWrapper( WrapperOf.DRIVER, element ) ) {
+			final Object wrapped = SeleniumWrapperUtil.getWrapped( WrapperOf.DRIVER, element );
+			return WebDriverMetadataProvider.of( (WebDriver) wrapped );
+		}
+		if ( SeleniumWrapperUtil.isWrapper( WrapperOf.ELEMENT, element ) ) {
+			final Object wrapped = SeleniumWrapperUtil.getWrapped( WrapperOf.ELEMENT, element );
+			return extractDriverMetadataProvider( (WebElement) wrapped );
+		}
+		log.warn( "Cannot retrieve driver from element {}. Element must be of '{}'. Returning empty metadata.", element,
+				RemoteWebElement.class.getSimpleName() );
+		return MetadataProvider.empty();
+	}
+}

--- a/src/test/java/de/retest/web/it/SimplePageDiffIT.testSimpleChange.approved.txt
+++ b/src/test/java/de/retest/web/it/SimplePageDiffIT.testSimpleChange.approved.txt
@@ -3,6 +3,9 @@ A detailed report will be created at '/home/travis/build/retest/recheck-web/targ
 1 check(s) in 'de.retest.web.it.SimplePageDiffIT' found the following difference(s):
 Test 'testSimpleChange' has 4 difference(s) in 1 state(s):
 open resulted in:
+	Metadata Differences:
+		os.name: expected="LINUX", actual="null"
+		os.version: expected="4.4.0-101-generic", actual="null"
 	div at 'html[1]/body[1]/div[3]':
 		id: expected="twoblocks", actual="changedblock"
 	p [Some text] at 'html[1]/body[1]/div[3]/p[1]':

--- a/src/test/java/de/retest/web/meta/SeleniumMetadataProviderTest.java
+++ b/src/test/java/de/retest/web/meta/SeleniumMetadataProviderTest.java
@@ -1,0 +1,62 @@
+package de.retest.web.meta;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.RETURNS_MOCKS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.WrapsDriver;
+import org.openqa.selenium.WrapsElement;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.remote.RemoteWebElement;
+
+import de.retest.recheck.meta.MetadataProvider;
+
+class SeleniumMetadataProviderTest {
+
+	@Test
+	void retrieve_should_identify_driver() throws Exception {
+		final WebDriver driver = mock( RemoteWebDriver.class, RETURNS_MOCKS );
+
+		final MetadataProvider cut = SeleniumMetadataProvider.of( driver );
+
+		assertThat( cut.retrieve() ) //
+				.contains( Pair.of( SeleniumMetadata.CHECK_TYPE, SeleniumMetadataProvider.TYPE_DRIVER ) );
+	}
+
+	@Test
+	void retrieve_should_identify_wrapped_driver() throws Exception {
+		final WrapsDriver wrapsDriver = mock( WrapsDriver.class );
+		when( wrapsDriver.getWrappedDriver() ).thenReturn( mock( RemoteWebDriver.class, RETURNS_MOCKS ) );
+
+		final MetadataProvider cut = SeleniumMetadataProvider.of( wrapsDriver );
+
+		assertThat( cut.retrieve() ) //
+				.contains( Pair.of( SeleniumMetadata.CHECK_TYPE, SeleniumMetadataProvider.TYPE_DRIVER ) );
+	}
+
+	@Test
+	void retrieve_should_identify_element() throws Exception {
+		final WebElement element = mock( WebElement.class, RETURNS_MOCKS );
+
+		final MetadataProvider cut = SeleniumMetadataProvider.of( element );
+
+		assertThat( cut.retrieve() ) //
+				.contains( Pair.of( SeleniumMetadata.CHECK_TYPE, SeleniumMetadataProvider.TYPE_ELEMENT ) );
+	}
+
+	@Test
+	void retrieve_should_identify_wrapped_element() throws Exception {
+		final WrapsElement wrapsElement = mock( WrapsElement.class );
+		when( wrapsElement.getWrappedElement() ).thenReturn( mock( RemoteWebElement.class, RETURNS_MOCKS ) );
+
+		final MetadataProvider cut = SeleniumMetadataProvider.of( wrapsElement );
+
+		assertThat( cut.retrieve() ) //
+				.contains( Pair.of( SeleniumMetadata.CHECK_TYPE, SeleniumMetadataProvider.TYPE_ELEMENT ) );
+	}
+}

--- a/src/test/java/de/retest/web/meta/driver/WebDriverMetadataProviderTest.java
+++ b/src/test/java/de/retest/web/meta/driver/WebDriverMetadataProviderTest.java
@@ -1,0 +1,39 @@
+package de.retest.web.meta.driver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.RETURNS_MOCKS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import de.retest.recheck.meta.MetadataProvider;
+import de.retest.web.meta.SeleniumMetadata;
+import de.retest.web.selenium.UnbreakableDriver;
+
+class WebDriverMetadataProviderTest {
+
+	@Test
+	void retrieve_should_directly_take_driver_type() throws Exception {
+		final WebDriver driver = mock( WebDriver.class, RETURNS_MOCKS );
+
+		final MetadataProvider cut = WebDriverMetadataProvider.of( driver );
+
+		assertThat( cut.retrieve() )
+				.contains( Pair.of( SeleniumMetadata.DRIVER_TYPE, driver.getClass().getSimpleName() ) );
+	}
+
+	@Test
+	void retrieve_should_directly_take_driver_type_if_wrapped() throws Exception {
+		final UnbreakableDriver driver = mock( UnbreakableDriver.class, RETURNS_MOCKS );
+		when( driver.getWrappedDriver() ).thenReturn( mock( RemoteWebDriver.class, RETURNS_MOCKS ) );
+
+		final MetadataProvider cut = WebDriverMetadataProvider.of( driver );
+
+		assertThat( cut.retrieve() )
+				.contains( Pair.of( SeleniumMetadata.DRIVER_TYPE, driver.getClass().getSimpleName() ) );
+	}
+}

--- a/src/test/java/de/retest/web/meta/driver/capabilities/AllCapabilities.java
+++ b/src/test/java/de/retest/web/meta/driver/capabilities/AllCapabilities.java
@@ -1,0 +1,28 @@
+package de.retest.web.meta.driver.capabilities;
+
+import java.util.stream.Stream;
+
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.remote.DesiredCapabilities;
+
+public class AllCapabilities {
+
+	public static Stream<Capabilities> capabilities() {
+		return Stream.of( // 
+				DesiredCapabilities.android(), //
+				DesiredCapabilities.iphone(), //
+				DesiredCapabilities.ipad(), //
+				DesiredCapabilities.htmlUnit(), //
+
+				DesiredCapabilities.chrome(), //
+				DesiredCapabilities.firefox(), //
+
+				DesiredCapabilities.edge(), //
+				DesiredCapabilities.internetExplorer(), //
+
+				DesiredCapabilities.safari(), //
+
+				DesiredCapabilities.operaBlink() //
+		);
+	}
+}

--- a/src/test/java/de/retest/web/meta/driver/capabilities/BrowserMetadataProviderTest.java
+++ b/src/test/java/de/retest/web/meta/driver/capabilities/BrowserMetadataProviderTest.java
@@ -1,0 +1,21 @@
+package de.retest.web.meta.driver.capabilities;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.openqa.selenium.Capabilities;
+
+import de.retest.web.meta.SeleniumMetadata;
+
+class BrowserMetadataProviderTest {
+
+	@ParameterizedTest
+	@MethodSource( "de.retest.web.meta.driver.capabilities.AllCapabilities#capabilities" )
+	void retrieve_should_gather_browser_name_and_version( final Capabilities capabilities ) throws Exception {
+		final BrowserMetadataProvider cut = new BrowserMetadataProvider( capabilities );
+
+		assertThat( cut.retrieve() ) //
+				.containsKeys( SeleniumMetadata.BROWSER_NAME, SeleniumMetadata.BROWSER_VERSION );
+	}
+}

--- a/src/test/java/de/retest/web/meta/driver/capabilities/CapabilityMetadataProviderTest.java
+++ b/src/test/java/de/retest/web/meta/driver/capabilities/CapabilityMetadataProviderTest.java
@@ -1,0 +1,44 @@
+package de.retest.web.meta.driver.capabilities;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.RETURNS_MOCKS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import de.retest.recheck.meta.MetadataProvider;
+import de.retest.web.selenium.UnbreakableDriver;
+
+class CapabilityMetadataProviderTest {
+
+	@Test
+	void of_should_identify_driver() throws Exception {
+		final WebDriver driver = mock( RemoteWebDriver.class, RETURNS_MOCKS );
+
+		final MetadataProvider cut = CapabilityMetadataProvider.of( driver );
+
+		assertThat( cut.retrieve() ).isNotEmpty();
+	}
+
+	@Test
+	void of_should_identify_wrapped_driver() throws Exception {
+		final UnbreakableDriver wrapsDriver = mock( UnbreakableDriver.class, RETURNS_MOCKS );
+		when( wrapsDriver.getWrappedDriver() ).thenReturn( mock( RemoteWebDriver.class, RETURNS_MOCKS ) );
+
+		final MetadataProvider cut = CapabilityMetadataProvider.of( wrapsDriver );
+
+		assertThat( cut.retrieve() ).isNotEmpty();
+	}
+
+	@Test
+	void of_should_not_use_plain_web_driver_and_return_empty_provider() throws Exception {
+		final WebDriver driver = mock( WebDriver.class );
+
+		final MetadataProvider cut = CapabilityMetadataProvider.of( driver );
+
+		assertThat( cut.retrieve() ).isEmpty();
+	}
+}

--- a/src/test/java/de/retest/web/meta/driver/capabilities/PlatformMetadataProviderTest.java
+++ b/src/test/java/de/retest/web/meta/driver/capabilities/PlatformMetadataProviderTest.java
@@ -1,0 +1,23 @@
+package de.retest.web.meta.driver.capabilities;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.openqa.selenium.Capabilities;
+
+import de.retest.web.meta.SeleniumMetadata;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+class PlatformMetadataProviderTest {
+
+	@ParameterizedTest
+	@MethodSource( "de.retest.web.meta.driver.capabilities.AllCapabilities#capabilities" )
+	void retrieve_should_properly_resolve_platform( final Capabilities capabilities ) throws Exception {
+		final PlatformMetadataProvider cut = new PlatformMetadataProvider( capabilities );
+
+		assertThat( cut.retrieve() ) //
+				.containsKeys( SeleniumMetadata.OS_NAME );
+	}
+}

--- a/src/test/java/de/retest/web/meta/element/WebElementMetadataProviderTest.java
+++ b/src/test/java/de/retest/web/meta/element/WebElementMetadataProviderTest.java
@@ -1,0 +1,44 @@
+package de.retest.web.meta.element;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.RETURNS_MOCKS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.RemoteWebElement;
+
+import de.retest.recheck.meta.MetadataProvider;
+import de.retest.web.selenium.AutocheckingWebElement;
+
+class WebElementMetadataProviderTest {
+
+	@Test
+	void of_should_extract_driver_from_element() throws Exception {
+		final RemoteWebElement element = mock( RemoteWebElement.class, RETURNS_MOCKS );
+
+		final MetadataProvider cut = WebElementMetadataProvider.of( element );
+
+		assertThat( cut.retrieve() ).isNotEmpty();
+	}
+
+	@Test
+	void of_should_extract_driver_from_wrapped() throws Exception {
+		final AutocheckingWebElement element = mock( AutocheckingWebElement.class );
+		when( element.getWrappedElement() ).thenReturn( mock( RemoteWebElement.class, RETURNS_MOCKS ) );
+
+		final MetadataProvider cut = WebElementMetadataProvider.of( element );
+
+		assertThat( cut.retrieve() ).isNotEmpty();
+	}
+
+	@Test
+	void of_should_not_use_plain_web_element_and_return_empty_provider() throws Exception {
+		final WebElement element = mock( WebElement.class );
+
+		final MetadataProvider cut = WebElementMetadataProvider.of( element );
+
+		assertThat( cut.retrieve() ).isEmpty();
+	}
+}


### PR DESCRIPTION
*Before submission, please check that ...*

- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [x] the necessary tests are either created or updated.
- [x] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [x] you updated the changelog.
- [x] you updated necessary documentation within [retest/docs](https://github.com/retest/docs) (see retest/docs#71).

<!-- Note: You can always ask a maintainer to help you with the above tasks. -->

## Description

> TL;DR This adds web specific metadata as specified by RET-1899.

The list can be seen below:

| Key                    | Value (Example)   |
| ---------------------- | ----------------- |
| `check.type`           | driver            |
| `browser.name`         | chrome            |
| `browser.version`      | 78.0.3904.108     |
| `driver.type`          | UnbreakableDriver |
| `driver.window.width`  | 1200              |
| `driver.window.height` | 800               |
| `os.name`              | XP                |
| `os.version`           | 10.0              |

This PR builds upon several ideas:

1. Have the constants in one class so that those are not scattered around the providers.
2. Each provider only provides a small, categorized amount of data and will be built together using the `MultiMetadataProvider`.
3. Use a similar technique to extract the bottom `WebDriver` and kinda assume that it is a `RemoteWebDriver` as to extract the `Capabilities`.

### State of this PR

Same as before, the tests for the metadata do not explicitly check for a value present, as mocking this behavior would be quite complex. However, they ensure that the proper extraction of a `RemoteWebDriver` or a driver from an `WebElement` works properly.

Secondly, this (the integration into Recheck) has been tested manually.