### PR TITLE
[DRAFT] Feature/retestid without gm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Table of Contents
 
 ### Improvements
 
+* Since `retestId` is now created deterministically, we can reference it before we even have a Golden Master. So if you know what the `retestId` will gona be (e.g. your element has a specific text, HTML ID or you have your own `RetestIdProvider`), you can already use it in the test. 
 
 --------------------------------------------------------------------------------
 

--- a/src/main/java/de/retest/web/selenium/By.java
+++ b/src/main/java/de/retest/web/selenium/By.java
@@ -31,7 +31,7 @@ public abstract class By extends org.openqa.selenium.By {
 		return resultFromActual.applyRetestId( resultFromExpected.getRetestId() );
 	}
 
-	private static Element findElement( final List<Element> children, final Predicate<Element> predicate ) {
+	public static Element findElement( final List<Element> children, final Predicate<Element> predicate ) {
 		for ( final Element element : children ) {
 			if ( predicate.test( element ) ) {
 				return element;

--- a/src/main/java/de/retest/web/selenium/ByBestMatchToRetestId.java
+++ b/src/main/java/de/retest/web/selenium/ByBestMatchToRetestId.java
@@ -52,6 +52,11 @@ public class ByBestMatchToRetestId extends By implements Serializable {
 	 * @return Maybe an element whose children have a different retest ID than in the Golden Master.
 	 */
 	public Element findElement( final RootElement lastExpectedState, final RootElement lastActualState ) {
+		if ( lastExpectedState == null ) {
+			// find by retestId even in case of just creating the state
+			return de.retest.web.selenium.By.findElement( lastActualState.getContainedElements(),
+					element -> retestId.equals( element.getRetestId() ) );
+		}
 		final Element result = de.retest.web.selenium.By.findElement( lastExpectedState, lastActualState,
 				element -> retestId.equals( element.getRetestId() ) );
 		if ( result == null ) {

--- a/src/main/java/de/retest/web/selenium/UnbreakableDriver.java
+++ b/src/main/java/de/retest/web/selenium/UnbreakableDriver.java
@@ -64,10 +64,6 @@ public class UnbreakableDriver implements WebDriver, JavascriptExecutor, FindsBy
 	}
 
 	public WebElement findElement( final ByBestMatchToRetestId by ) {
-		if ( lastExpectedState == null ) {
-			throw new IllegalStateException( "You must use the " + RecheckWebImpl.class.getSimpleName()
-					+ " and first check the state before being able to use the retest ID locator." );
-		}
 		final Element searchedFor = by.findElement( lastExpectedState, lastActualState );
 		final WebElement element =
 				wrappedDriver.findElement( By.xpath( searchedFor.getIdentifyingAttributes().getPath() ) );


### PR DESCRIPTION
- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [ ] the necessary tests are either created or updated.
- [x] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [x] you updated the changelog.
- [ ] you updated necessary documentation within [retest/docs](https://github.com/retest/docs).

Since `retestId` is now created deterministically, we can reference it before we even have a Golden Master. This is gonna be helpful in a variety of situations, but especially when generating Surili tests.