### PR TITLE
Add recheck to the ignored updates

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -13,3 +13,6 @@ update_configs:
           # As long as the issue is not fixed, we need to use version 0.9
           # see https://github.com/assertthat/selenium-shutterbug/issues/64
           dependency_name: "com.assertthat:selenium-shutterbug"
+      - match:
+          # We update this manually within the release process
+          dependency_name: "de.retest:recheck"


### PR DESCRIPTION
*Before submission, please check that ...*

- [x] ~the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.~
- [x] ~the necessary tests are either created or updated.~
- [x] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [x] ~you updated the changelog.~
- [x] ~you updated necessary documentation within [retest/docs](https://github.com/retest/docs).~

<!-- Note: You can always ask a maintainer to help you with the above tasks. -->

## Description

We do not want to have dependabot update the recheck version. This is done within the release process.

### State of this PR

The [documentation](https://dependabot.com/docs/config-file/#ignored_updates) has followed and [verified](https://dependabot.com/docs/config-file/validator/), thus it *should* work, but for now as #493 has been closed, dependabot will not update the recheck version until the next release.

### Additional Context

I want to test the the automatic assignment with this too.