### PR TITLE
Fix/update recheck

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
 		<dependency>
 			<groupId>de.retest</groupId>
 			<artifactId>recheck</artifactId>
-			<version>1.10.0-beta.1</version>
+			<version>1.10.0-beta.2</version>
 		</dependency>
 
 		<dependency>

--- a/src/test/java/de/retest/web/it/RecheckRemoteWebElementFailingIT.java
+++ b/src/test/java/de/retest/web/it/RecheckRemoteWebElementFailingIT.java
@@ -47,8 +47,8 @@ class RecheckRemoteWebElementFailingIT {
 			re.capTest();
 			fail( MISSING_ASSERTION_MSG );
 		} catch ( final AssertionError e ) {
-			Assertions.assertThat( e ).hasMessageContaining(
-					"html[1]/body[1]/form[3]/select[2]/option[5] at 'html[1]/body[1]/form[3]/select[2]/option[5]':\n"
+			Assertions.assertThat( e )
+					.hasMessageContaining( "option (option) at 'html[1]/body[1]/form[3]/select[2]/option[5]':\n" // 
 							+ "\t\twas inserted" );
 		}
 	}
@@ -72,7 +72,7 @@ class RecheckRemoteWebElementFailingIT {
 			fail( MISSING_ASSERTION_MSG );
 		} catch ( final AssertionError e ) {
 			Assertions.assertThat( e ).hasMessageContaining(
-					"option [Onion gravy] at 'html[1]/body[1]/form[3]/select[2]/option[4]':\n		was deleted" );
+					"option (onion_gravy) at 'html[1]/body[1]/form[3]/select[2]/option[4]':\n		was deleted" );
 		}
 	}
 

--- a/src/test/java/de/retest/web/it/RootElementPeerNullIT.java
+++ b/src/test/java/de/retest/web/it/RootElementPeerNullIT.java
@@ -58,7 +58,7 @@ class RootElementPeerNullIT {
 
 		assertThatThrownBy( () -> re.capTest() ) //
 				.isInstanceOf( AssertionError.class ) //
-				.hasMessageContaining( "html[1]/body[1]/div[1]/nav[1] at 'html[1]/body[1]/div[1]/nav[1]':\n" //
+				.hasMessageContaining( "nav (html[1]/body[1]/div[1]/nav[1]) at 'html[1]/body[1]/div[1]/nav[1]':\n" //
 						+ "\t\twas inserted" );
 	}
 }

--- a/src/test/java/de/retest/web/it/SimplePageDiffIT.java
+++ b/src/test/java/de/retest/web/it/SimplePageDiffIT.java
@@ -37,17 +37,17 @@ public class SimplePageDiffIT {
 			fail( "Assertion Error expected" );
 		} catch ( final AssertionError e ) {
 			assertThat( e ).hasMessageContaining( "Test 'testSimpleChange' has 4 difference(s) in 1 state(s):" ) //
-					.hasMessageEndingWith( "\tdiv [twoblocks] at 'html[1]/body[1]/div[3]':\n" //
+					.hasMessageEndingWith( "\tdiv (div-5f5f0) at 'html[1]/body[1]/div[3]':\n" //
 							+ "\t\tid:\n" //
 							+ "\t\t  expected=\"twoblocks\",\n" //
 							+ "\t\t    actual=\"changedblock\"\n" //
-							+ "\tp [Some text] at 'html[1]/body[1]/div[3]/p[1]':\n" //
+							+ "\tp (some_text) at 'html[1]/body[1]/div[3]/p[1]':\n" //
 							+ "\t\ttext:\n" //
 							+ "\t\t  expected=\"Some text\",\n" //
 							+ "\t\t    actual=\"Some changed text\"\n" //
-							+ "\tp [Some more text] at 'html[1]/body[1]/div[3]/p[2]':\n" //
+							+ "\tp (some_more_text) at 'html[1]/body[1]/div[3]/p[2]':\n" //
 							+ "\t\twas deleted\n" //
-							+ "\th2 [Subheading] at 'html[1]/body[1]/h2[1]':\n" //
+							+ "\th2 (subheading) at 'html[1]/body[1]/h2[1]':\n" //
 							+ "\t\twas inserted" );
 		}
 	}


### PR DESCRIPTION
The text was now changed to include `{$tag} (${retestID})` (see retest/recheck#667)