### PR TITLE
Feature/prevent implicit explicit mixing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ Table of Contents
 
 ### Improvements
 
+* An exception is now thrown if explicit `Recheck#check` is called with an implicit `RecheckDriver`. This kind of mixing is not expected and therefore now prevented as it produced unexpected behavior due to both checks trying to find and create a Golden Master.
+
 
 --------------------------------------------------------------------------------
 

--- a/src/main/java/de/retest/web/RecheckSeleniumAdapter.java
+++ b/src/main/java/de/retest/web/RecheckSeleniumAdapter.java
@@ -85,22 +85,38 @@ public class RecheckSeleniumAdapter implements RecheckAdapter {
 
 	@Override
 	public Set<RootElement> convert( final Object toVerify ) {
-		if ( SeleniumWrapperUtil.isWrapper( WrapperOf.ELEMENT, toVerify ) ) {
-			return convert( SeleniumWrapperUtil.getWrapped( WrapperOf.ELEMENT, toVerify ) );
+		final RemoteWebElement webElement = retrieveWebElement( toVerify );
+		if ( webElement != null ) {
+			return convertWebElement( webElement );
 		}
-		if ( toVerify instanceof RemoteWebElement ) {
-			return convertWebElement( (RemoteWebElement) toVerify );
-		}
-		if ( toVerify instanceof UnbreakableDriver ) {
-			return convertWebDriver( (UnbreakableDriver) toVerify );
-		}
-		if ( SeleniumWrapperUtil.isWrapper( WrapperOf.DRIVER, toVerify ) ) {
-			return convert( SeleniumWrapperUtil.getWrapped( WrapperOf.DRIVER, toVerify ) );
-		}
-		if ( toVerify instanceof RemoteWebDriver ) {
-			return convertWebDriver( (RemoteWebDriver) toVerify );
+		final WebDriver webDriver = retrieveWebDriver( toVerify );
+		if ( webDriver != null ) {
+			return convertWebDriver( webDriver );
 		}
 		throw new IllegalArgumentException( "Cannot convert objects of type '" + toVerify.getClass().getName() + "'." );
+	}
+
+	private RemoteWebElement retrieveWebElement( final Object toVerify ) {
+		if ( SeleniumWrapperUtil.isWrapper( WrapperOf.ELEMENT, toVerify ) ) {
+			return retrieveWebElement( SeleniumWrapperUtil.getWrapped( WrapperOf.ELEMENT, toVerify ) );
+		}
+		if ( toVerify instanceof RemoteWebElement ) {
+			return (RemoteWebElement) toVerify;
+		}
+		return null;
+	}
+
+	private WebDriver retrieveWebDriver( final Object toVerify ) {
+		if ( toVerify instanceof UnbreakableDriver ) {
+			return (UnbreakableDriver) toVerify;
+		}
+		if ( SeleniumWrapperUtil.isWrapper( WrapperOf.DRIVER, toVerify ) ) {
+			return retrieveWebDriver( SeleniumWrapperUtil.getWrapped( WrapperOf.DRIVER, toVerify ) );
+		}
+		if ( toVerify instanceof RemoteWebDriver ) {
+			return (RemoteWebDriver) toVerify;
+		}
+		return null;
 	}
 
 	Set<RootElement> convertWebDriver( final WebDriver driver ) {

--- a/src/main/java/de/retest/web/RecheckSeleniumAdapter.java
+++ b/src/main/java/de/retest/web/RecheckSeleniumAdapter.java
@@ -28,6 +28,8 @@ import de.retest.recheck.ui.descriptors.idproviders.RetestIdProvider;
 import de.retest.web.mapping.PathsToWebDataMapping;
 import de.retest.web.meta.SeleniumMetadataProvider;
 import de.retest.web.screenshot.ScreenshotProvider;
+import de.retest.web.selenium.AutocheckingRecheckDriver;
+import de.retest.web.selenium.ImplicitDriverWrapper;
 import de.retest.web.selenium.UnbreakableDriver;
 import de.retest.web.util.SeleniumWrapperUtil;
 import de.retest.web.util.SeleniumWrapperUtil.WrapperOf;
@@ -89,7 +91,7 @@ public class RecheckSeleniumAdapter implements RecheckAdapter {
 		if ( webElement != null ) {
 			return convertWebElement( webElement );
 		}
-		final WebDriver webDriver = retrieveWebDriver( toVerify );
+		final WebDriver webDriver = retrieveWebDriver( unwrapImplicitDriver( toVerify ) );
 		if ( webDriver != null ) {
 			return convertWebDriver( webDriver );
 		}
@@ -104,6 +106,18 @@ public class RecheckSeleniumAdapter implements RecheckAdapter {
 			return (RemoteWebElement) toVerify;
 		}
 		return null;
+	}
+
+	private Object unwrapImplicitDriver( final Object toVerify ) {
+		if ( toVerify instanceof AutocheckingRecheckDriver ) {
+			throw new UnsupportedOperationException( String.format(
+					"Mixing implicit checking used by '%s' and explicit checking with 'Recheck#check' is not supported.",
+					toVerify.getClass().getSimpleName() ) );
+		}
+		if ( toVerify instanceof ImplicitDriverWrapper ) {
+			return ((ImplicitDriverWrapper) toVerify).getWrappedDriver();
+		}
+		return toVerify;
 	}
 
 	private WebDriver retrieveWebDriver( final Object toVerify ) {

--- a/src/main/java/de/retest/web/RecheckSeleniumAdapter.java
+++ b/src/main/java/de/retest/web/RecheckSeleniumAdapter.java
@@ -111,7 +111,10 @@ public class RecheckSeleniumAdapter implements RecheckAdapter {
 	private Object unwrapImplicitDriver( final Object toVerify ) {
 		if ( toVerify instanceof AutocheckingRecheckDriver ) {
 			throw new UnsupportedOperationException( String.format(
-					"Mixing implicit checking used by '%s' and explicit checking with 'Recheck#check' is not supported.",
+					"The '%s' does implicit checking after each action, " // 
+							+ "therefore no explicit check with 'Recheck#check' is needed. " // 
+							+ "Please remove the explicit check. " //
+							+ "For more information, please have a look at https://docs.retest.de/recheck-web/introduction/usage/.",
 					toVerify.getClass().getSimpleName() ) );
 		}
 		if ( toVerify instanceof ImplicitDriverWrapper ) {

--- a/src/main/java/de/retest/web/RecheckWebImpl.java
+++ b/src/main/java/de/retest/web/RecheckWebImpl.java
@@ -6,7 +6,10 @@ import de.retest.recheck.RecheckAdapter;
 import de.retest.recheck.RecheckImpl;
 import de.retest.recheck.RecheckOptions;
 import de.retest.recheck.ui.descriptors.SutState;
+import de.retest.web.selenium.ImplicitDriverWrapper;
 import de.retest.web.selenium.UnbreakableDriver;
+import lombok.AccessLevel;
+import lombok.Getter;
 
 /**
  * This class is specifically needed in conjunction with the {@link UnbreakableDriver}. For simple explicit calls to
@@ -14,6 +17,7 @@ import de.retest.web.selenium.UnbreakableDriver;
  */
 public class RecheckWebImpl extends RecheckImpl {
 
+	@Getter( AccessLevel.PACKAGE )
 	private UnbreakableDriver driver;
 
 	public RecheckWebImpl() {
@@ -37,6 +41,9 @@ public class RecheckWebImpl extends RecheckImpl {
 	}
 
 	private UnbreakableDriver retrieveUnbreakableDriver( final Object driver ) {
+		if ( driver instanceof ImplicitDriverWrapper ) {
+			return retrieveUnbreakableDriver( ((ImplicitDriverWrapper) driver).getWrappedDriver() );
+		}
 		if ( driver instanceof UnbreakableDriver ) {
 			return (UnbreakableDriver) driver;
 		}

--- a/src/main/java/de/retest/web/RecheckWebImpl.java
+++ b/src/main/java/de/retest/web/RecheckWebImpl.java
@@ -26,18 +26,21 @@ public class RecheckWebImpl extends RecheckImpl {
 
 	@Override
 	public void check( final Object driver, final RecheckAdapter seleniumAdapter, final String currentStep ) {
-		if ( driver instanceof UnbreakableDriver ) {
-			this.driver = (UnbreakableDriver) driver;
-		}
+		this.driver = retrieveUnbreakableDriver( driver );
 		super.check( driver, seleniumAdapter, currentStep );
 	}
 
 	@Override
 	public void check( final Object driver, final String currentStep ) {
-		if ( driver instanceof UnbreakableDriver ) {
-			this.driver = (UnbreakableDriver) driver;
-		}
+		this.driver = retrieveUnbreakableDriver( driver );
 		super.check( driver, currentStep );
+	}
+
+	private UnbreakableDriver retrieveUnbreakableDriver( final Object driver ) {
+		if ( driver instanceof UnbreakableDriver ) {
+			return (UnbreakableDriver) driver;
+		}
+		return null;
 	}
 
 	@Override

--- a/src/main/java/de/retest/web/selenium/AutocheckingRecheckDriver.java
+++ b/src/main/java/de/retest/web/selenium/AutocheckingRecheckDriver.java
@@ -152,14 +152,14 @@ public class AutocheckingRecheckDriver extends UnbreakableDriver implements Rech
 		if ( re == null ) {
 			startTest();
 		}
-		re.check( this, checkNamingStrategy.getUniqueCheckName( action, target, params ) );
+		re.check( ImplicitDriverWrapper.of( this ), checkNamingStrategy.getUniqueCheckName( action, target, params ) );
 	}
 
 	void check( final String action ) {
 		if ( re == null ) {
 			startTest();
 		}
-		re.check( this, checkNamingStrategy.getUniqueCheckName( action ) );
+		re.check( ImplicitDriverWrapper.of( this ), checkNamingStrategy.getUniqueCheckName( action ) );
 	}
 
 	@Override

--- a/src/main/java/de/retest/web/selenium/ImplicitDriverWrapper.java
+++ b/src/main/java/de/retest/web/selenium/ImplicitDriverWrapper.java
@@ -1,0 +1,18 @@
+package de.retest.web.selenium;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WrapsDriver;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor( access = AccessLevel.PACKAGE, staticName = "of" )
+public class ImplicitDriverWrapper implements WrapsDriver {
+
+	private final WebDriver wrapped;
+
+	@Override
+	public WebDriver getWrappedDriver() {
+		return wrapped;
+	}
+}

--- a/src/test/java/de/retest/web/RecheckSeleniumAdapterTest.java
+++ b/src/test/java/de/retest/web/RecheckSeleniumAdapterTest.java
@@ -147,7 +147,7 @@ class RecheckSeleniumAdapterTest {
 		final WrappingRemoteWebElement outer = createOuterWrappingElement( inner );
 
 		assertThat( cut.convert( outer ) ).isEmpty();
-		verify( cut ).convert( inner.getWrappedElement() );
+		verify( cut ).convertWebElement( (RemoteWebElement) inner.getWrappedElement() );
 	}
 
 	@Test
@@ -159,7 +159,7 @@ class RecheckSeleniumAdapterTest {
 		final WrappingRemoteWebDriver outer = createOuterWrappingDriver( inner );
 
 		assertThat( cut.convert( outer ) ).isEmpty();
-		verify( cut ).convert( inner.getWrappedDriver() );
+		verify( cut ).convertWebDriver( inner.getWrappedDriver() );
 	}
 
 	@Test

--- a/src/test/java/de/retest/web/RecheckSeleniumAdapterTest.java
+++ b/src/test/java/de/retest/web/RecheckSeleniumAdapterTest.java
@@ -218,7 +218,7 @@ class RecheckSeleniumAdapterTest {
 		assertThatThrownBy( () -> cut.convert( driver ) ) //
 				.isInstanceOf( UnsupportedOperationException.class ) //
 				.hasMessageStartingWith( String.format(
-						"Mixing implicit checking used by '%s' and explicit checking with 'Recheck#check' is not supported.",
+						"The '%s' does implicit checking after each action, therefore no explicit check with 'Recheck#check' is needed",
 						driver.getClass().getSimpleName() ) );
 	}
 

--- a/src/test/java/de/retest/web/RecheckSeleniumAdapterTest.java
+++ b/src/test/java/de/retest/web/RecheckSeleniumAdapterTest.java
@@ -32,6 +32,7 @@ import org.openqa.selenium.safari.SafariDriver;
 
 import de.retest.recheck.RecheckAdapter;
 import de.retest.web.selenium.AutocheckingRecheckDriver;
+import de.retest.web.selenium.ImplicitDriverWrapper;
 import de.retest.web.selenium.RecheckDriver;
 import de.retest.web.selenium.UnbreakableDriver;
 
@@ -205,6 +206,33 @@ class RecheckSeleniumAdapterTest {
 		doReturn( Collections.emptySet() ).when( cut ).convertWebDriver( any() );
 
 		assertThatCode( () -> cut.convert( mock( WebDriver.class ) ) ).isInstanceOf( IllegalArgumentException.class );
+	}
+
+	@Test
+	void convert_should_throw_with_autochecking_driver() throws Exception {
+		final RecheckSeleniumAdapter cut = spy( new RecheckSeleniumAdapter() );
+		doReturn( Collections.emptySet() ).when( cut ).convertWebDriver( any() );
+
+		final AutocheckingRecheckDriver driver = mock( AutocheckingRecheckDriver.class );
+
+		assertThatThrownBy( () -> cut.convert( driver ) ) //
+				.isInstanceOf( UnsupportedOperationException.class ) //
+				.hasMessageStartingWith( String.format(
+						"Mixing implicit checking used by '%s' and explicit checking with 'Recheck#check' is not supported.",
+						driver.getClass().getSimpleName() ) );
+	}
+
+	@Test
+	void convert_should_not_walk_through_implicit_checking_if_unbreakable() throws Exception {
+		final UnbreakableDriver unbreakableDriver = mock( UnbreakableDriver.class );
+
+		final RecheckSeleniumAdapter cut = spy( new RecheckSeleniumAdapter() );
+		doReturn( Collections.emptySet() ).when( cut ).convertWebDriver( unbreakableDriver );
+
+		final ImplicitDriverWrapper wrapper = mock( ImplicitDriverWrapper.class );
+		when( wrapper.getWrappedDriver() ).thenReturn( unbreakableDriver );
+
+		assertThat( cut.convert( wrapper ) ).isNotNull();
 	}
 
 	private WrappingRemoteWebElement createOuterWrappingElement( final WrappingRemoteWebElement inner ) {

--- a/src/test/java/de/retest/web/RecheckWebImplIT.java
+++ b/src/test/java/de/retest/web/RecheckWebImplIT.java
@@ -50,8 +50,8 @@ class RecheckWebImplIT {
 			re.check( driver, "explicit-implicit-mixed" );
 		} ) //
 				.isInstanceOf( UnsupportedOperationException.class ) //
-				.hasMessage(
-						"Mixing implicit checking used by 'RecheckDriver' and explicit checking with 'Recheck#check' is not supported." );
+				.hasMessageStartingWith(
+						"The 'RecheckDriver' does implicit checking after each action, therefore no explicit check with 'Recheck#check' is needed" );
 
 		capTestSilently( re );
 		capTestSilently( driver );

--- a/src/test/java/de/retest/web/RecheckWebImplIT.java
+++ b/src/test/java/de/retest/web/RecheckWebImplIT.java
@@ -1,0 +1,76 @@
+package de.retest.web;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import de.retest.recheck.RecheckLifecycle;
+import de.retest.recheck.RecheckOptions;
+import de.retest.recheck.persistence.SeparatePathsProjectLayout;
+import de.retest.web.selenium.RecheckDriver;
+import de.retest.web.testutils.WebDriverFactory;
+import de.retest.web.testutils.WebDriverFactory.Driver;
+
+class RecheckWebImplIT {
+
+	RecheckWebImpl re;
+
+	RecheckDriver driver;
+
+	@BeforeEach
+	void setUp( @TempDir final Path project ) {
+		final Path goldenMasterDirectory = project.resolve( "state" );
+		final Path reportDirectory = project.resolve( "report" );
+		final RecheckOptions options = RecheckWebOptions.builder()
+				.projectLayout( new SeparatePathsProjectLayout( goldenMasterDirectory, reportDirectory ) ) //
+				.build();
+
+		re = new RecheckWebImpl( options );
+		driver = new RecheckDriver( WebDriverFactory.driver( Driver.CHROME ), options );
+	}
+
+	@AfterEach
+	void tearDown() {
+		driver.quit();
+		re.cap();
+	}
+
+	@Test
+	void check_should_throw_if_explicit_checking() throws Exception {
+		re.startTest();
+		driver.startTest();
+
+		assertThatThrownBy( () -> {
+			re.check( driver, "explicit-implicit-mixed" );
+		} ) //
+				.isInstanceOf( UnsupportedOperationException.class ) //
+				.hasMessage(
+						"Mixing implicit checking used by 'RecheckDriver' and explicit checking with 'Recheck#check' is not supported." );
+
+		capTestSilently( re );
+		capTestSilently( driver );
+	}
+
+	@Test
+	void check_should_not_throw_if_implicit_checking() throws Exception {
+		driver.startTest();
+
+		assertThatCode( () -> driver.get( "https://retest.de" ) ).doesNotThrowAnyException();
+
+		capTestSilently( driver );
+	}
+
+	private void capTestSilently( final RecheckLifecycle re ) {
+		try {
+			re.capTest();
+		} catch ( final AssertionError e ) {
+			// expected
+		}
+	}
+}

--- a/src/test/java/de/retest/web/RecheckWebImplTest.java
+++ b/src/test/java/de/retest/web/RecheckWebImplTest.java
@@ -1,0 +1,120 @@
+package de.retest.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.RETURNS_MOCKS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.nio.file.Path;
+import java.util.Collections;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import de.retest.recheck.RecheckAdapter;
+import de.retest.recheck.RecheckOptions;
+import de.retest.recheck.persistence.SeparatePathsProjectLayout;
+import de.retest.recheck.ui.descriptors.RootElement;
+import de.retest.web.selenium.ImplicitDriverWrapper;
+import de.retest.web.selenium.UnbreakableDriver;
+
+class RecheckWebImplTest {
+
+	RecheckWebImpl re;
+	RecheckAdapter adapter;
+
+	@BeforeEach
+	void setUp( @TempDir final Path project ) {
+		final Path goldenMasterDirectory = project.resolve( "state" );
+		final Path reportDirectory = project.resolve( "report" );
+		final RecheckOptions options = RecheckWebOptions.builder()
+				.projectLayout( new SeparatePathsProjectLayout( goldenMasterDirectory, reportDirectory ) ) //
+				.build();
+
+		final RootElement rootElement = mock( RootElement.class, RETURNS_MOCKS );
+
+		re = new RecheckWebImpl( options );
+		adapter = mock( RecheckAdapter.class );
+		when( adapter.convert( any() ) ).thenReturn( Collections.singleton( rootElement ) );
+	}
+
+	@AfterEach
+	void tearDown() {
+		re.cap();
+	}
+
+	@Test
+	void check_should_properly_extract_unbreakable_driver() throws Exception {
+		re.startTest();
+
+		re.check( mock( UnbreakableDriver.class ), adapter, "unbreakable" );
+
+		assertThat( re.getDriver() ).isNotNull();
+
+		capTestSilently();
+	}
+
+	@Test
+	void check_should_properly_fail_if_no_unbreakable_driver() throws Exception {
+		re.startTest();
+
+		assertThatThrownBy( () -> {
+			re.check( mock( RemoteWebDriver.class ), adapter, "unbreakable" );
+		} ) //
+				.isInstanceOf( IllegalStateException.class ) //
+				.hasMessage(
+						"Must first call a check-method with an UnbreakableDriver before being able to load a Golden Master (needed for unbreakable tests)!" );
+
+		assertThat( re.getDriver() ).isNull();
+
+		capTestSilently();
+	}
+
+	@Test
+	void check_should_properly_extract_unbreakable_from_implicit_wrapper() throws Exception {
+		re.startTest();
+
+		final UnbreakableDriver unbreakableDriver = mock( UnbreakableDriver.class );
+		final ImplicitDriverWrapper wrapper = mock( ImplicitDriverWrapper.class );
+		when( wrapper.getWrappedDriver() ).thenReturn( unbreakableDriver );
+
+		re.check( wrapper, adapter, "unbreakable" );
+
+		assertThat( re.getDriver() ).isNotNull();
+
+		capTestSilently();
+	}
+
+	@Test
+	void check_should_properly_fail_if_no_unbreakable_driver_from_implicit_wrapper() throws Exception {
+		re.startTest();
+
+		final RemoteWebDriver driver = mock( RemoteWebDriver.class );
+		final ImplicitDriverWrapper wrapper = mock( ImplicitDriverWrapper.class );
+		when( wrapper.getWrappedDriver() ).thenReturn( driver );
+
+		assertThatThrownBy( () -> {
+			re.check( wrapper, adapter, "unbreakable" );
+		} ) //
+				.isInstanceOf( IllegalStateException.class ) //
+				.hasMessage(
+						"Must first call a check-method with an UnbreakableDriver before being able to load a Golden Master (needed for unbreakable tests)!" );
+
+		assertThat( re.getDriver() ).isNull();
+
+		capTestSilently();
+	}
+
+	private void capTestSilently() {
+		try {
+			re.capTest();
+		} catch ( final AssertionError e ) {
+			// expected
+		}
+	}
+}

--- a/src/test/java/de/retest/web/testutils/WebDriverFactory.java
+++ b/src/test/java/de/retest/web/testutils/WebDriverFactory.java
@@ -10,15 +10,16 @@ import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxOptions;
+import org.openqa.selenium.remote.RemoteWebDriver;
 
 public class WebDriverFactory {
 
 	public enum Driver {
 		CHROME,
-		FIREFOX;
+		FIREFOX
 	}
 
-	public static WebDriver driver( final Driver driver ) {
+	public static RemoteWebDriver driver( final Driver driver ) {
 		switch ( driver ) {
 			case CHROME: {
 				return new ChromeDriver( new ChromeOptions().addArguments( commonArguments() ) );

--- a/src/test/java/de/retest/web/util/SeleniumWrapperUtilTest.java
+++ b/src/test/java/de/retest/web/util/SeleniumWrapperUtilTest.java
@@ -13,6 +13,7 @@ import org.openqa.selenium.internal.WrapsDriver;
 import org.openqa.selenium.internal.WrapsElement;
 
 import de.retest.web.util.SeleniumWrapperUtil.WrapperOf;
+import lombok.Value;
 
 class SeleniumWrapperUtilTest {
 
@@ -89,5 +90,36 @@ class SeleniumWrapperUtilTest {
 
 		assertThatThrownBy( () -> SeleniumWrapperUtil.getWrapped( WrapperOf.DRIVER, notElement ) )
 				.isInstanceOf( IllegalArgumentException.class );
+	}
+
+	@Test
+	void getWrapped_should_properly_handle_if_driver_returns_null() throws Exception {
+		final org.openqa.selenium.WrapsDriver nullDriver = mock( org.openqa.selenium.WrapsDriver.class );
+
+		assertThat( SeleniumWrapperUtil.getWrapped( WrapperOf.DRIVER, nullDriver ) ).isEqualTo( null );
+	}
+
+	@Test
+	void getWrapped_should_properly_handle_if_element_returns_null() throws Exception {
+		final WrapsElement nullElement = mock( WrapsElement.class );
+
+		assertThat( SeleniumWrapperUtil.getWrapped( WrapperOf.ELEMENT, nullElement ) ).isEqualTo( null );
+	}
+
+	@Test
+	void getWrapped_should_throw_when_method_does_not_return_expected_type() throws Exception {
+		final Wrapper<?> fooled = new Wrapper<>( new Object() );
+		final org.openqa.selenium.WrapsDriver fooledDriver = () -> ((Wrapper<WebDriver>) fooled).getWrapped();
+
+		assertThatThrownBy( () -> SeleniumWrapperUtil.getWrapped( WrapperOf.DRIVER, fooledDriver ) ) //
+				.isInstanceOf( RuntimeException.class ) //
+				.hasMessageStartingWith( "Failed to invoke SeleniumWrapperUtilTest" ) //
+				.hasCauseInstanceOf( ClassCastException.class );
+	}
+
+	@Value
+	private static class Wrapper<T> {
+
+		T wrapped;
 	}
 }


### PR DESCRIPTION
*Before submission, please check that ...*

- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [x] the necessary tests are either created or updated.
- [x] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [x] you updated the changelog.
- [x] you updated necessary documentation within [retest/docs](https://github.com/retest/docs). See #retest/docs#75.

<!-- Note: You can always ask a maintainer to help you with the above tasks. -->

## Description

> TL;DR Disallow mixing of implicit and explicit checking.

This PR aims to forbid explicit and implicit checking as described here:

```java
@ExtendWith( RecheckExtension.class )
class LoginTest {

	Recheck re;
	WebDriver driver;

	@BeforeEach
	void setUp() {
		re = new RecheckImpl();
		driver = new RecheckDriver( new ChromeDriver() ); 
	}

	@AfterEach
	void tearDown() {
		driver.quit();
	}

	@Test
	void mixing_implicit_and_explicit_checking() throws Exception {
		driver.get( "https://example.com" );

		re.check( driver, "mixing" ); // Will now throw an exception
	}
}
```

#### How does this work?

The `AutocheckingDriver` simply wraps itself (i.e. the UnbreakableDriver) into a separate wrapper `ImplicitDriverWrapper`. Within the `SeleniumAdapter` the wrapper is unwrapped and the original driver is used to be converted. However, the user does not have access to said wrapper and can only pass the `AutocheckingDriver` into the check method. This can now be detected, as the `SeleniumAdapter` simply disallows any raw `AutocheckingDriver` to be passed into the `convert` method as it expects it to be wrapped in the `ImplicitDriverWrapper`.

However that brought some complications which have been resolved, but rise the below mentioned questions. The `RecheckWebImpl` (both explicitly and implicitly used) needs to access the `UnbreakableDriver` behind the `AutocheckingDriver` (which now is wrapped). Therefore it, too, needs to unwrap the driver and pass the wrapped along to the adapter.

### State of this PR

While this PR prevents the mixing, we should discuss some points, which may be addressed separately.

1. Does the `AutocheckingDriver` have to be unbreakable? If I recall correctly from our last discussion about the implicit/explicit topic, this was a limitation in order for the feature to work correctly. 

   However, since we can now wrap any `WebDriver` within `ImplicitDriverWrapper` this should be no limitation anymore. 

    1. The `AutocheckingDriver` can simply call `ImplicitDriverWrapper.of( internalDriver )` and not be unbreakable.
    2. The `RecheckDriver` can simply delegate using `AutocheckingDriver` and pass the `UnbreakableDriver`.

   Secondly, this would resolve the discussion around #381 as each driver would have its own purpose (and the `RecheckDriver` combining all of them).
2. Do we really want to completely block of implicit and explicit mixing. A use case would be to have an unstable page. Consider the following example for a login page where an invalid password has been entered:

    1. Type user `"admin"`.
    2. Type password `"invalid"`.
    3. Click login.
    4. Wait for page to be stable, because the login needs to query the database first.
    5. Expect an error message to be displayed.

    The hindering part is the waiting for stabilization. The login check would still display the spinning button, waiting for a response of the server. How is the user supposed to check for the message being displayed without executing another action? 

   Some solutions come to mind:

   1. Use explicit checking. ... Oh wait, this does not work. However, we could expose the internal driver (e.g.: `re.check( autoRe.getWrappedDriver(), "implicit-and-explicit-working"))`). However, this would only be possible if the above has been addressed.
   2. Have support to wait for stabilization. Selenium does not provide a good way to do so (even though there is a `WebDriverWait`, but requires the driver and a `List<ExpectedConditions>`). 