### PR TITLE
Bumb recheck version to 1.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
 		<dependency>
 			<groupId>de.retest</groupId>
 			<artifactId>recheck</artifactId>
-			<version>1.9.0-beta.2</version>
+			<version>1.9.0</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
~Due to some deploying errors, this is not available in central or github releases yet, and thus is provided through jitpack~ Travis finally decided to pass