### PR TITLE
Feature/ret 1917 implement warning creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,10 +32,12 @@ Table of Contents
 ### New Features
 
 * Provide additional metadata: current URL
+* Save the warnings identified by the `UnbreakableDriver` to the report to allow for healing of the test code.
 
 ### Improvements
 
 * An exception is now thrown if explicit `Recheck#check` is called with an implicit `RecheckDriver`. This kind of mixing is not expected and therefore now prevented as it produced unexpected behavior due to both checks trying to find and create a Golden Master.
+* Improve the breaking messages from a `UnbreakableDriver` to include more information like the line number.
 
 
 --------------------------------------------------------------------------------

--- a/src/main/java/de/retest/web/selenium/QualifiedElementWarning.java
+++ b/src/main/java/de/retest/web/selenium/QualifiedElementWarning.java
@@ -1,0 +1,13 @@
+package de.retest.web.selenium;
+
+import de.retest.recheck.ui.diff.ElementIdentificationWarning;
+import lombok.Value;
+
+@Value
+public class QualifiedElementWarning {
+
+	private String retestId;
+	private String attributeKey;
+	private ElementIdentificationWarning warning;
+
+}

--- a/src/main/java/de/retest/web/selenium/TestHealer.java
+++ b/src/main/java/de/retest/web/selenium/TestHealer.java
@@ -10,6 +10,7 @@ import static de.retest.web.selenium.ByWhisperer.retrieveLinkText;
 import static de.retest.web.selenium.ByWhisperer.retrieveName;
 import static de.retest.web.selenium.ByWhisperer.retrievePartialLinkText;
 
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -31,6 +32,7 @@ import de.retest.recheck.TestCaseFinder;
 import de.retest.recheck.ui.descriptors.Element;
 import de.retest.recheck.ui.descriptors.IdentifyingAttributes;
 import de.retest.recheck.ui.descriptors.RootElement;
+import de.retest.recheck.ui.diff.ElementIdentificationWarning;
 
 public class TestHealer {
 
@@ -48,6 +50,7 @@ public class TestHealer {
 	private final UnbreakableDriver wrapped;
 	private final RootElement lastExpectedState;
 	private final RootElement lastActualState;
+	private final Consumer<QualifiedElementWarning> warningConsumer;
 
 	private TestHealer( final UnbreakableDriver wrapped ) {
 		this.wrapped = wrapped;
@@ -56,6 +59,7 @@ public class TestHealer {
 			throw new IllegalStateException( "No last expected state to find old element in!" );
 		}
 		lastActualState = wrapped.getLastActualState();
+		warningConsumer = wrapped.getWarningConsumer();
 	}
 
 	public static WebElement findElement( final By by, final UnbreakableDriver wrapped ) {
@@ -353,6 +357,10 @@ public class TestHealer {
 		} else {
 			logger.warn( "Use `By.retestId(\"{}\")` to update your test {}:{}.", actualElement.getRetestId(),
 					callSiteFileName, callSiteLineNumber );
+		}
+		if ( warningConsumer != null ) {
+			warningConsumer.accept( new QualifiedElementWarning( actualElement.getRetestId(), elementIdentifier,
+					new ElementIdentificationWarning( callSiteFileName, callSiteLineNumber, byMethodName, test ) ) );
 		}
 	}
 

--- a/src/main/java/de/retest/web/selenium/TestHealer.java
+++ b/src/main/java/de/retest/web/selenium/TestHealer.java
@@ -100,8 +100,8 @@ public class TestHealer {
 			logger.warn( "{} with id '{}'.", ELEMENT_NOT_FOUND_MESSAGE, id );
 			return null;
 		} else {
-			writeWarnLogForChangedIdentifier( "HTML id attribute", id,
-					actualElement.getIdentifyingAttributes().get( ID ), ID, actualElement.getRetestId() );
+			writeWarnLogForChangedIdentifier( ID, id, actualElement.getIdentifyingAttributes().get( ID ), ID,
+					actualElement );
 			return wrapped.findElement( By.xpath( actualElement.getIdentifyingAttributes().getPath() ) );
 		}
 	}
@@ -115,8 +115,8 @@ public class TestHealer {
 			logger.warn( "{} with CSS class '{}'.", ELEMENT_NOT_FOUND_MESSAGE, className );
 			return null;
 		} else {
-			writeWarnLogForChangedIdentifier( "HTML class attribute", className,
-					actualElement.getIdentifyingAttributes().get( CLASS ), "className", actualElement.getRetestId() );
+			writeWarnLogForChangedIdentifier( CLASS, className, actualElement.getIdentifyingAttributes().get( CLASS ),
+					"className", actualElement );
 			return wrapped.findElement( By.xpath( actualElement.getIdentifyingAttributes().getPath() ) );
 		}
 	}
@@ -130,8 +130,8 @@ public class TestHealer {
 			logger.warn( "{} with name '{}'.", ELEMENT_NOT_FOUND_MESSAGE, name );
 			return null;
 		} else {
-			writeWarnLogForChangedIdentifier( "HTML name attribute", name,
-					actualElement.getIdentifyingAttributes().get( NAME ), NAME, actualElement.getRetestId() );
+			writeWarnLogForChangedIdentifier( NAME, name, actualElement.getIdentifyingAttributes().get( NAME ), NAME,
+					actualElement );
 			return wrapped.findElement( By.xpath( actualElement.getIdentifyingAttributes().getPath() ) );
 		}
 	}
@@ -145,8 +145,8 @@ public class TestHealer {
 			logger.warn( "{} with link text '{}'.", ELEMENT_NOT_FOUND_MESSAGE, linkText );
 			return null;
 		} else {
-			writeWarnLogForChangedIdentifier( "link text", linkText,
-					actualElement.getIdentifyingAttributes().get( TEXT ), "linkText", actualElement.getRetestId() );
+			writeWarnLogForChangedIdentifier( TEXT, linkText, actualElement.getIdentifyingAttributes().get( TEXT ),
+					"linkText", actualElement );
 			return wrapped.findElement( By.xpath( actualElement.getIdentifyingAttributes().getPath() ) );
 		}
 	}
@@ -161,8 +161,7 @@ public class TestHealer {
 			return null;
 		} else {
 			writeWarnLogForChangedIdentifier( "partial link text", partialLinkText,
-					actualElement.getIdentifyingAttributes().get( TEXT ), "partialLinkText",
-					actualElement.getRetestId() );
+					actualElement.getIdentifyingAttributes().get( TEXT ), "partialLinkText", actualElement );
 			return wrapped.findElement( By.xpath( actualElement.getIdentifyingAttributes().getPath() ) );
 		}
 	}
@@ -219,8 +218,8 @@ public class TestHealer {
 			logger.warn( "{} with CSS selector '{}'.", ELEMENT_NOT_FOUND_MESSAGE, origSelector );
 			return null;
 		} else {
-			writeWarnLogForChangedIdentifier( "HTML class attribute", origSelector,
-					actualElement.getIdentifyingAttributes().get( CLASS ), "cssSelector", actualElement.getRetestId() );
+			writeWarnLogForChangedIdentifier( CLASS, origSelector,
+					actualElement.getIdentifyingAttributes().get( CLASS ), "cssSelector", actualElement );
 			return wrapped.findElement( By.xpath( actualElement.getIdentifyingAttributes().getPath() ) );
 		}
 	}
@@ -303,8 +302,8 @@ public class TestHealer {
 			logger.warn( "{} with XPath '{}'.", ELEMENT_NOT_FOUND_MESSAGE, xpathExpression );
 			return null;
 		} else {
-			writeWarnLogForChangedIdentifier( "xpath", xpathExpression,
-					actualElement.getIdentifyingAttributes().get( PATH ), "xpath", actualElement.getRetestId() );
+			writeWarnLogForChangedIdentifier( PATH, xpathExpression,
+					actualElement.getIdentifyingAttributes().get( PATH ), "xpath", actualElement );
 			return wrapped.findElement( By.xpath( actualElement.getIdentifyingAttributes().getPath() ) );
 		}
 	}
@@ -318,27 +317,29 @@ public class TestHealer {
 			logger.warn( "{} with tag '{}'.", ELEMENT_NOT_FOUND_MESSAGE, tag );
 			return null;
 		} else {
-			writeWarnLogForChangedIdentifier( "HTML tag attribute", tag,
-					actualElement.getIdentifyingAttributes().get( TYPE ), TYPE, actualElement.getRetestId() );
+			writeWarnLogForChangedIdentifier( TYPE, tag, actualElement.getIdentifyingAttributes().get( TYPE ), TYPE,
+					actualElement );
 			return wrapped.findElement( By.xpath( actualElement.getIdentifyingAttributes().getPath() ) );
 		}
 	}
 
 	private void writeWarnLogForChangedIdentifier( final String elementIdentifier, final Object oldValue,
-			final Object newValue, final String byMethodName, final String retestId ) {
+			final Object newValue, final String byMethodName, final Element actualElement ) {
 		logger.warn( "*************** recheck warning ***************" );
-		logger.warn( "The {} used for element identification changed from '{}' to '{}'.", elementIdentifier, oldValue,
-				newValue );
+		logger.warn( "The {} used for element identification changed from '{}' to '{}'.",
+				makeHumanReadable( elementIdentifier ), oldValue, newValue );
 		logger.warn( "retest identified the element based on the persisted Golden Master." );
 
 		String test = "";
-		String callLocation = "";
+		String callSiteFileName = "";
+		Integer callSiteLineNumber = -1;
 		try {
 			final StackTraceElement callSite = TestCaseFinder.getInstance() //
 					.findTestCaseMethodInStack() //
 					.getStackTraceElement();
 			test = callSite.getClassName();
-			callLocation = callSite.getFileName() + ":" + callSite.getLineNumber();
+			callSiteFileName = callSite.getFileName();
+			callSiteLineNumber = callSite.getLineNumber();
 		} catch ( final Exception e ) {
 			logger.warn( "Exception retrieving call site of findBy call." );
 		}
@@ -347,11 +348,22 @@ public class TestHealer {
 		logger.warn( "If you apply these changes to the Golden Master {}, your test {} will break.", "", test );
 
 		if ( newValue != null ) {
-			logger.warn( "Use `By.{}(\"{}\")` or `By.retestId(\"{}\")` to update your test {}.", byMethodName, newValue,
-					retestId, callLocation );
+			logger.warn( "Use `By.{}(\"{}\")` or `By.retestId(\"{}\")` to update your test {}:{}.", byMethodName,
+					newValue, actualElement.getRetestId(), callSiteFileName, callSiteLineNumber );
 		} else {
-			logger.warn( "Use `By.retestId(\"{}\")` to update your test {}.", retestId, callLocation );
+			logger.warn( "Use `By.retestId(\"{}\")` to update your test {}:{}.", actualElement.getRetestId(),
+					callSiteFileName, callSiteLineNumber );
 		}
+	}
+
+	private String makeHumanReadable( final String elementIdentifier ) {
+		if ( elementIdentifier.equals( TYPE ) ) {
+			return "HTML tag attribute";
+		}
+		if ( elementIdentifier.equals( TEXT ) ) {
+			return "link text";
+		}
+		return "HTML " + elementIdentifier + " attribute";
 	}
 
 }

--- a/src/main/java/de/retest/web/selenium/UnbreakableDriver.java
+++ b/src/main/java/de/retest/web/selenium/UnbreakableDriver.java
@@ -3,6 +3,7 @@ package de.retest.web.selenium;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.Capabilities;
@@ -50,6 +51,7 @@ public class UnbreakableDriver implements WebDriver, JavascriptExecutor, FindsBy
 	private final RemoteWebDriver wrappedDriver;
 	private RootElement lastExpectedState;
 	private RootElement lastActualState;
+	private Consumer<QualifiedElementWarning> warningConsumer;
 
 	/**
 	 * @param wrappedDriver

--- a/src/main/java/de/retest/web/selenium/WriteToResultWarningConsumer.java
+++ b/src/main/java/de/retest/web/selenium/WriteToResultWarningConsumer.java
@@ -1,0 +1,45 @@
+package de.retest.web.selenium;
+
+import java.util.Collection;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import de.retest.recheck.ui.diff.AttributeDifference;
+import de.retest.recheck.ui.diff.ElementDifference;
+import de.retest.recheck.ui.diff.ElementIdentificationWarning;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class WriteToResultWarningConsumer implements Consumer<QualifiedElementWarning> {
+
+	private final ElementDifferenceRetriever retriever;
+
+	@Override
+	public void accept( final QualifiedElementWarning warning ) {
+		retriever.getDifferences() //
+				.filter( matchesRetestId( warning.getRetestId() ) ) //
+				.map( ElementDifference::getAttributeDifferences ) //
+				.flatMap( Collection::stream ) //
+				.filter( matchesAttributeKey( warning.getAttributeKey() ) ) // Should only be one difference
+				.forEach( addWarning( warning.getWarning() ) );
+	}
+
+	private Predicate<ElementDifference> matchesRetestId( final String retestId ) {
+		return difference -> difference.getRetestId().equals( retestId );
+	}
+
+	private Predicate<AttributeDifference> matchesAttributeKey( final String attributeKey ) {
+		return difference -> difference.getKey().equals( attributeKey );
+	}
+
+	private Consumer<AttributeDifference> addWarning( final ElementIdentificationWarning warning ) {
+		return difference -> difference.addElementIdentificationWarning( warning );
+	}
+
+	@FunctionalInterface
+	public interface ElementDifferenceRetriever {
+
+		Stream<ElementDifference> getDifferences();
+	}
+}

--- a/src/test/java/de/retest/web/RecheckSeleniumAdapterIT.java
+++ b/src/test/java/de/retest/web/RecheckSeleniumAdapterIT.java
@@ -1,0 +1,115 @@
+package de.retest.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.assertj.core.data.Index;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.openqa.selenium.By;
+
+import de.retest.recheck.RecheckAdapter;
+import de.retest.recheck.report.ActionReplayResult;
+import de.retest.recheck.ui.diff.AttributeDifference;
+import de.retest.recheck.ui.diff.ElementDifference;
+import de.retest.web.selenium.UnbreakableDriver;
+import de.retest.web.testutils.WebDriverFactory;
+import de.retest.web.testutils.WebDriverFactory.Driver;
+
+class RecheckSeleniumAdapterIT {
+
+	UnbreakableDriver driver;
+	RecheckWebImpl re;
+
+	@BeforeEach
+	void setUp() {
+		driver = new UnbreakableDriver( WebDriverFactory.driver( Driver.CHROME ) );
+		re = new RecheckWebImpl();
+	}
+
+	@AfterEach
+	void tearDown() {
+		driver.quit();
+		re.cap();
+	}
+
+	@Test
+	void warnings_should_be_notified_properly_on_breaking_change() {
+		re.startTest();
+
+		driver.get( getClass().getResource( "AutoHealingTest.html" ).toExternalForm() );
+
+		final RecheckAdapter open = spyAdapter();
+		re.check( driver, open, "open" );
+
+		driver.findElement( By.id( "a" ) ).click();
+		verifyWarning( open, "a", "b", 53 );
+
+		final RecheckAdapter a = spyAdapter();
+		re.check( driver, a, "a" );
+
+		driver.findElement( By.id( "b" ) ).click();
+		verifyWarning( a, "b", "a", 59 );
+
+		final RecheckAdapter b = spyAdapter();
+		re.check( driver, b, "b" );
+		verifyNoWarning( b );
+
+		assertThatThrownBy( () -> re.capTest() ) //
+				.hasMessageContainingAll( "id: expected=\"a\", actual=\"b\"", "id: expected=\"b\", actual=\"a\"" );
+	}
+
+	public RecheckAdapter spyAdapter() {
+		return spy( new RecheckSeleniumAdapter() );
+	}
+
+	private void verifyNoWarning( final RecheckAdapter adapter ) {
+		final ArgumentCaptor<ActionReplayResult> captor = ArgumentCaptor.forClass( ActionReplayResult.class );
+		verify( adapter ).notifyAboutDifferences( captor.capture() );
+		final ActionReplayResult result = captor.getValue();
+
+		assertThat( getAllAttributeDifferences( result ) ).allSatisfy( difference -> { // There are still differences
+			assertThat( difference.getElementIdentificationWarnings() ).isEmpty();
+		} );
+	}
+
+	private void verifyWarning( final RecheckAdapter adapter, final String expected, final String actual,
+			final int line ) {
+		final ArgumentCaptor<ActionReplayResult> captor = ArgumentCaptor.forClass( ActionReplayResult.class );
+		verify( adapter ).notifyAboutDifferences( captor.capture() );
+		final ActionReplayResult result = captor.getValue();
+
+		assertThat( findAttributeDifferenceForId( result ) ).hasValueSatisfying( difference -> {
+			assertThat( difference.getElementIdentificationWarnings() ) //
+					.hasSize( 1 ) //
+					.satisfies( warning -> {
+						assertThat( warning.getTestFileName() ).isEqualTo( getClass().getSimpleName() + ".java" );
+						assertThat( warning.getQualifiedTestName() ).isEqualTo( getClass().getName() );
+						assertThat( warning.getTestLineNumber() ).isEqualTo( line );
+						assertThat( warning.getFindByMethodName() ).isEqualTo( "id" );
+					}, Index.atIndex( 0 ) );
+			assertThat( difference.getExpected() ).isEqualTo( expected );
+			assertThat( difference.getActual() ).isEqualTo( actual );
+		} );
+	}
+
+	private Optional<AttributeDifference> findAttributeDifferenceForId( final ActionReplayResult result ) {
+		return getAllAttributeDifferences( result ) //
+				.filter( difference -> difference.getKey().equals( "id" ) ) // Only look for the id, but not the value
+				.findFirst();
+	}
+
+	private Stream<AttributeDifference> getAllAttributeDifferences( final ActionReplayResult result ) {
+		return result.getAllElementDifferences().stream() //
+				.map( ElementDifference::getAttributeDifferences ) //
+				.flatMap( Collection::stream );
+	}
+}

--- a/src/test/java/de/retest/web/RecheckSeleniumAdapterTest.java
+++ b/src/test/java/de/retest/web/RecheckSeleniumAdapterTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -11,12 +13,15 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.awt.image.BufferedImage;
 import java.util.Collections;
+import java.util.function.Consumer;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chrome.ChromeDriver;
@@ -31,8 +36,13 @@ import org.openqa.selenium.remote.RemoteWebElement;
 import org.openqa.selenium.safari.SafariDriver;
 
 import de.retest.recheck.RecheckAdapter;
+import de.retest.recheck.report.ActionReplayResult;
+import de.retest.recheck.ui.descriptors.RootElement;
+import de.retest.recheck.ui.diff.ElementIdentificationWarning;
+import de.retest.web.screenshot.NoScreenshot;
 import de.retest.web.selenium.AutocheckingRecheckDriver;
 import de.retest.web.selenium.ImplicitDriverWrapper;
+import de.retest.web.selenium.QualifiedElementWarning;
 import de.retest.web.selenium.RecheckDriver;
 import de.retest.web.selenium.UnbreakableDriver;
 
@@ -233,6 +243,60 @@ class RecheckSeleniumAdapterTest {
 		when( wrapper.getWrappedDriver() ).thenReturn( unbreakableDriver );
 
 		assertThat( cut.convert( wrapper ) ).isNotNull();
+	}
+
+	@Test
+	void convert_and_notify_should_allow_for_warnings_to_be_issued() throws Exception {
+		final ElementIdentificationWarning warning = new ElementIdentificationWarning( "test.java", 0, "id", "Test" );
+		final QualifiedElementWarning qualifiedElementWarning = new QualifiedElementWarning( "id", "id", warning );
+
+		final UnbreakableDriver unbreakableDriver = mock( UnbreakableDriver.class );
+		when( unbreakableDriver.executeScript( any(), any() ) ).thenReturn( Collections.emptyMap() );
+
+		final RecheckSeleniumAdapter cut = spy( new RecheckSeleniumAdapter( RecheckWebOptions.builder() //
+				.screenshotProvider( new NoScreenshot() ) //
+				.build() ) );
+		doReturn( mock( RootElement.class ) ).when( cut ).convert( anyMap(), nullable( String.class ),
+				nullable( String.class ), nullable( BufferedImage.class ) );
+
+		cut.convert( unbreakableDriver );
+
+		final ArgumentCaptor<Consumer<QualifiedElementWarning>> captor = ArgumentCaptor.forClass( Consumer.class );
+		verify( unbreakableDriver ).setWarningConsumer( captor.capture() );
+
+		cut.notifyAboutDifferences( mock( ActionReplayResult.class ) );
+
+		final Consumer<QualifiedElementWarning> warningConsumer = captor.getValue();
+
+		assertThatCode( () -> {
+			warningConsumer.accept( qualifiedElementWarning );
+		} ).doesNotThrowAnyException();
+	}
+
+	@Test
+	void convert_without_notify_should_not_throw_exception() throws Exception {
+		final ElementIdentificationWarning warning = new ElementIdentificationWarning( "test.java", 0, "id", "Test" );
+		final QualifiedElementWarning qualifiedElementWarning = new QualifiedElementWarning( "id", "id", warning );
+
+		final UnbreakableDriver unbreakableDriver = mock( UnbreakableDriver.class );
+		when( unbreakableDriver.executeScript( any(), any() ) ).thenReturn( Collections.emptyMap() );
+
+		final RecheckSeleniumAdapter cut = spy( new RecheckSeleniumAdapter( RecheckWebOptions.builder() //
+				.screenshotProvider( new NoScreenshot() ) //
+				.build() ) );
+		doReturn( mock( RootElement.class ) ).when( cut ).convert( anyMap(), nullable( String.class ),
+				nullable( String.class ), nullable( BufferedImage.class ) );
+
+		cut.convert( unbreakableDriver );
+
+		final ArgumentCaptor<Consumer<QualifiedElementWarning>> captor = ArgumentCaptor.forClass( Consumer.class );
+		verify( unbreakableDriver ).setWarningConsumer( captor.capture() );
+
+		final Consumer<QualifiedElementWarning> warningConsumer = captor.getValue();
+
+		assertThatCode( () -> {
+			warningConsumer.accept( qualifiedElementWarning );
+		} ).doesNotThrowAnyException();
 	}
 
 	private WrappingRemoteWebElement createOuterWrappingElement( final WrappingRemoteWebElement inner ) {

--- a/src/test/java/de/retest/web/selenium/WriteToResultWarningConsumerTest.java
+++ b/src/test/java/de/retest/web/selenium/WriteToResultWarningConsumerTest.java
@@ -1,0 +1,84 @@
+package de.retest.web.selenium;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import de.retest.recheck.ui.diff.AttributeDifference;
+import de.retest.recheck.ui.diff.ElementDifference;
+import de.retest.recheck.ui.diff.ElementIdentificationWarning;
+import de.retest.web.selenium.WriteToResultWarningConsumer.ElementDifferenceRetriever;
+
+class WriteToResultWarningConsumerTest {
+
+	ElementDifferenceRetriever retriever;
+	WriteToResultWarningConsumer cut;
+
+	ElementIdentificationWarning warning;
+	QualifiedElementWarning qualifiedWarning;
+
+	@BeforeEach
+	void setUp() {
+		retriever = mock( ElementDifferenceRetriever.class );
+
+		cut = new WriteToResultWarningConsumer( retriever );
+
+		warning = new ElementIdentificationWarning( "file.java", 0, "id", "File" );
+		qualifiedWarning = new QualifiedElementWarning( "id", "id", warning );
+	}
+
+	@Test
+	void accept_should_find_warning_and_add_to_result() throws Exception {
+		final AttributeDifference attribute = mock( AttributeDifference.class );
+		when( attribute.getKey() ).thenReturn( "id" );
+
+		final ElementDifference difference = mock( ElementDifference.class );
+		when( difference.getRetestId() ).thenReturn( "id" );
+		when( difference.getAttributeDifferences() ).thenReturn( Collections.singletonList( attribute ) );
+
+		when( retriever.getDifferences() ).thenReturn( Stream.of( difference ) );
+
+		cut.accept( qualifiedWarning );
+
+		verify( attribute ).addElementIdentificationWarning( warning );
+	}
+
+	@Test
+	void accept_should_not_add_if_attribute_does_not_match() throws Exception {
+		final AttributeDifference attribute = mock( AttributeDifference.class );
+		when( attribute.getKey() ).thenReturn( "foo" );
+
+		final ElementDifference difference = mock( ElementDifference.class );
+		when( difference.getRetestId() ).thenReturn( "id" );
+		when( difference.getAttributeDifferences() ).thenReturn( Collections.singletonList( attribute ) );
+
+		when( retriever.getDifferences() ).thenReturn( Stream.of( difference ) );
+
+		cut.accept( qualifiedWarning );
+
+		verify( attribute, never() ).addElementIdentificationWarning( warning );
+	}
+
+	@Test
+	void accept_should_not_add_if_retest_id_does_not_match() throws Exception {
+		final AttributeDifference attribute = mock( AttributeDifference.class );
+		when( attribute.getKey() ).thenReturn( "id" );
+
+		final ElementDifference difference = mock( ElementDifference.class );
+		when( difference.getRetestId() ).thenReturn( "foo" );
+		when( difference.getAttributeDifferences() ).thenReturn( Collections.singletonList( attribute ) );
+
+		when( retriever.getDifferences() ).thenReturn( Stream.of( difference ) );
+
+		cut.accept( qualifiedWarning );
+
+		verify( attribute, never() ).addElementIdentificationWarning( warning );
+	}
+}

--- a/src/test/resources/de/retest/web/AutoHealingTest.html
+++ b/src/test/resources/de/retest/web/AutoHealingTest.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>AutoHealingTest</title>
+</head>
+
+<body>
+  <button id="b">Click to change!</button>
+  <input type="text" id="id" readonly>
+</body>
+
+<script>
+  const changing = {
+    a: "b",
+    b: "a"
+  }
+
+  window.onload = () => {
+    const button = document.getElementById("b")
+    const input = document.getElementById("id")
+
+    button.onclick = ()=>{
+      change(button)
+      update(input, button.id)
+    }
+
+    update(input, button.id)
+  }
+
+  function change(button) {
+    button.id = changing[button.id]
+  }
+
+  function update(input, value) {
+    input.value = value
+  }
+</script>
+
+</html>

--- a/src/test/resources/retest/recheck/de.retest.web.RecheckSeleniumAdapterIT/warnings_should_be_notified_properly_on_breaking_change.a.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.RecheckSeleniumAdapterIT/warnings_should_be_notified_properly_on_breaking_change.a.recheck/retest.xml
@@ -1,0 +1,540 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<reTestXmlDataContainer xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" reTestVersion="1.8.0" dataType="de.retest.recheck.ui.descriptors.SutState" dataTypeVersion="4">
+	<data xsi:type="sutState">
+		<descriptors retestId="html" screenId="1" screen="AutoHealingTest" title="AutoHealingTest">
+			<identifyingAttributes>
+				<attributes>
+					<attribute key="absolute-outline" xsi:type="outlineAttribute">
+						<x>0</x>
+						<y>0</y>
+						<height>37</height>
+						<width>1200</width>
+					</attribute>
+					<attribute key="outline" xsi:type="outlineAttribute">
+						<x>0</x>
+						<y>0</y>
+						<height>37</height>
+						<width>1200</width>
+					</attribute>
+					<attribute key="path" xsi:type="pathAttribute">html[1]</attribute>
+					<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
+					<attribute key="type" xsi:type="stringAttribute">html</attribute>
+				</attributes>
+			</identifyingAttributes>
+			<attributes>
+				<attributes>
+					<entry>
+						<key>lang</key>
+						<value xsi:type="xsd:string">en</value>
+					</entry>
+					<entry>
+						<key>shown</key>
+						<value xsi:type="xsd:string">true</value>
+					</entry>
+				</attributes>
+			</attributes>
+			<containedElements retestId="head">
+				<identifyingAttributes>
+					<attributes>
+						<attribute key="absolute-outline" xsi:type="outlineAttribute">
+							<x>0</x>
+							<y>0</y>
+							<height>0</height>
+							<width>0</width>
+						</attribute>
+						<attribute key="outline" xsi:type="outlineAttribute">
+							<x>0</x>
+							<y>0</y>
+							<height>-37</height>
+							<width>-1200</width>
+						</attribute>
+						<attribute key="path" xsi:type="pathAttribute">html[1]/head[1]</attribute>
+						<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
+						<attribute key="type" xsi:type="stringAttribute">head</attribute>
+					</attributes>
+				</identifyingAttributes>
+				<attributes>
+					<attributes>
+						<entry>
+							<key>shown</key>
+							<value xsi:type="xsd:string">false</value>
+						</entry>
+					</attributes>
+				</attributes>
+				<containedElements retestId="autohealingtest">
+					<identifyingAttributes>
+						<attributes>
+							<attribute key="absolute-outline" xsi:type="outlineAttribute">
+								<x>0</x>
+								<y>0</y>
+								<height>0</height>
+								<width>0</width>
+							</attribute>
+							<attribute key="outline" xsi:type="outlineAttribute">
+								<x>0</x>
+								<y>0</y>
+								<height>0</height>
+								<width>0</width>
+							</attribute>
+							<attribute key="path" xsi:type="pathAttribute">html[1]/head[1]/title[1]</attribute>
+							<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
+							<attribute key="text" xsi:type="textAttribute">AutoHealingTest</attribute>
+							<attribute key="type" xsi:type="stringAttribute">title</attribute>
+						</attributes>
+					</identifyingAttributes>
+					<attributes>
+						<attributes>
+							<entry>
+								<key>shown</key>
+								<value xsi:type="xsd:string">false</value>
+							</entry>
+						</attributes>
+					</attributes>
+				</containedElements>
+				<containedElements retestId="meta">
+					<identifyingAttributes>
+						<attributes>
+							<attribute key="absolute-outline" xsi:type="outlineAttribute">
+								<x>0</x>
+								<y>0</y>
+								<height>0</height>
+								<width>0</width>
+							</attribute>
+							<attribute key="outline" xsi:type="outlineAttribute">
+								<x>0</x>
+								<y>0</y>
+								<height>0</height>
+								<width>0</width>
+							</attribute>
+							<attribute key="path" xsi:type="pathAttribute">html[1]/head[1]/meta[1]</attribute>
+							<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
+							<attribute key="type" xsi:type="stringAttribute">meta</attribute>
+						</attributes>
+					</identifyingAttributes>
+					<attributes>
+						<attributes>
+							<entry>
+								<key>charset</key>
+								<value xsi:type="xsd:string">UTF-8</value>
+							</entry>
+							<entry>
+								<key>shown</key>
+								<value xsi:type="xsd:string">false</value>
+							</entry>
+						</attributes>
+					</attributes>
+				</containedElements>
+				<containedElements retestId="meta-1">
+					<identifyingAttributes>
+						<attributes>
+							<attribute key="absolute-outline" xsi:type="outlineAttribute">
+								<x>0</x>
+								<y>0</y>
+								<height>0</height>
+								<width>0</width>
+							</attribute>
+							<attribute key="name" xsi:type="stringAttribute">viewport</attribute>
+							<attribute key="outline" xsi:type="outlineAttribute">
+								<x>0</x>
+								<y>0</y>
+								<height>0</height>
+								<width>0</width>
+							</attribute>
+							<attribute key="path" xsi:type="pathAttribute">html[1]/head[1]/meta[2]</attribute>
+							<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
+							<attribute key="type" xsi:type="stringAttribute">meta</attribute>
+						</attributes>
+					</identifyingAttributes>
+					<attributes>
+						<attributes>
+							<entry>
+								<key>content</key>
+								<value xsi:type="xsd:string">width=device-width, initial-scale=1.0</value>
+							</entry>
+							<entry>
+								<key>shown</key>
+								<value xsi:type="xsd:string">false</value>
+							</entry>
+						</attributes>
+					</attributes>
+				</containedElements>
+				<containedElements retestId="meta-2">
+					<identifyingAttributes>
+						<attributes>
+							<attribute key="absolute-outline" xsi:type="outlineAttribute">
+								<x>0</x>
+								<y>0</y>
+								<height>0</height>
+								<width>0</width>
+							</attribute>
+							<attribute key="outline" xsi:type="outlineAttribute">
+								<x>0</x>
+								<y>0</y>
+								<height>0</height>
+								<width>0</width>
+							</attribute>
+							<attribute key="path" xsi:type="pathAttribute">html[1]/head[1]/meta[3]</attribute>
+							<attribute key="suffix" xsi:type="suffixAttribute">3</attribute>
+							<attribute key="type" xsi:type="stringAttribute">meta</attribute>
+						</attributes>
+					</identifyingAttributes>
+					<attributes>
+						<attributes>
+							<entry>
+								<key>content</key>
+								<value xsi:type="xsd:string">ie=edge</value>
+							</entry>
+							<entry>
+								<key>http-equiv</key>
+								<value xsi:type="xsd:string">X-UA-Compatible</value>
+							</entry>
+							<entry>
+								<key>shown</key>
+								<value xsi:type="xsd:string">false</value>
+							</entry>
+						</attributes>
+					</attributes>
+				</containedElements>
+			</containedElements>
+			<containedElements retestId="body">
+				<identifyingAttributes>
+					<attributes>
+						<attribute key="absolute-outline" xsi:type="outlineAttribute">
+							<x>8</x>
+							<y>8</y>
+							<height>21</height>
+							<width>1184</width>
+						</attribute>
+						<attribute key="outline" xsi:type="outlineAttribute">
+							<x>8</x>
+							<y>8</y>
+							<height>-16</height>
+							<width>-16</width>
+						</attribute>
+						<attribute key="path" xsi:type="pathAttribute">html[1]/body[1]</attribute>
+						<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
+						<attribute key="type" xsi:type="stringAttribute">body</attribute>
+					</attributes>
+				</identifyingAttributes>
+				<attributes>
+					<attributes>
+						<entry>
+							<key>shown</key>
+							<value xsi:type="xsd:string">true</value>
+						</entry>
+					</attributes>
+				</attributes>
+				<containedElements retestId="id">
+					<identifyingAttributes>
+						<attributes>
+							<attribute key="absolute-outline" xsi:type="outlineAttribute">
+								<x>123</x>
+								<y>8</y>
+								<height>21</height>
+								<width>173</width>
+							</attribute>
+							<attribute key="id" xsi:type="stringAttribute">id</attribute>
+							<attribute key="outline" xsi:type="outlineAttribute">
+								<x>115</x>
+								<y>0</y>
+								<height>0</height>
+								<width>-1011</width>
+							</attribute>
+							<attribute key="path" xsi:type="pathAttribute">html[1]/body[1]/input[1]</attribute>
+							<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
+							<attribute key="type" xsi:type="stringAttribute">input</attribute>
+						</attributes>
+					</identifyingAttributes>
+					<attributes>
+						<attributes>
+							<entry>
+								<key>background-color</key>
+								<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
+							</entry>
+							<entry>
+								<key>border-bottom-style</key>
+								<value xsi:type="xsd:string">inset</value>
+							</entry>
+							<entry>
+								<key>border-bottom-width</key>
+								<value xsi:type="xsd:string">2px</value>
+							</entry>
+							<entry>
+								<key>border-left-style</key>
+								<value xsi:type="xsd:string">inset</value>
+							</entry>
+							<entry>
+								<key>border-left-width</key>
+								<value xsi:type="xsd:string">2px</value>
+							</entry>
+							<entry>
+								<key>border-right-style</key>
+								<value xsi:type="xsd:string">inset</value>
+							</entry>
+							<entry>
+								<key>border-right-width</key>
+								<value xsi:type="xsd:string">2px</value>
+							</entry>
+							<entry>
+								<key>border-top-style</key>
+								<value xsi:type="xsd:string">inset</value>
+							</entry>
+							<entry>
+								<key>border-top-width</key>
+								<value xsi:type="xsd:string">2px</value>
+							</entry>
+							<entry>
+								<key>font-family</key>
+								<value xsi:type="xsd:string">Arial</value>
+							</entry>
+							<entry>
+								<key>font-size</key>
+								<value xsi:type="xsd:string">13.3333px</value>
+							</entry>
+							<entry>
+								<key>margin-bottom</key>
+								<value xsi:type="xsd:string">0px</value>
+							</entry>
+							<entry>
+								<key>margin-top</key>
+								<value xsi:type="xsd:string">0px</value>
+							</entry>
+							<entry>
+								<key>padding-bottom</key>
+								<value xsi:type="xsd:string">1px</value>
+							</entry>
+							<entry>
+								<key>padding-top</key>
+								<value xsi:type="xsd:string">1px</value>
+							</entry>
+							<entry>
+								<key>read-only</key>
+								<value xsi:type="xsd:string">true</value>
+							</entry>
+							<entry>
+								<key>shown</key>
+								<value xsi:type="xsd:string">true</value>
+							</entry>
+							<entry>
+								<key>type</key>
+								<value xsi:type="xsd:string">text</value>
+							</entry>
+							<entry>
+								<key>value</key>
+								<value xsi:type="xsd:string">b</value>
+							</entry>
+						</attributes>
+					</attributes>
+				</containedElements>
+				<containedElements retestId="b">
+					<identifyingAttributes>
+						<attributes>
+							<attribute key="absolute-outline" xsi:type="outlineAttribute">
+								<x>8</x>
+								<y>8</y>
+								<height>21</height>
+								<width>111</width>
+							</attribute>
+							<attribute key="id" xsi:type="stringAttribute">b</attribute>
+							<attribute key="outline" xsi:type="outlineAttribute">
+								<x>0</x>
+								<y>0</y>
+								<height>0</height>
+								<width>-1073</width>
+							</attribute>
+							<attribute key="path" xsi:type="pathAttribute">html[1]/body[1]/button[1]</attribute>
+							<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
+							<attribute key="text" xsi:type="textAttribute">Click to change!</attribute>
+							<attribute key="type" xsi:type="stringAttribute">button</attribute>
+						</attributes>
+					</identifyingAttributes>
+					<attributes>
+						<attributes>
+							<entry>
+								<key>align-items</key>
+								<value xsi:type="xsd:string">flex-start</value>
+							</entry>
+							<entry>
+								<key>background-color</key>
+								<value xsi:type="xsd:string">rgb(221, 221, 221)</value>
+							</entry>
+							<entry>
+								<key>border-bottom-color</key>
+								<value xsi:type="xsd:string">rgb(221, 221, 221)</value>
+							</entry>
+							<entry>
+								<key>border-bottom-style</key>
+								<value xsi:type="xsd:string">outset</value>
+							</entry>
+							<entry>
+								<key>border-bottom-width</key>
+								<value xsi:type="xsd:string">2px</value>
+							</entry>
+							<entry>
+								<key>border-left-color</key>
+								<value xsi:type="xsd:string">rgb(221, 221, 221)</value>
+							</entry>
+							<entry>
+								<key>border-left-style</key>
+								<value xsi:type="xsd:string">outset</value>
+							</entry>
+							<entry>
+								<key>border-left-width</key>
+								<value xsi:type="xsd:string">2px</value>
+							</entry>
+							<entry>
+								<key>border-right-color</key>
+								<value xsi:type="xsd:string">rgb(221, 221, 221)</value>
+							</entry>
+							<entry>
+								<key>border-right-style</key>
+								<value xsi:type="xsd:string">outset</value>
+							</entry>
+							<entry>
+								<key>border-right-width</key>
+								<value xsi:type="xsd:string">2px</value>
+							</entry>
+							<entry>
+								<key>border-top-color</key>
+								<value xsi:type="xsd:string">rgb(221, 221, 221)</value>
+							</entry>
+							<entry>
+								<key>border-top-style</key>
+								<value xsi:type="xsd:string">outset</value>
+							</entry>
+							<entry>
+								<key>border-top-width</key>
+								<value xsi:type="xsd:string">2px</value>
+							</entry>
+							<entry>
+								<key>box-sizing</key>
+								<value xsi:type="xsd:string">border-box</value>
+							</entry>
+							<entry>
+								<key>display</key>
+								<value xsi:type="xsd:string">inline-block</value>
+							</entry>
+							<entry>
+								<key>font-family</key>
+								<value xsi:type="xsd:string">Arial</value>
+							</entry>
+							<entry>
+								<key>font-size</key>
+								<value xsi:type="xsd:string">13.3333px</value>
+							</entry>
+							<entry>
+								<key>outline-color</key>
+								<value xsi:type="xsd:string">rgb(229, 151, 0)</value>
+							</entry>
+							<entry>
+								<key>outline-width</key>
+								<value xsi:type="xsd:string">1px</value>
+							</entry>
+							<entry>
+								<key>padding-bottom</key>
+								<value xsi:type="xsd:string">1px</value>
+							</entry>
+							<entry>
+								<key>padding-left</key>
+								<value xsi:type="xsd:string">6px</value>
+							</entry>
+							<entry>
+								<key>padding-right</key>
+								<value xsi:type="xsd:string">6px</value>
+							</entry>
+							<entry>
+								<key>padding-top</key>
+								<value xsi:type="xsd:string">1px</value>
+							</entry>
+							<entry>
+								<key>read-only</key>
+							</entry>
+							<entry>
+								<key>shown</key>
+								<value xsi:type="xsd:string">true</value>
+							</entry>
+							<entry>
+								<key>text-align</key>
+								<value xsi:type="xsd:string">center</value>
+							</entry>
+						</attributes>
+					</attributes>
+				</containedElements>
+			</containedElements>
+		</descriptors>
+		<metadata>
+			<entry>
+				<key>driver.type</key>
+				<value>UnbreakableDriver</value>
+			</entry>
+			<entry>
+				<key>time.offset</key>
+				<value>+01:00</value>
+			</entry>
+			<entry>
+				<key>os.arch</key>
+				<value>amd64</value>
+			</entry>
+			<entry>
+				<key>check.type</key>
+				<value>driver</value>
+			</entry>
+			<entry>
+				<key>vcs.commit</key>
+				<value>133270c5c2878a8275304a840baec0004fb0a2fb</value>
+			</entry>
+			<entry>
+				<key>window.height</key>
+				<value>800</value>
+			</entry>
+			<entry>
+				<key>vcs.branch</key>
+				<value>feature/RET-1917-implement-warning-creation</value>
+			</entry>
+			<entry>
+				<key>url</key>
+				<value>file:///C:/Users/diehl/Documents/Work/Repo/Company/open/recheck-web/target/test-classes/de/retest/web/AutoHealingTest.html</value>
+			</entry>
+			<entry>
+				<key>machine.name</key>
+				<value>PC-BASTIAN</value>
+			</entry>
+			<entry>
+				<key>os.version</key>
+				<value>10.0</value>
+			</entry>
+			<entry>
+				<key>browser.name</key>
+				<value>chrome</value>
+			</entry>
+			<entry>
+				<key>browser.version</key>
+				<value>79.0.3945.117</value>
+			</entry>
+			<entry>
+				<key>time.time</key>
+				<value>15:39:21.118</value>
+			</entry>
+			<entry>
+				<key>time.zone</key>
+				<value>Europe/Berlin</value>
+			</entry>
+			<entry>
+				<key>window.width</key>
+				<value>1200</value>
+			</entry>
+			<entry>
+				<key>os.name</key>
+				<value>XP</value>
+			</entry>
+			<entry>
+				<key>time.date</key>
+				<value>2020-01-08</value>
+			</entry>
+			<entry>
+				<key>vcs.name</key>
+				<value>git</value>
+			</entry>
+		</metadata>
+	</data>
+</reTestXmlDataContainer>

--- a/src/test/resources/retest/recheck/de.retest.web.RecheckSeleniumAdapterIT/warnings_should_be_notified_properly_on_breaking_change.b.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.RecheckSeleniumAdapterIT/warnings_should_be_notified_properly_on_breaking_change.b.recheck/retest.xml
@@ -1,0 +1,540 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<reTestXmlDataContainer xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" reTestVersion="1.8.0" dataType="de.retest.recheck.ui.descriptors.SutState" dataTypeVersion="4">
+	<data xsi:type="sutState">
+		<descriptors retestId="html" screenId="1" screen="AutoHealingTest" title="AutoHealingTest">
+			<identifyingAttributes>
+				<attributes>
+					<attribute key="absolute-outline" xsi:type="outlineAttribute">
+						<x>0</x>
+						<y>0</y>
+						<height>37</height>
+						<width>1200</width>
+					</attribute>
+					<attribute key="outline" xsi:type="outlineAttribute">
+						<x>0</x>
+						<y>0</y>
+						<height>37</height>
+						<width>1200</width>
+					</attribute>
+					<attribute key="path" xsi:type="pathAttribute">html[1]</attribute>
+					<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
+					<attribute key="type" xsi:type="stringAttribute">html</attribute>
+				</attributes>
+			</identifyingAttributes>
+			<attributes>
+				<attributes>
+					<entry>
+						<key>lang</key>
+						<value xsi:type="xsd:string">en</value>
+					</entry>
+					<entry>
+						<key>shown</key>
+						<value xsi:type="xsd:string">true</value>
+					</entry>
+				</attributes>
+			</attributes>
+			<containedElements retestId="head">
+				<identifyingAttributes>
+					<attributes>
+						<attribute key="absolute-outline" xsi:type="outlineAttribute">
+							<x>0</x>
+							<y>0</y>
+							<height>0</height>
+							<width>0</width>
+						</attribute>
+						<attribute key="outline" xsi:type="outlineAttribute">
+							<x>0</x>
+							<y>0</y>
+							<height>-37</height>
+							<width>-1200</width>
+						</attribute>
+						<attribute key="path" xsi:type="pathAttribute">html[1]/head[1]</attribute>
+						<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
+						<attribute key="type" xsi:type="stringAttribute">head</attribute>
+					</attributes>
+				</identifyingAttributes>
+				<attributes>
+					<attributes>
+						<entry>
+							<key>shown</key>
+							<value xsi:type="xsd:string">false</value>
+						</entry>
+					</attributes>
+				</attributes>
+				<containedElements retestId="autohealingtest">
+					<identifyingAttributes>
+						<attributes>
+							<attribute key="absolute-outline" xsi:type="outlineAttribute">
+								<x>0</x>
+								<y>0</y>
+								<height>0</height>
+								<width>0</width>
+							</attribute>
+							<attribute key="outline" xsi:type="outlineAttribute">
+								<x>0</x>
+								<y>0</y>
+								<height>0</height>
+								<width>0</width>
+							</attribute>
+							<attribute key="path" xsi:type="pathAttribute">html[1]/head[1]/title[1]</attribute>
+							<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
+							<attribute key="text" xsi:type="textAttribute">AutoHealingTest</attribute>
+							<attribute key="type" xsi:type="stringAttribute">title</attribute>
+						</attributes>
+					</identifyingAttributes>
+					<attributes>
+						<attributes>
+							<entry>
+								<key>shown</key>
+								<value xsi:type="xsd:string">false</value>
+							</entry>
+						</attributes>
+					</attributes>
+				</containedElements>
+				<containedElements retestId="meta">
+					<identifyingAttributes>
+						<attributes>
+							<attribute key="absolute-outline" xsi:type="outlineAttribute">
+								<x>0</x>
+								<y>0</y>
+								<height>0</height>
+								<width>0</width>
+							</attribute>
+							<attribute key="outline" xsi:type="outlineAttribute">
+								<x>0</x>
+								<y>0</y>
+								<height>0</height>
+								<width>0</width>
+							</attribute>
+							<attribute key="path" xsi:type="pathAttribute">html[1]/head[1]/meta[1]</attribute>
+							<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
+							<attribute key="type" xsi:type="stringAttribute">meta</attribute>
+						</attributes>
+					</identifyingAttributes>
+					<attributes>
+						<attributes>
+							<entry>
+								<key>charset</key>
+								<value xsi:type="xsd:string">UTF-8</value>
+							</entry>
+							<entry>
+								<key>shown</key>
+								<value xsi:type="xsd:string">false</value>
+							</entry>
+						</attributes>
+					</attributes>
+				</containedElements>
+				<containedElements retestId="meta-1">
+					<identifyingAttributes>
+						<attributes>
+							<attribute key="absolute-outline" xsi:type="outlineAttribute">
+								<x>0</x>
+								<y>0</y>
+								<height>0</height>
+								<width>0</width>
+							</attribute>
+							<attribute key="name" xsi:type="stringAttribute">viewport</attribute>
+							<attribute key="outline" xsi:type="outlineAttribute">
+								<x>0</x>
+								<y>0</y>
+								<height>0</height>
+								<width>0</width>
+							</attribute>
+							<attribute key="path" xsi:type="pathAttribute">html[1]/head[1]/meta[2]</attribute>
+							<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
+							<attribute key="type" xsi:type="stringAttribute">meta</attribute>
+						</attributes>
+					</identifyingAttributes>
+					<attributes>
+						<attributes>
+							<entry>
+								<key>content</key>
+								<value xsi:type="xsd:string">width=device-width, initial-scale=1.0</value>
+							</entry>
+							<entry>
+								<key>shown</key>
+								<value xsi:type="xsd:string">false</value>
+							</entry>
+						</attributes>
+					</attributes>
+				</containedElements>
+				<containedElements retestId="meta-2">
+					<identifyingAttributes>
+						<attributes>
+							<attribute key="absolute-outline" xsi:type="outlineAttribute">
+								<x>0</x>
+								<y>0</y>
+								<height>0</height>
+								<width>0</width>
+							</attribute>
+							<attribute key="outline" xsi:type="outlineAttribute">
+								<x>0</x>
+								<y>0</y>
+								<height>0</height>
+								<width>0</width>
+							</attribute>
+							<attribute key="path" xsi:type="pathAttribute">html[1]/head[1]/meta[3]</attribute>
+							<attribute key="suffix" xsi:type="suffixAttribute">3</attribute>
+							<attribute key="type" xsi:type="stringAttribute">meta</attribute>
+						</attributes>
+					</identifyingAttributes>
+					<attributes>
+						<attributes>
+							<entry>
+								<key>content</key>
+								<value xsi:type="xsd:string">ie=edge</value>
+							</entry>
+							<entry>
+								<key>http-equiv</key>
+								<value xsi:type="xsd:string">X-UA-Compatible</value>
+							</entry>
+							<entry>
+								<key>shown</key>
+								<value xsi:type="xsd:string">false</value>
+							</entry>
+						</attributes>
+					</attributes>
+				</containedElements>
+			</containedElements>
+			<containedElements retestId="body">
+				<identifyingAttributes>
+					<attributes>
+						<attribute key="absolute-outline" xsi:type="outlineAttribute">
+							<x>8</x>
+							<y>8</y>
+							<height>21</height>
+							<width>1184</width>
+						</attribute>
+						<attribute key="outline" xsi:type="outlineAttribute">
+							<x>8</x>
+							<y>8</y>
+							<height>-16</height>
+							<width>-16</width>
+						</attribute>
+						<attribute key="path" xsi:type="pathAttribute">html[1]/body[1]</attribute>
+						<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
+						<attribute key="type" xsi:type="stringAttribute">body</attribute>
+					</attributes>
+				</identifyingAttributes>
+				<attributes>
+					<attributes>
+						<entry>
+							<key>shown</key>
+							<value xsi:type="xsd:string">true</value>
+						</entry>
+					</attributes>
+				</attributes>
+				<containedElements retestId="id">
+					<identifyingAttributes>
+						<attributes>
+							<attribute key="absolute-outline" xsi:type="outlineAttribute">
+								<x>123</x>
+								<y>8</y>
+								<height>21</height>
+								<width>173</width>
+							</attribute>
+							<attribute key="id" xsi:type="stringAttribute">id</attribute>
+							<attribute key="outline" xsi:type="outlineAttribute">
+								<x>115</x>
+								<y>0</y>
+								<height>0</height>
+								<width>-1011</width>
+							</attribute>
+							<attribute key="path" xsi:type="pathAttribute">html[1]/body[1]/input[1]</attribute>
+							<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
+							<attribute key="type" xsi:type="stringAttribute">input</attribute>
+						</attributes>
+					</identifyingAttributes>
+					<attributes>
+						<attributes>
+							<entry>
+								<key>background-color</key>
+								<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
+							</entry>
+							<entry>
+								<key>border-bottom-style</key>
+								<value xsi:type="xsd:string">inset</value>
+							</entry>
+							<entry>
+								<key>border-bottom-width</key>
+								<value xsi:type="xsd:string">2px</value>
+							</entry>
+							<entry>
+								<key>border-left-style</key>
+								<value xsi:type="xsd:string">inset</value>
+							</entry>
+							<entry>
+								<key>border-left-width</key>
+								<value xsi:type="xsd:string">2px</value>
+							</entry>
+							<entry>
+								<key>border-right-style</key>
+								<value xsi:type="xsd:string">inset</value>
+							</entry>
+							<entry>
+								<key>border-right-width</key>
+								<value xsi:type="xsd:string">2px</value>
+							</entry>
+							<entry>
+								<key>border-top-style</key>
+								<value xsi:type="xsd:string">inset</value>
+							</entry>
+							<entry>
+								<key>border-top-width</key>
+								<value xsi:type="xsd:string">2px</value>
+							</entry>
+							<entry>
+								<key>font-family</key>
+								<value xsi:type="xsd:string">Arial</value>
+							</entry>
+							<entry>
+								<key>font-size</key>
+								<value xsi:type="xsd:string">13.3333px</value>
+							</entry>
+							<entry>
+								<key>margin-bottom</key>
+								<value xsi:type="xsd:string">0px</value>
+							</entry>
+							<entry>
+								<key>margin-top</key>
+								<value xsi:type="xsd:string">0px</value>
+							</entry>
+							<entry>
+								<key>padding-bottom</key>
+								<value xsi:type="xsd:string">1px</value>
+							</entry>
+							<entry>
+								<key>padding-top</key>
+								<value xsi:type="xsd:string">1px</value>
+							</entry>
+							<entry>
+								<key>read-only</key>
+								<value xsi:type="xsd:string">true</value>
+							</entry>
+							<entry>
+								<key>shown</key>
+								<value xsi:type="xsd:string">true</value>
+							</entry>
+							<entry>
+								<key>type</key>
+								<value xsi:type="xsd:string">text</value>
+							</entry>
+							<entry>
+								<key>value</key>
+								<value xsi:type="xsd:string">a</value>
+							</entry>
+						</attributes>
+					</attributes>
+				</containedElements>
+				<containedElements retestId="a">
+					<identifyingAttributes>
+						<attributes>
+							<attribute key="absolute-outline" xsi:type="outlineAttribute">
+								<x>8</x>
+								<y>8</y>
+								<height>21</height>
+								<width>111</width>
+							</attribute>
+							<attribute key="id" xsi:type="stringAttribute">a</attribute>
+							<attribute key="outline" xsi:type="outlineAttribute">
+								<x>0</x>
+								<y>0</y>
+								<height>0</height>
+								<width>-1073</width>
+							</attribute>
+							<attribute key="path" xsi:type="pathAttribute">html[1]/body[1]/button[1]</attribute>
+							<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
+							<attribute key="text" xsi:type="textAttribute">Click to change!</attribute>
+							<attribute key="type" xsi:type="stringAttribute">button</attribute>
+						</attributes>
+					</identifyingAttributes>
+					<attributes>
+						<attributes>
+							<entry>
+								<key>align-items</key>
+								<value xsi:type="xsd:string">flex-start</value>
+							</entry>
+							<entry>
+								<key>background-color</key>
+								<value xsi:type="xsd:string">rgb(221, 221, 221)</value>
+							</entry>
+							<entry>
+								<key>border-bottom-color</key>
+								<value xsi:type="xsd:string">rgb(221, 221, 221)</value>
+							</entry>
+							<entry>
+								<key>border-bottom-style</key>
+								<value xsi:type="xsd:string">outset</value>
+							</entry>
+							<entry>
+								<key>border-bottom-width</key>
+								<value xsi:type="xsd:string">2px</value>
+							</entry>
+							<entry>
+								<key>border-left-color</key>
+								<value xsi:type="xsd:string">rgb(221, 221, 221)</value>
+							</entry>
+							<entry>
+								<key>border-left-style</key>
+								<value xsi:type="xsd:string">outset</value>
+							</entry>
+							<entry>
+								<key>border-left-width</key>
+								<value xsi:type="xsd:string">2px</value>
+							</entry>
+							<entry>
+								<key>border-right-color</key>
+								<value xsi:type="xsd:string">rgb(221, 221, 221)</value>
+							</entry>
+							<entry>
+								<key>border-right-style</key>
+								<value xsi:type="xsd:string">outset</value>
+							</entry>
+							<entry>
+								<key>border-right-width</key>
+								<value xsi:type="xsd:string">2px</value>
+							</entry>
+							<entry>
+								<key>border-top-color</key>
+								<value xsi:type="xsd:string">rgb(221, 221, 221)</value>
+							</entry>
+							<entry>
+								<key>border-top-style</key>
+								<value xsi:type="xsd:string">outset</value>
+							</entry>
+							<entry>
+								<key>border-top-width</key>
+								<value xsi:type="xsd:string">2px</value>
+							</entry>
+							<entry>
+								<key>box-sizing</key>
+								<value xsi:type="xsd:string">border-box</value>
+							</entry>
+							<entry>
+								<key>display</key>
+								<value xsi:type="xsd:string">inline-block</value>
+							</entry>
+							<entry>
+								<key>font-family</key>
+								<value xsi:type="xsd:string">Arial</value>
+							</entry>
+							<entry>
+								<key>font-size</key>
+								<value xsi:type="xsd:string">13.3333px</value>
+							</entry>
+							<entry>
+								<key>outline-color</key>
+								<value xsi:type="xsd:string">rgb(229, 151, 0)</value>
+							</entry>
+							<entry>
+								<key>outline-width</key>
+								<value xsi:type="xsd:string">1px</value>
+							</entry>
+							<entry>
+								<key>padding-bottom</key>
+								<value xsi:type="xsd:string">1px</value>
+							</entry>
+							<entry>
+								<key>padding-left</key>
+								<value xsi:type="xsd:string">6px</value>
+							</entry>
+							<entry>
+								<key>padding-right</key>
+								<value xsi:type="xsd:string">6px</value>
+							</entry>
+							<entry>
+								<key>padding-top</key>
+								<value xsi:type="xsd:string">1px</value>
+							</entry>
+							<entry>
+								<key>read-only</key>
+							</entry>
+							<entry>
+								<key>shown</key>
+								<value xsi:type="xsd:string">true</value>
+							</entry>
+							<entry>
+								<key>text-align</key>
+								<value xsi:type="xsd:string">center</value>
+							</entry>
+						</attributes>
+					</attributes>
+				</containedElements>
+			</containedElements>
+		</descriptors>
+		<metadata>
+			<entry>
+				<key>driver.type</key>
+				<value>UnbreakableDriver</value>
+			</entry>
+			<entry>
+				<key>time.offset</key>
+				<value>+01:00</value>
+			</entry>
+			<entry>
+				<key>os.arch</key>
+				<value>amd64</value>
+			</entry>
+			<entry>
+				<key>check.type</key>
+				<value>driver</value>
+			</entry>
+			<entry>
+				<key>vcs.commit</key>
+				<value>133270c5c2878a8275304a840baec0004fb0a2fb</value>
+			</entry>
+			<entry>
+				<key>window.height</key>
+				<value>800</value>
+			</entry>
+			<entry>
+				<key>vcs.branch</key>
+				<value>feature/RET-1917-implement-warning-creation</value>
+			</entry>
+			<entry>
+				<key>url</key>
+				<value>file:///C:/Users/diehl/Documents/Work/Repo/Company/open/recheck-web/target/test-classes/de/retest/web/AutoHealingTest.html</value>
+			</entry>
+			<entry>
+				<key>machine.name</key>
+				<value>PC-BASTIAN</value>
+			</entry>
+			<entry>
+				<key>os.version</key>
+				<value>10.0</value>
+			</entry>
+			<entry>
+				<key>browser.name</key>
+				<value>chrome</value>
+			</entry>
+			<entry>
+				<key>browser.version</key>
+				<value>79.0.3945.117</value>
+			</entry>
+			<entry>
+				<key>time.time</key>
+				<value>15:39:21.488</value>
+			</entry>
+			<entry>
+				<key>time.zone</key>
+				<value>Europe/Berlin</value>
+			</entry>
+			<entry>
+				<key>window.width</key>
+				<value>1200</value>
+			</entry>
+			<entry>
+				<key>os.name</key>
+				<value>XP</value>
+			</entry>
+			<entry>
+				<key>time.date</key>
+				<value>2020-01-08</value>
+			</entry>
+			<entry>
+				<key>vcs.name</key>
+				<value>git</value>
+			</entry>
+		</metadata>
+	</data>
+</reTestXmlDataContainer>

--- a/src/test/resources/retest/recheck/de.retest.web.RecheckSeleniumAdapterIT/warnings_should_be_notified_properly_on_breaking_change.open.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.RecheckSeleniumAdapterIT/warnings_should_be_notified_properly_on_breaking_change.open.recheck/retest.xml
@@ -1,0 +1,532 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<reTestXmlDataContainer xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" reTestVersion="1.8.0" dataType="de.retest.recheck.ui.descriptors.SutState" dataTypeVersion="4">
+	<data xsi:type="sutState">
+		<descriptors retestId="html" screenId="1" screen="AutoHealingTest" title="AutoHealingTest">
+			<identifyingAttributes>
+				<attributes>
+					<attribute key="absolute-outline" xsi:type="outlineAttribute">
+						<x>0</x>
+						<y>0</y>
+						<height>37</height>
+						<width>1200</width>
+					</attribute>
+					<attribute key="outline" xsi:type="outlineAttribute">
+						<x>0</x>
+						<y>0</y>
+						<height>37</height>
+						<width>1200</width>
+					</attribute>
+					<attribute key="path" xsi:type="pathAttribute">html[1]</attribute>
+					<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
+					<attribute key="type" xsi:type="stringAttribute">html</attribute>
+				</attributes>
+			</identifyingAttributes>
+			<attributes>
+				<attributes>
+					<entry>
+						<key>lang</key>
+						<value xsi:type="xsd:string">en</value>
+					</entry>
+					<entry>
+						<key>shown</key>
+						<value xsi:type="xsd:string">true</value>
+					</entry>
+				</attributes>
+			</attributes>
+			<containedElements retestId="head">
+				<identifyingAttributes>
+					<attributes>
+						<attribute key="absolute-outline" xsi:type="outlineAttribute">
+							<x>0</x>
+							<y>0</y>
+							<height>0</height>
+							<width>0</width>
+						</attribute>
+						<attribute key="outline" xsi:type="outlineAttribute">
+							<x>0</x>
+							<y>0</y>
+							<height>-37</height>
+							<width>-1200</width>
+						</attribute>
+						<attribute key="path" xsi:type="pathAttribute">html[1]/head[1]</attribute>
+						<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
+						<attribute key="type" xsi:type="stringAttribute">head</attribute>
+					</attributes>
+				</identifyingAttributes>
+				<attributes>
+					<attributes>
+						<entry>
+							<key>shown</key>
+							<value xsi:type="xsd:string">false</value>
+						</entry>
+					</attributes>
+				</attributes>
+				<containedElements retestId="autohealingtest">
+					<identifyingAttributes>
+						<attributes>
+							<attribute key="absolute-outline" xsi:type="outlineAttribute">
+								<x>0</x>
+								<y>0</y>
+								<height>0</height>
+								<width>0</width>
+							</attribute>
+							<attribute key="outline" xsi:type="outlineAttribute">
+								<x>0</x>
+								<y>0</y>
+								<height>0</height>
+								<width>0</width>
+							</attribute>
+							<attribute key="path" xsi:type="pathAttribute">html[1]/head[1]/title[1]</attribute>
+							<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
+							<attribute key="text" xsi:type="textAttribute">AutoHealingTest</attribute>
+							<attribute key="type" xsi:type="stringAttribute">title</attribute>
+						</attributes>
+					</identifyingAttributes>
+					<attributes>
+						<attributes>
+							<entry>
+								<key>shown</key>
+								<value xsi:type="xsd:string">false</value>
+							</entry>
+						</attributes>
+					</attributes>
+				</containedElements>
+				<containedElements retestId="meta">
+					<identifyingAttributes>
+						<attributes>
+							<attribute key="absolute-outline" xsi:type="outlineAttribute">
+								<x>0</x>
+								<y>0</y>
+								<height>0</height>
+								<width>0</width>
+							</attribute>
+							<attribute key="outline" xsi:type="outlineAttribute">
+								<x>0</x>
+								<y>0</y>
+								<height>0</height>
+								<width>0</width>
+							</attribute>
+							<attribute key="path" xsi:type="pathAttribute">html[1]/head[1]/meta[1]</attribute>
+							<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
+							<attribute key="type" xsi:type="stringAttribute">meta</attribute>
+						</attributes>
+					</identifyingAttributes>
+					<attributes>
+						<attributes>
+							<entry>
+								<key>charset</key>
+								<value xsi:type="xsd:string">UTF-8</value>
+							</entry>
+							<entry>
+								<key>shown</key>
+								<value xsi:type="xsd:string">false</value>
+							</entry>
+						</attributes>
+					</attributes>
+				</containedElements>
+				<containedElements retestId="meta-1">
+					<identifyingAttributes>
+						<attributes>
+							<attribute key="absolute-outline" xsi:type="outlineAttribute">
+								<x>0</x>
+								<y>0</y>
+								<height>0</height>
+								<width>0</width>
+							</attribute>
+							<attribute key="name" xsi:type="stringAttribute">viewport</attribute>
+							<attribute key="outline" xsi:type="outlineAttribute">
+								<x>0</x>
+								<y>0</y>
+								<height>0</height>
+								<width>0</width>
+							</attribute>
+							<attribute key="path" xsi:type="pathAttribute">html[1]/head[1]/meta[2]</attribute>
+							<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
+							<attribute key="type" xsi:type="stringAttribute">meta</attribute>
+						</attributes>
+					</identifyingAttributes>
+					<attributes>
+						<attributes>
+							<entry>
+								<key>content</key>
+								<value xsi:type="xsd:string">width=device-width, initial-scale=1.0</value>
+							</entry>
+							<entry>
+								<key>shown</key>
+								<value xsi:type="xsd:string">false</value>
+							</entry>
+						</attributes>
+					</attributes>
+				</containedElements>
+				<containedElements retestId="meta-2">
+					<identifyingAttributes>
+						<attributes>
+							<attribute key="absolute-outline" xsi:type="outlineAttribute">
+								<x>0</x>
+								<y>0</y>
+								<height>0</height>
+								<width>0</width>
+							</attribute>
+							<attribute key="outline" xsi:type="outlineAttribute">
+								<x>0</x>
+								<y>0</y>
+								<height>0</height>
+								<width>0</width>
+							</attribute>
+							<attribute key="path" xsi:type="pathAttribute">html[1]/head[1]/meta[3]</attribute>
+							<attribute key="suffix" xsi:type="suffixAttribute">3</attribute>
+							<attribute key="type" xsi:type="stringAttribute">meta</attribute>
+						</attributes>
+					</identifyingAttributes>
+					<attributes>
+						<attributes>
+							<entry>
+								<key>content</key>
+								<value xsi:type="xsd:string">ie=edge</value>
+							</entry>
+							<entry>
+								<key>http-equiv</key>
+								<value xsi:type="xsd:string">X-UA-Compatible</value>
+							</entry>
+							<entry>
+								<key>shown</key>
+								<value xsi:type="xsd:string">false</value>
+							</entry>
+						</attributes>
+					</attributes>
+				</containedElements>
+			</containedElements>
+			<containedElements retestId="body">
+				<identifyingAttributes>
+					<attributes>
+						<attribute key="absolute-outline" xsi:type="outlineAttribute">
+							<x>8</x>
+							<y>8</y>
+							<height>21</height>
+							<width>1184</width>
+						</attribute>
+						<attribute key="outline" xsi:type="outlineAttribute">
+							<x>8</x>
+							<y>8</y>
+							<height>-16</height>
+							<width>-16</width>
+						</attribute>
+						<attribute key="path" xsi:type="pathAttribute">html[1]/body[1]</attribute>
+						<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
+						<attribute key="type" xsi:type="stringAttribute">body</attribute>
+					</attributes>
+				</identifyingAttributes>
+				<attributes>
+					<attributes>
+						<entry>
+							<key>shown</key>
+							<value xsi:type="xsd:string">true</value>
+						</entry>
+					</attributes>
+				</attributes>
+				<containedElements retestId="id">
+					<identifyingAttributes>
+						<attributes>
+							<attribute key="absolute-outline" xsi:type="outlineAttribute">
+								<x>123</x>
+								<y>8</y>
+								<height>21</height>
+								<width>173</width>
+							</attribute>
+							<attribute key="id" xsi:type="stringAttribute">id</attribute>
+							<attribute key="outline" xsi:type="outlineAttribute">
+								<x>115</x>
+								<y>0</y>
+								<height>0</height>
+								<width>-1011</width>
+							</attribute>
+							<attribute key="path" xsi:type="pathAttribute">html[1]/body[1]/input[1]</attribute>
+							<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
+							<attribute key="type" xsi:type="stringAttribute">input</attribute>
+						</attributes>
+					</identifyingAttributes>
+					<attributes>
+						<attributes>
+							<entry>
+								<key>background-color</key>
+								<value xsi:type="xsd:string">rgb(255, 255, 255)</value>
+							</entry>
+							<entry>
+								<key>border-bottom-style</key>
+								<value xsi:type="xsd:string">inset</value>
+							</entry>
+							<entry>
+								<key>border-bottom-width</key>
+								<value xsi:type="xsd:string">2px</value>
+							</entry>
+							<entry>
+								<key>border-left-style</key>
+								<value xsi:type="xsd:string">inset</value>
+							</entry>
+							<entry>
+								<key>border-left-width</key>
+								<value xsi:type="xsd:string">2px</value>
+							</entry>
+							<entry>
+								<key>border-right-style</key>
+								<value xsi:type="xsd:string">inset</value>
+							</entry>
+							<entry>
+								<key>border-right-width</key>
+								<value xsi:type="xsd:string">2px</value>
+							</entry>
+							<entry>
+								<key>border-top-style</key>
+								<value xsi:type="xsd:string">inset</value>
+							</entry>
+							<entry>
+								<key>border-top-width</key>
+								<value xsi:type="xsd:string">2px</value>
+							</entry>
+							<entry>
+								<key>font-family</key>
+								<value xsi:type="xsd:string">Arial</value>
+							</entry>
+							<entry>
+								<key>font-size</key>
+								<value xsi:type="xsd:string">13.3333px</value>
+							</entry>
+							<entry>
+								<key>margin-bottom</key>
+								<value xsi:type="xsd:string">0px</value>
+							</entry>
+							<entry>
+								<key>margin-top</key>
+								<value xsi:type="xsd:string">0px</value>
+							</entry>
+							<entry>
+								<key>padding-bottom</key>
+								<value xsi:type="xsd:string">1px</value>
+							</entry>
+							<entry>
+								<key>padding-top</key>
+								<value xsi:type="xsd:string">1px</value>
+							</entry>
+							<entry>
+								<key>read-only</key>
+								<value xsi:type="xsd:string">true</value>
+							</entry>
+							<entry>
+								<key>shown</key>
+								<value xsi:type="xsd:string">true</value>
+							</entry>
+							<entry>
+								<key>type</key>
+								<value xsi:type="xsd:string">text</value>
+							</entry>
+							<entry>
+								<key>value</key>
+								<value xsi:type="xsd:string">a</value>
+							</entry>
+						</attributes>
+					</attributes>
+				</containedElements>
+				<containedElements retestId="a">
+					<identifyingAttributes>
+						<attributes>
+							<attribute key="absolute-outline" xsi:type="outlineAttribute">
+								<x>8</x>
+								<y>8</y>
+								<height>21</height>
+								<width>111</width>
+							</attribute>
+							<attribute key="id" xsi:type="stringAttribute">a</attribute>
+							<attribute key="outline" xsi:type="outlineAttribute">
+								<x>0</x>
+								<y>0</y>
+								<height>0</height>
+								<width>-1073</width>
+							</attribute>
+							<attribute key="path" xsi:type="pathAttribute">html[1]/body[1]/button[1]</attribute>
+							<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
+							<attribute key="text" xsi:type="textAttribute">Click to change!</attribute>
+							<attribute key="type" xsi:type="stringAttribute">button</attribute>
+						</attributes>
+					</identifyingAttributes>
+					<attributes>
+						<attributes>
+							<entry>
+								<key>align-items</key>
+								<value xsi:type="xsd:string">flex-start</value>
+							</entry>
+							<entry>
+								<key>background-color</key>
+								<value xsi:type="xsd:string">rgb(221, 221, 221)</value>
+							</entry>
+							<entry>
+								<key>border-bottom-color</key>
+								<value xsi:type="xsd:string">rgb(221, 221, 221)</value>
+							</entry>
+							<entry>
+								<key>border-bottom-style</key>
+								<value xsi:type="xsd:string">outset</value>
+							</entry>
+							<entry>
+								<key>border-bottom-width</key>
+								<value xsi:type="xsd:string">2px</value>
+							</entry>
+							<entry>
+								<key>border-left-color</key>
+								<value xsi:type="xsd:string">rgb(221, 221, 221)</value>
+							</entry>
+							<entry>
+								<key>border-left-style</key>
+								<value xsi:type="xsd:string">outset</value>
+							</entry>
+							<entry>
+								<key>border-left-width</key>
+								<value xsi:type="xsd:string">2px</value>
+							</entry>
+							<entry>
+								<key>border-right-color</key>
+								<value xsi:type="xsd:string">rgb(221, 221, 221)</value>
+							</entry>
+							<entry>
+								<key>border-right-style</key>
+								<value xsi:type="xsd:string">outset</value>
+							</entry>
+							<entry>
+								<key>border-right-width</key>
+								<value xsi:type="xsd:string">2px</value>
+							</entry>
+							<entry>
+								<key>border-top-color</key>
+								<value xsi:type="xsd:string">rgb(221, 221, 221)</value>
+							</entry>
+							<entry>
+								<key>border-top-style</key>
+								<value xsi:type="xsd:string">outset</value>
+							</entry>
+							<entry>
+								<key>border-top-width</key>
+								<value xsi:type="xsd:string">2px</value>
+							</entry>
+							<entry>
+								<key>box-sizing</key>
+								<value xsi:type="xsd:string">border-box</value>
+							</entry>
+							<entry>
+								<key>display</key>
+								<value xsi:type="xsd:string">inline-block</value>
+							</entry>
+							<entry>
+								<key>font-family</key>
+								<value xsi:type="xsd:string">Arial</value>
+							</entry>
+							<entry>
+								<key>font-size</key>
+								<value xsi:type="xsd:string">13.3333px</value>
+							</entry>
+							<entry>
+								<key>padding-bottom</key>
+								<value xsi:type="xsd:string">1px</value>
+							</entry>
+							<entry>
+								<key>padding-left</key>
+								<value xsi:type="xsd:string">6px</value>
+							</entry>
+							<entry>
+								<key>padding-right</key>
+								<value xsi:type="xsd:string">6px</value>
+							</entry>
+							<entry>
+								<key>padding-top</key>
+								<value xsi:type="xsd:string">1px</value>
+							</entry>
+							<entry>
+								<key>read-only</key>
+							</entry>
+							<entry>
+								<key>shown</key>
+								<value xsi:type="xsd:string">true</value>
+							</entry>
+							<entry>
+								<key>text-align</key>
+								<value xsi:type="xsd:string">center</value>
+							</entry>
+						</attributes>
+					</attributes>
+				</containedElements>
+			</containedElements>
+		</descriptors>
+		<metadata>
+			<entry>
+				<key>driver.type</key>
+				<value>UnbreakableDriver</value>
+			</entry>
+			<entry>
+				<key>time.offset</key>
+				<value>+01:00</value>
+			</entry>
+			<entry>
+				<key>os.arch</key>
+				<value>amd64</value>
+			</entry>
+			<entry>
+				<key>check.type</key>
+				<value>driver</value>
+			</entry>
+			<entry>
+				<key>vcs.commit</key>
+				<value>133270c5c2878a8275304a840baec0004fb0a2fb</value>
+			</entry>
+			<entry>
+				<key>window.height</key>
+				<value>800</value>
+			</entry>
+			<entry>
+				<key>vcs.branch</key>
+				<value>feature/RET-1917-implement-warning-creation</value>
+			</entry>
+			<entry>
+				<key>url</key>
+				<value>file:///C:/Users/diehl/Documents/Work/Repo/Company/open/recheck-web/target/test-classes/de/retest/web/AutoHealingTest.html</value>
+			</entry>
+			<entry>
+				<key>machine.name</key>
+				<value>PC-BASTIAN</value>
+			</entry>
+			<entry>
+				<key>os.version</key>
+				<value>10.0</value>
+			</entry>
+			<entry>
+				<key>browser.name</key>
+				<value>chrome</value>
+			</entry>
+			<entry>
+				<key>browser.version</key>
+				<value>79.0.3945.117</value>
+			</entry>
+			<entry>
+				<key>time.time</key>
+				<value>15:39:16.33</value>
+			</entry>
+			<entry>
+				<key>time.zone</key>
+				<value>Europe/Berlin</value>
+			</entry>
+			<entry>
+				<key>window.width</key>
+				<value>1200</value>
+			</entry>
+			<entry>
+				<key>os.name</key>
+				<value>XP</value>
+			</entry>
+			<entry>
+				<key>time.date</key>
+				<value>2020-01-08</value>
+			</entry>
+			<entry>
+				<key>vcs.name</key>
+				<value>git</value>
+			</entry>
+		</metadata>
+	</data>
+</reTestXmlDataContainer>


### PR DESCRIPTION
*Before submission, please check that ...*

- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [x] the necessary tests are either created or updated.
- [x] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [x] you updated the changelog.
- [x] ~you updated necessary documentation within [retest/docs](https://github.com/retest/docs).~

<!-- Note: You can always ask a maintainer to help you with the above tasks. -->

## Description

This PR adds the warnings created by the `TestHealer` into the `ActionReplayResult`. The code is mostly used from @roesslerj. 

All warnings that occur are added to the last `ActionReplayResult`, i.e. the last `check`:
```java
driver.get( "url" )
re.check( "open") // -> diff 'open'

driver.findElement( By.id( "a" ) ).click() // -> warning: add to 'open'
re.check( "a") -> diff 'a'

driver.findElement( By.id( "b" ) ).click() // -> warning: add to 'a'
re.check( "b") // -> diff 'b'
```

Some things to mention (which are reflected in the commit messages):

1. The `notifyAboutDifferences` is called after `convert` why the access to the `actionReplayResult` must be a lambda.
2. The Integration test does not 1 to 1 replicate the actual behavior of `Recheck` since I need access to the arguments in order to verify the correct behavior.

### State of this PR

I did not write a test for each case that is possible, because

1. we firstly only want to support the most simplest case.
2. we need to test this more anyways.