### PR TITLE
Revert "Bump recheck version to 1.9.0-beta.1"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
 		<dependency>
 			<groupId>de.retest</groupId>
 			<artifactId>recheck</artifactId>
-			<version>1.9.0-beta.1</version>
+			<version>d3b0b678</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
This reverts commit d764d03553479bdbae6825020c1b3db7e03f195f.

I always do the update branch on the wrong base initially. To avoid any accidental build failures, I revert this for now.

Please note that this is the **master** branch and not the *release* branch.