### PR TITLE
Changed wording in logging from "Found 0 frame(s)" to "Found 0 sub-frame(s)"

### DIFF
--- a/src/main/java/de/retest/web/FrameConverter.java
+++ b/src/main/java/de/retest/web/FrameConverter.java
@@ -36,7 +36,7 @@ public class FrameConverter {
 	public void addChildrenFromFrames( final WebDriver driver, final RootElement lastChecked ) {
 		final List<Element> frames =
 				de.retest.web.selenium.By.findElements( lastChecked.getContainedElements(), isFrame() );
-		log.debug( "Found {} frame(s), getting data per frame.", frames.size() );
+		log.debug( "Found {} sub-frame(s), getting data per frame.", frames.size() );
 		for ( final Element frame : frames ) {
 			addChildrenFromFrame( driver, frame );
 			driver.switchTo().defaultContent();

--- a/src/main/java/de/retest/web/FrameConverter.java
+++ b/src/main/java/de/retest/web/FrameConverter.java
@@ -36,6 +36,10 @@ public class FrameConverter {
 	public void addChildrenFromFrames( final WebDriver driver, final RootElement lastChecked ) {
 		final List<Element> frames =
 				de.retest.web.selenium.By.findElements( lastChecked.getContainedElements(), isFrame() );
+		if ( frames.size() <= 0 ) {
+			log.debug( "Found no sub-frames." );
+			return;
+		}
 		log.debug( "Found {} sub-frame(s), getting data per frame.", frames.size() );
 		for ( final Element frame : frames ) {
 			addChildrenFromFrame( driver, frame );


### PR DESCRIPTION
As people might think we didn't get any data if there are no frames. Was a real question/concern...
