### PR TITLE
Do not upload reports to rehub by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -292,9 +292,6 @@
 					<!-- combine Surefire and Failsafe reports for SonarCloud -->
 					<!-- see https://stackoverflow.com/a/15567782 -->
 					<reportsDirectory>${project.build.directory}/surefire-reports/</reportsDirectory>
-					<systemPropertyVariables>
-						<de.retest.recheck.rehub.reportUploadEnabled>true</de.retest.recheck.rehub.reportUploadEnabled>
-					</systemPropertyVariables>
 				</configuration>
 				<executions>
 					<execution>


### PR DESCRIPTION
This property can be set on demand via MVN_ARGS env variable.