### PR TITLE
Feature/screenshots for webelements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,12 @@ Table of Contents
 
 ### Breaking Changes
 
+* Add `shoot(WebDriver, WebElement)` in interface `ScreenshotProvider` to create screenshots for `WebElement`
+
 ### Bug Fixes
 
 * Fix that cascading frames inside of frames are not analyzed. Now depth doesn't matter...
+* Fix that `NoScreenshot` or `RecheckWebOptions#disableScreenshots` is not applied to web elements.
 
 ### New Features
 

--- a/src/main/java/de/retest/web/screenshot/FullPageScreenshot.java
+++ b/src/main/java/de/retest/web/screenshot/FullPageScreenshot.java
@@ -6,6 +6,7 @@ import static de.retest.web.screenshot.ScreenshotProviders.SCALE;
 import java.awt.image.BufferedImage;
 
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chrome.ChromeDriver;
 
 import com.assertthat.selenium_shutterbug.core.Shutterbug;
@@ -30,6 +31,11 @@ public class FullPageScreenshot implements ScreenshotProvider {
 		return Shutterbug //
 				.shootPage( driver, ScrollStrategy.BOTH_DIRECTIONS, SCROLL_TIMEOUT_MS, USE_DEVICE_PIXEL_RATIO ) //
 				.getImage();
+	}
+
+	@Override
+	public BufferedImage shoot( final WebDriver driver, final WebElement element ) {
+		return Shutterbug.shootElement( driver, element, USE_DEVICE_PIXEL_RATIO ).getImage();
 	}
 
 }

--- a/src/main/java/de/retest/web/screenshot/NoScreenshot.java
+++ b/src/main/java/de/retest/web/screenshot/NoScreenshot.java
@@ -3,6 +3,7 @@ package de.retest.web.screenshot;
 import java.awt.image.BufferedImage;
 
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
 
 /**
  * Does not take any screenshot at all. Increases the performance. Cannot be set globally.
@@ -11,6 +12,11 @@ public class NoScreenshot implements ScreenshotProvider {
 
 	@Override
 	public BufferedImage shoot( final WebDriver driver ) {
+		return null;
+	}
+
+	@Override
+	public BufferedImage shoot( final WebDriver driver, final WebElement element ) {
 		return null;
 	}
 

--- a/src/main/java/de/retest/web/screenshot/ScreenshotProvider.java
+++ b/src/main/java/de/retest/web/screenshot/ScreenshotProvider.java
@@ -3,6 +3,7 @@ package de.retest.web.screenshot;
 import java.awt.image.BufferedImage;
 
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
 
 /**
  * The screenshot provider for way screenshots are taken.
@@ -22,5 +23,18 @@ public interface ScreenshotProvider {
 	 *             If an exception occurred during screenshot creation.
 	 */
 	BufferedImage shoot( WebDriver driver ) throws Exception;
+
+	/**
+	 * Takes the screenshot from {@link WebElement}.
+	 *
+	 * @param driver
+	 *            Webdriver for taking the screenshot.
+	 * @param element
+	 *            WebElement where screenshot is taken from.
+	 * @return screenshot image of tested web element. May return {@code null} if screenshots are not supported.
+	 * @throws Exception
+	 *             If an exception occurred during screenshot creation.
+	 */
+	BufferedImage shoot( WebDriver driver, WebElement element ) throws Exception;
 
 }

--- a/src/main/java/de/retest/web/screenshot/ScreenshotProviders.java
+++ b/src/main/java/de/retest/web/screenshot/ScreenshotProviders.java
@@ -9,15 +9,13 @@ import org.aeonbits.owner.Converter;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
-import com.assertthat.selenium_shutterbug.core.Shutterbug;
-
 import de.retest.web.RecheckWebOptions;
 import de.retest.web.RecheckWebProperties;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class ScreenshotProviders {
-	
+
 	public static final ScreenshotProvider DEFAULT = new ViewportOnlyMinimalScreenshot();
 	public static final ScreenshotProvider NONE = new NoScreenshot();
 
@@ -44,8 +42,6 @@ public class ScreenshotProviders {
 
 	}
 
-	private static final boolean USE_DEVICE_PIXEL_RATIO = true;
-
 	public static final int SCALE = extractScale();
 
 	private ScreenshotProviders() {}
@@ -55,7 +51,7 @@ public class ScreenshotProviders {
 		try {
 			final long startTime = System.currentTimeMillis();
 			if ( element != null ) {
-				return shootElement( driver, element );
+				return screenshotProvider.shoot( driver, element );
 			}
 			final BufferedImage result = screenshotProvider.shoot( driver );
 			log.info( "Took {}ms to create the screenshot.", System.currentTimeMillis() - startTime );
@@ -66,7 +62,4 @@ public class ScreenshotProviders {
 		}
 	}
 
-	private static BufferedImage shootElement( final WebDriver driver, final WebElement element ) {
-		return Shutterbug.shootElement( driver, element, USE_DEVICE_PIXEL_RATIO ).getImage();
-	}
 }

--- a/src/main/java/de/retest/web/screenshot/ViewportOnlyMinimalScreenshot.java
+++ b/src/main/java/de/retest/web/screenshot/ViewportOnlyMinimalScreenshot.java
@@ -3,6 +3,7 @@ package de.retest.web.screenshot;
 import java.awt.image.BufferedImage;
 
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
 
 import com.assertthat.selenium_shutterbug.core.Shutterbug;
 
@@ -16,12 +17,16 @@ public class ViewportOnlyMinimalScreenshot implements ScreenshotProvider {
 	static final int DEFAULT_WANTED_WIDTH_PX = 800;
 	private static final String RESIZE_MAX_WIDTH_PX = "de.retest.recheck.web.screenshot.maxWidthPx";
 	private static final int WANTED_WIDTH = Integer.getInteger( RESIZE_MAX_WIDTH_PX, DEFAULT_WANTED_WIDTH_PX );
-
 	private static final boolean USE_DEVICE_PIXEL_RATIO = true;
 
 	@Override
 	public BufferedImage shoot( final WebDriver driver ) {
 		return resizeImage( Shutterbug.shootPage( driver, USE_DEVICE_PIXEL_RATIO ).getImage() );
+	}
+
+	@Override
+	public BufferedImage shoot( final WebDriver driver, final WebElement element ) {
+		return resizeImage( Shutterbug.shootElement( driver, element, USE_DEVICE_PIXEL_RATIO ).getImage() );
 	}
 
 	public static BufferedImage resizeImage( final BufferedImage image ) {

--- a/src/main/java/de/retest/web/screenshot/ViewportOnlyScreenshot.java
+++ b/src/main/java/de/retest/web/screenshot/ViewportOnlyScreenshot.java
@@ -3,6 +3,7 @@ package de.retest.web.screenshot;
 import java.awt.image.BufferedImage;
 
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
 
 import com.assertthat.selenium_shutterbug.core.Shutterbug;
 
@@ -16,6 +17,11 @@ public class ViewportOnlyScreenshot implements ScreenshotProvider {
 	@Override
 	public BufferedImage shoot( final WebDriver driver ) {
 		return Shutterbug.shootPage( driver, USE_DEVICE_PIXEL_RATIO ).getImage();
+	}
+
+	@Override
+	public BufferedImage shoot( final WebDriver driver, final WebElement element ) {
+		return Shutterbug.shootElement( driver, element, USE_DEVICE_PIXEL_RATIO ).getImage();
 	}
 
 }

--- a/src/test/java/de/retest/web/it/SimplePageDiffIT.testSimpleChange.approved.txt
+++ b/src/test/java/de/retest/web/it/SimplePageDiffIT.testSimpleChange.approved.txt
@@ -5,7 +5,7 @@ Test 'testSimpleChange' has 4 difference(s) in 1 state(s):
 open resulted in:
 	Metadata Differences:
 		browser.name: expected="null", actual="chrome"
-		browser.version: expected="null", actual="79.0.3945.130"
+		browser.version: expected="null", actual="80.0.3987.87"
 		check.type: expected="null", actual="driver"
 		driver.type: expected="null", actual="ChromeDriver"
 		os.name: expected="null", actual="LINUX"


### PR DESCRIPTION
- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [ ] <s>the necessary tests are either created or updated.</s>
- [x] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [x] you updated the changelog.
- [ ] <s>you updated necessary documentation within [retest/docs](https://github.com/retest/docs).</s>

<!-- Note: You can always ask a maintainer to help you with the above tasks. -->

## Description

> Unify screenshot behavior for WebElements <!-- Please provide some short description here -->

<!-- Please provide additional description with this PR. If there are any related issues, please link them here too. -->

Until now, screenshots of web elements were created although screenshots have been disabled by option or properties. This PR unifies the behavior of `WebDriver` and `WebElement` concerning screenshots by changing the API in `ScreenshotProvider` to include also `WebElement` as parameter in a new method `shoot(WebDriver driver, WebElement element)` that returns the screenshot of `element`.

### State of this PR

<!-- If there is any work left (see above) or things to consider -->

### Additional Context

<!-- Add any other context, screenshots or minimal code example about the feature request here. Please check that you do not expose any secrets. -->