### PR TITLE
Add skipCheck() method to our drivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Table of Contents
 
 ### New Features
 
+* Introduce a `skipCheck()` method on `RecheckDriver`, `AutocheckingRecheckDriver`, and `UnbreakableDriver`, which is an alias for `getWrappedDriver()`, making it possible signal a clearer intent when writing tests.
+
 ### Improvements
 
 

--- a/src/main/java/de/retest/web/selenium/UnbreakableDriver.java
+++ b/src/main/java/de/retest/web/selenium/UnbreakableDriver.java
@@ -291,4 +291,13 @@ public class UnbreakableDriver implements WebDriver, JavascriptExecutor, FindsBy
 		}
 		return wrappedDriver;
 	}
+
+	/**
+	 * Skip checks for actions performed on this web driver. Alias for {@link #getWrappedDriver()}.
+	 *
+	 * @return the {@link WebDriver} wrapped by this instance
+	 */
+	public WebDriver skipCheck() {
+		return getWrappedDriver();
+	}
 }


### PR DESCRIPTION
*Before submission, please check that ...*

- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [ ] ~the necessary tests are either created or updated.~
- [ ] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [x] you updated the changelog.
- [ ] ~you updated necessary documentation within [retest/docs](https://github.com/retest/docs).~

## Description

Provides an alias for `getWrappedDriver()` in oder to make usage for skipping checks more apparent.

There doesn't seem to be usage of `getWrappedDriver()` in the documentation so far, maybe an example should be added somewhere.

### State of this PR

All done.