### PR TITLE
Feature/fix unbreakable throws exception for element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Table of Contents
 * Fix that cascading frames inside of frames are not analyzed. Now depth doesn't matter...
 * Fix that `NoScreenshot` or `RecheckWebOptions#disableScreenshots()` is not applied to web elements.
 * Fix that `de.retest.recheck.web.screenshot.provider` from `recheck.ignore` is ignored when `RecheckWebOptions` are used.
+* Fix that passing an element into `RecheckWebImpl` from an `UnbreakableDriver` throws an error.
 
 ### New Features
 

--- a/src/main/java/de/retest/web/RecheckWebImpl.java
+++ b/src/main/java/de/retest/web/RecheckWebImpl.java
@@ -8,6 +8,8 @@ import de.retest.recheck.RecheckOptions;
 import de.retest.recheck.ui.descriptors.SutState;
 import de.retest.web.selenium.ImplicitDriverWrapper;
 import de.retest.web.selenium.UnbreakableDriver;
+import de.retest.web.util.SeleniumWrapperUtil;
+import de.retest.web.util.SeleniumWrapperUtil.WrapperOf;
 import lombok.AccessLevel;
 import lombok.Getter;
 
@@ -46,6 +48,9 @@ public class RecheckWebImpl extends RecheckImpl {
 		}
 		if ( driver instanceof UnbreakableDriver ) {
 			return (UnbreakableDriver) driver;
+		}
+		if ( SeleniumWrapperUtil.isWrapper( WrapperOf.DRIVER, driver ) ) {
+			return retrieveUnbreakableDriver( SeleniumWrapperUtil.getWrapped( WrapperOf.DRIVER, driver ) );
 		}
 		return null;
 	}

--- a/src/main/java/de/retest/web/selenium/AutocheckingRecheckDriver.java
+++ b/src/main/java/de/retest/web/selenium/AutocheckingRecheckDriver.java
@@ -1,8 +1,5 @@
 package de.retest.web.selenium;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -117,35 +114,23 @@ public class AutocheckingRecheckDriver extends UnbreakableDriver implements Rech
 	}
 
 	@Override
+	protected WebElement wrap( final WebElement element ) {
+		return AutocheckingWebElement.of( element, this );
+	}
+
+	@Override
 	public AutocheckingWebElement findElement( final ByBestMatchToRetestId by ) {
 		final WebElement wrapped = super.findElement( by );
 		String result = wrapped.toString();
 		// replace " -> xpath: HTML[1]/BODY[1]/A[1]"
 		result = result.substring( 0, result.lastIndexOf( " -> xpath: " ) );
 		final String representation = result + " -> retestId: " + by.getRetestId() + "]";
-		return new AutocheckingWebElement( wrapped, this ) {
-			@Override
-			public String toString() {
-				return representation;
-			}
-		};
+		return AutocheckingWebElement.of( wrapped, this, representation );
 	}
 
 	@Override
 	public AutocheckingWebElement findElement( final By by ) {
-		final WebElement result = super.findElement( by );
-		if ( result instanceof AutocheckingWebElement ) {
-			// Element was not found, so we already have it wrapped
-			return (AutocheckingWebElement) result;
-		}
-		return new AutocheckingWebElement( result, this );
-	}
-
-	@Override
-	public List<WebElement> findElements( final By by ) {
-		return super.findElements( by ).stream() //
-				.map( element -> new AutocheckingWebElement( element, this ) ) //
-				.collect( Collectors.toList() );
+		return (AutocheckingWebElement) super.findElement( by );
 	}
 
 	void check( final String action, final WebElement target, final Object... params ) {

--- a/src/main/java/de/retest/web/selenium/AutocheckingWebElement.java
+++ b/src/main/java/de/retest/web/selenium/AutocheckingWebElement.java
@@ -8,15 +8,17 @@ import org.openqa.selenium.Dimension;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.Point;
 import org.openqa.selenium.Rectangle;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.WrapsDriver;
 import org.openqa.selenium.internal.WrapsElement;
 
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor( access = AccessLevel.PRIVATE )
-public class AutocheckingWebElement implements WebElement, WrapsElement {
+public class AutocheckingWebElement implements WebElement, WrapsDriver, WrapsElement {
 
 	private final WebElement wrappedElement;
 	private final AutocheckingRecheckDriver driver;
@@ -140,6 +142,11 @@ public class AutocheckingWebElement implements WebElement, WrapsElement {
 	@Override
 	public String getCssValue( final String propertyName ) {
 		return wrappedElement.getCssValue( propertyName );
+	}
+
+	@Override
+	public WebDriver getWrappedDriver() {
+		return driver;
 	}
 
 	@Override

--- a/src/main/java/de/retest/web/selenium/AutocheckingWebElement.java
+++ b/src/main/java/de/retest/web/selenium/AutocheckingWebElement.java
@@ -12,17 +12,34 @@ import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.internal.WrapsElement;
 
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor( access = AccessLevel.PRIVATE )
 public class AutocheckingWebElement implements WebElement, WrapsElement {
 
 	private final WebElement wrappedElement;
 	private final AutocheckingRecheckDriver driver;
 
-	public AutocheckingWebElement( final WebElement wrappedElement, final AutocheckingRecheckDriver driver ) {
+	public static AutocheckingWebElement of( final WebElement wrappedElement, final AutocheckingRecheckDriver driver ) {
 		if ( wrappedElement instanceof AutocheckingWebElement ) {
-			throw new IllegalArgumentException( "Cannot wrap WebElementWrapper inside WebElementWrapper." );
+			return (AutocheckingWebElement) wrappedElement;
 		}
-		this.wrappedElement = wrappedElement;
-		this.driver = driver;
+		return new AutocheckingWebElement( wrappedElement, driver );
+	}
+
+	public static AutocheckingWebElement of( final WebElement wrappedElement, final AutocheckingRecheckDriver driver,
+			final String representation ) {
+		if ( wrappedElement instanceof AutocheckingWebElement ) {
+			return (AutocheckingWebElement) wrappedElement;
+		}
+
+		return new AutocheckingWebElement( wrappedElement, driver ) {
+			@Override
+			public String toString() {
+				return representation;
+			}
+		};
 	}
 
 	/**
@@ -91,13 +108,13 @@ public class AutocheckingWebElement implements WebElement, WrapsElement {
 	@Override
 	public List<WebElement> findElements( final By by ) {
 		return wrappedElement.findElements( by ).stream() //
-				.map( element -> new AutocheckingWebElement( element, driver ) ) //
+				.map( element -> of( element, driver ) ) //
 				.collect( Collectors.toList() );
 	}
 
 	@Override
 	public WebElement findElement( final By by ) {
-		return new AutocheckingWebElement( wrappedElement.findElement( by ), driver );
+		return of( wrappedElement.findElement( by ), driver );
 	}
 
 	@Override
@@ -128,5 +145,10 @@ public class AutocheckingWebElement implements WebElement, WrapsElement {
 	@Override
 	public WebElement getWrappedElement() {
 		return wrappedElement;
+	}
+
+	@Override
+	public String toString() {
+		return wrappedElement.toString();
 	}
 }

--- a/src/main/java/de/retest/web/selenium/UnbreakableDriver.java
+++ b/src/main/java/de/retest/web/selenium/UnbreakableDriver.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.Capabilities;
@@ -68,7 +69,19 @@ public class UnbreakableDriver implements WebDriver, JavascriptExecutor, FindsBy
 					+ " and first check the state before being able to use the retest ID locator." );
 		}
 		final Element searchedFor = by.findElement( lastExpectedState, lastActualState );
-		return wrappedDriver.findElement( By.xpath( searchedFor.getIdentifyingAttributes().getPath() ) );
+		final WebElement element =
+				wrappedDriver.findElement( By.xpath( searchedFor.getIdentifyingAttributes().getPath() ) );
+		return wrap( element );
+	}
+
+	protected WebElement wrap( final WebElement element ) {
+		return WrappingWebElement.wrap( this, element );
+	}
+
+	private List<WebElement> wrap( final List<WebElement> elements ) {
+		return elements.stream() //
+				.map( this::wrap ) //
+				.collect( Collectors.toList() );
 	}
 
 	public WebElement findElementByRetestId( final String retestId ) {
@@ -81,99 +94,99 @@ public class UnbreakableDriver implements WebDriver, JavascriptExecutor, FindsBy
 			return findElement( (ByBestMatchToRetestId) by );
 		}
 		try {
-			return wrappedDriver.findElement( by );
+			return wrap( wrappedDriver.findElement( by ) );
 		} catch ( final NoSuchElementException e ) {
 			final WebElement matchedOld = TestHealer.findElement( by, this );
 			if ( matchedOld == null ) {
 				throw e;
 			}
-			return matchedOld;
+			return wrap( matchedOld );
 		}
 	}
 
 	@Override
 	public List<WebElement> findElements( final By by ) {
-		return wrappedDriver.findElements( by );
+		return wrap( wrappedDriver.findElements( by ) );
 	}
 
 	@Override
 	public WebElement findElementById( final String using ) {
-		return wrappedDriver.findElementById( using );
+		return wrap( wrappedDriver.findElementById( using ) );
 	}
 
 	@Override
 	public List<WebElement> findElementsById( final String using ) {
-		return wrappedDriver.findElementsById( using );
+		return wrap( wrappedDriver.findElementsById( using ) );
 	}
 
 	@Override
 	public WebElement findElementByClassName( final String using ) {
-		return wrappedDriver.findElementByClassName( using );
+		return wrap( wrappedDriver.findElementByClassName( using ) );
 	}
 
 	@Override
 	public List<WebElement> findElementsByClassName( final String using ) {
-		return wrappedDriver.findElementsByClassName( using );
+		return wrap( wrappedDriver.findElementsByClassName( using ) );
 	}
 
 	@Override
 	public WebElement findElementByLinkText( final String using ) {
-		return wrappedDriver.findElementByLinkText( using );
+		return wrap( wrappedDriver.findElementByLinkText( using ) );
 	}
 
 	@Override
 	public List<WebElement> findElementsByLinkText( final String using ) {
-		return wrappedDriver.findElementsByLinkText( using );
+		return wrap( wrappedDriver.findElementsByLinkText( using ) );
 	}
 
 	@Override
 	public WebElement findElementByPartialLinkText( final String using ) {
-		return wrappedDriver.findElementByPartialLinkText( using );
+		return wrap( wrappedDriver.findElementByPartialLinkText( using ) );
 	}
 
 	@Override
 	public List<WebElement> findElementsByPartialLinkText( final String using ) {
-		return wrappedDriver.findElementsByPartialLinkText( using );
+		return wrap( wrappedDriver.findElementsByPartialLinkText( using ) );
 	}
 
 	@Override
 	public WebElement findElementByName( final String using ) {
-		return wrappedDriver.findElementByName( using );
+		return wrap( wrappedDriver.findElementByName( using ) );
 	}
 
 	@Override
 	public List<WebElement> findElementsByName( final String using ) {
-		return wrappedDriver.findElementsByName( using );
+		return wrap( wrappedDriver.findElementsByName( using ) );
 	}
 
 	@Override
 	public WebElement findElementByCssSelector( final String using ) {
-		return wrappedDriver.findElementByCssSelector( using );
+		return wrap( wrappedDriver.findElementByCssSelector( using ) );
 	}
 
 	@Override
 	public List<WebElement> findElementsByCssSelector( final String using ) {
-		return wrappedDriver.findElementsByCssSelector( using );
+		return wrap( wrappedDriver.findElementsByCssSelector( using ) );
 	}
 
 	@Override
 	public WebElement findElementByTagName( final String using ) {
-		return wrappedDriver.findElementByTagName( using );
+		return wrap( wrappedDriver.findElementByTagName( using ) );
 	}
 
 	@Override
 	public List<WebElement> findElementsByTagName( final String using ) {
-		return wrappedDriver.findElementsByTagName( using );
+		return wrap( wrappedDriver.findElementsByTagName( using ) );
 	}
 
 	@Override
 	public WebElement findElementByXPath( final String using ) {
-		return wrappedDriver.findElementByXPath( using );
+		return wrap( wrappedDriver.findElementByXPath( using ) );
 	}
 
 	@Override
 	public List<WebElement> findElementsByXPath( final String using ) {
-		return wrappedDriver.findElementsByXPath( using );
+		return wrap( wrappedDriver.findElementsByXPath( using ) );
 	}
 
 	@Override

--- a/src/main/java/de/retest/web/selenium/WrappingWebElement.java
+++ b/src/main/java/de/retest/web/selenium/WrappingWebElement.java
@@ -1,0 +1,130 @@
+package de.retest.web.selenium;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.Dimension;
+import org.openqa.selenium.OutputType;
+import org.openqa.selenium.Point;
+import org.openqa.selenium.Rectangle;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.WrapsDriver;
+import org.openqa.selenium.WrapsElement;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+class WrappingWebElement implements WebElement, WrapsDriver, WrapsElement {
+
+	private final WebDriver driver;
+	private final WebElement element;
+
+	public static WebElement wrap( final WebDriver driver, final WebElement element ) {
+		return new WrappingWebElement( driver, element );
+	}
+
+	@Override
+	public WebDriver getWrappedDriver() {
+		return driver;
+	}
+
+	@Override
+	public WebElement getWrappedElement() {
+		return element;
+	}
+
+	@Override
+	public void click() {
+		element.click();
+	}
+
+	@Override
+	public void submit() {
+		element.submit();
+	}
+
+	@Override
+	public void sendKeys( final CharSequence... keysToSend ) {
+		element.sendKeys( keysToSend );
+	}
+
+	@Override
+	public void clear() {
+		element.clear();
+	}
+
+	@Override
+	public String getTagName() {
+		return element.getTagName();
+	}
+
+	@Override
+	public String getAttribute( final String name ) {
+		return element.getAttribute( name );
+	}
+
+	@Override
+	public boolean isSelected() {
+		return element.isSelected();
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return element.isEnabled();
+	}
+
+	@Override
+	public String getText() {
+		return element.getText();
+	}
+
+	@Override
+	public List<WebElement> findElements( final org.openqa.selenium.By by ) {
+		return element.findElements( by ).stream() //
+				.map( element -> new WrappingWebElement( driver, element ) ) //
+				.collect( Collectors.toList() );
+	}
+
+	@Override
+	public WebElement findElement( final By by ) {
+		return new WrappingWebElement( driver, element.findElement( by ) );
+	}
+
+	@Override
+	public boolean isDisplayed() {
+		return element.isDisplayed();
+	}
+
+	@Override
+	public Point getLocation() {
+		return element.getLocation();
+	}
+
+	@Override
+	public Dimension getSize() {
+		return element.getSize();
+	}
+
+	@Override
+	public Rectangle getRect() {
+		return element.getRect();
+	}
+
+	@Override
+	public String getCssValue( final String propertyName ) {
+		return element.getCssValue( propertyName );
+	}
+
+	@Override
+	public <X> X getScreenshotAs( final OutputType<X> target ) throws WebDriverException {
+		return element.getScreenshotAs( target );
+	}
+
+	@Override
+	public String toString() {
+		return element.toString();
+	}
+}

--- a/src/test/java/de/retest/web/RecheckWebImplTest.java
+++ b/src/test/java/de/retest/web/RecheckWebImplTest.java
@@ -14,7 +14,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WrapsDriver;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.remote.RemoteWebElement;
 
 import de.retest.recheck.RecheckAdapter;
 import de.retest.recheck.RecheckOptions;
@@ -110,6 +113,60 @@ class RecheckWebImplTest {
 		capTestSilently();
 	}
 
+	@Test
+	void check_should_allow_for_web_elements_to_be_passed_which_extracts_the_driver() {
+		re.startTest();
+
+		final WebDriver driver = mock( UnbreakableDriver.class );
+
+		final RemoteWebElement element = mock( RemoteWebElement.class );
+		when( element.getWrappedDriver() ).thenReturn( driver );
+
+		re.check( element, adapter, "element_should_not_throw_exception" );
+
+		assertThat( re.getDriver() ).isEqualTo( driver );
+
+		capTestSilently();
+	}
+
+	@Test
+	void check_should_allow_for_web_elements_to_be_passed_which_extracts_the_wrapped_driver() {
+		re.startTest();
+
+		final WebDriver wrapped = mock( UnbreakableDriver.class );
+
+		final WrappingDriver driver = mock( WrappingDriver.class );
+		when( driver.getWrappedDriver() ).thenReturn( wrapped );
+
+		final RemoteWebElement element = mock( RemoteWebElement.class );
+		when( element.getWrappedDriver() ).thenReturn( driver );
+
+		re.check( element, adapter, "element_should_not_throw_exception" );
+
+		assertThat( re.getDriver() ).isEqualTo( wrapped );
+
+		capTestSilently();
+	}
+
+	@Test
+	void check_should_allow_for_web_elements_to_be_passed_which_extracts_the_legacy_wrapped_driver() {
+		re.startTest();
+
+		final WebDriver wrapped = mock( UnbreakableDriver.class );
+
+		final LegacyWrappingDriver driver = mock( LegacyWrappingDriver.class );
+		when( driver.getWrappedDriver() ).thenReturn( wrapped );
+
+		final RemoteWebElement element = mock( RemoteWebElement.class );
+		when( element.getWrappedDriver() ).thenReturn( driver );
+
+		re.check( element, adapter, "element_should_not_throw_exception" );
+
+		assertThat( re.getDriver() ).isEqualTo( wrapped );
+
+		capTestSilently();
+	}
+
 	private void capTestSilently() {
 		try {
 			re.capTest();
@@ -117,4 +174,8 @@ class RecheckWebImplTest {
 			// expected
 		}
 	}
+
+	interface WrappingDriver extends WebDriver, WrapsDriver {}
+
+	interface LegacyWrappingDriver extends WebDriver, org.openqa.selenium.internal.WrapsDriver {}
 }

--- a/src/test/java/de/retest/web/meta/element/WebElementMetadataProviderTest.java
+++ b/src/test/java/de/retest/web/meta/element/WebElementMetadataProviderTest.java
@@ -10,6 +10,7 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.RemoteWebElement;
 
 import de.retest.recheck.meta.MetadataProvider;
+import de.retest.web.selenium.AutocheckingRecheckDriver;
 import de.retest.web.selenium.AutocheckingWebElement;
 
 class WebElementMetadataProviderTest {
@@ -26,7 +27,7 @@ class WebElementMetadataProviderTest {
 	@Test
 	void of_should_extract_driver_from_wrapped() throws Exception {
 		final AutocheckingWebElement element = mock( AutocheckingWebElement.class );
-		when( element.getWrappedElement() ).thenReturn( mock( RemoteWebElement.class, RETURNS_MOCKS ) );
+		when( element.getWrappedDriver() ).thenReturn( mock( AutocheckingRecheckDriver.class, RETURNS_MOCKS ) );
 
 		final MetadataProvider cut = WebElementMetadataProvider.of( element );
 

--- a/src/test/java/de/retest/web/selenium/AutocheckingWebElementTest.java
+++ b/src/test/java/de/retest/web/selenium/AutocheckingWebElementTest.java
@@ -15,7 +15,7 @@ class AutocheckingWebElementTest {
 	void check_is_skiped_when_skipCheck_is_called() throws Exception {
 		final WebElement delegate = mock( WebElement.class );
 		final AutocheckingRecheckDriver driver = mock( AutocheckingRecheckDriver.class );
-		final AutocheckingWebElement autoCheckElement = new AutocheckingWebElement( delegate, driver );
+		final AutocheckingWebElement autoCheckElement = AutocheckingWebElement.of( delegate, driver );
 
 		autoCheckElement.skipCheck().clear();
 		verify( delegate, times( 1 ) ).clear();
@@ -39,7 +39,7 @@ class AutocheckingWebElementTest {
 	void changing_methods_should_check_and_delegate_calls() {
 		final WebElement delegate = mock( WebElement.class );
 		final AutocheckingRecheckDriver driver = mock( AutocheckingRecheckDriver.class );
-		final AutocheckingWebElement autoCheckElement = new AutocheckingWebElement( delegate, driver );
+		final AutocheckingWebElement autoCheckElement = AutocheckingWebElement.of( delegate, driver );
 
 		autoCheckElement.clear();
 		verify( delegate, times( 1 ) ).clear();
@@ -62,7 +62,7 @@ class AutocheckingWebElementTest {
 	void other_methods_should_delegate_calls() {
 		final WebElement delegate = mock( WebElement.class );
 		final AutocheckingWebElement autoCheckElement =
-				new AutocheckingWebElement( delegate, mock( AutocheckingRecheckDriver.class ) );
+				AutocheckingWebElement.of( delegate, mock( AutocheckingRecheckDriver.class ) );
 
 		autoCheckElement.getAttribute( "test" );
 		verify( delegate, times( 1 ) ).getAttribute( "test" );

--- a/src/test/java/de/retest/web/selenium/UnbreakableDriverIT.java
+++ b/src/test/java/de/retest/web/selenium/UnbreakableDriverIT.java
@@ -1,0 +1,60 @@
+package de.retest.web.selenium;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.openqa.selenium.WebDriver;
+
+import de.retest.recheck.RecheckOptions;
+import de.retest.recheck.persistence.SeparatePathsProjectLayout;
+import de.retest.web.RecheckWebImpl;
+import de.retest.web.RecheckWebOptions;
+import de.retest.web.testutils.WebDriverFactory;
+
+class UnbreakableDriverIT {
+
+	RecheckWebImpl re;
+	WebDriver driver;
+
+	@BeforeEach
+	void setUp( @TempDir final Path project ) {
+		final Path goldenMasterDirectory = project.resolve( "state" );
+		final Path reportDirectory = project.resolve( "report" );
+		final RecheckOptions options = RecheckWebOptions.builder()
+				.projectLayout( new SeparatePathsProjectLayout( goldenMasterDirectory, reportDirectory ) ) //
+				.build();
+
+		re = new RecheckWebImpl( options );
+		driver = new UnbreakableDriver( WebDriverFactory.driver( WebDriverFactory.Driver.CHROME ) );
+	}
+
+	@AfterEach
+	void tearDown() {
+		driver.quit();
+		re.cap();
+	}
+
+	@Test
+	void check_with_web_element_should_properly_identify_the_unbreakable_driver() {
+		re.startTest();
+
+		driver.get( getClass().getResource( "UnbreakableDriverIT.html" ).toExternalForm() );
+
+		assertThatCode( () -> re.check( driver.findElement( By.id( "html" ) ), "element" ) ).doesNotThrowAnyException();
+
+		capTestSilently();
+	}
+
+	private void capTestSilently() {
+		try {
+			re.capTest();
+		} catch ( final AssertionError e ) {
+			// expected
+		}
+	}
+}

--- a/src/test/resources/de/retest/web/selenium/UnbreakableDriverIT.html
+++ b/src/test/resources/de/retest/web/selenium/UnbreakableDriverIT.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html id="html" lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Title</title>
+</head>
+<body>
+</body>
+</html>


### PR DESCRIPTION
*Before submission, please check that ...*

- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [x] the necessary tests are either created or updated.
- [ ] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [x] you updated the changelog.
- [x] ~you updated necessary documentation within [retest/docs](https://github.com/retest/docs).~

<!-- Note: You can always ask a maintainer to help you with the above tasks. -->

## Description

> TL;DR Elements cannot be passed into RecheckWebImpl as discussed [here](https://github.com/retest/recheck/issues/661#issuecomment-591451731)

This fixes the issue of not being able to pass elements into `RecheckWebImpl`. As it tries to identify the `UnbreakableDriver` from the called object, which obviously fails to identify the driver from an element. Thus an exception is thrown for `loadExpected`.

To fix this, the `RecheckWebImpl` will now query `WrapsDriver` to try to identify the driver within other wrapped drivers. In theory this should work for `RemoteWebElements` as returned by any driver, since they implement `WrapsDriver`. However, the driver is not the `UnbreakableDriver` but the `ChromeDriver`.

This can be resolved, by returning a custom web element that implements both `WrapsElement` and `WrapsDriver`. The former to allow the `SeleniumRecheckAdapter` to find the wrapped element (as returned by the `ChromeDriver`) and the a latter allows the `RecheckWebImpl` to find the driver (`UnbreakableDriver`).

### State of this PR

I did not implement that for the `AutocheckingDriver` or the `RecheckDriver` as both should never pass an element (although in theory, this should work since the extend from `UnbreakableDriver`) and the user should never manually call `re.check(autocheckingDriver.findElementBy(By.id("foo"))` (although we do not explicitly forbid this for elements as of yet...).

In theory, this should not break any existing tests. However, there seem currently tests breaking of which I assume that they are from a browser update. I will need to investigate that before approval.

### Additional Context

This was discovered by retest/recheck#661.