### PR TITLE
Always return instance of RecheckWebOptionsBuilder when building with it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Table of Contents
 
 ### Bug Fixes
 
+* `RecheckWebOptionsBuilder` now overrides all parent methods to return an instance of `RecheckWebOptionsBuilder`. Before that, using methods from the parent would effectively shadow methods from `RecheckWebOptionsBuilder`.
+
 ### New Features
 
 * Introduce a `skipCheck()` method on `RecheckDriver`, `AutocheckingRecheckDriver`, and `UnbreakableDriver`, which is an alias for `getWrappedDriver()`, making it possible signal a clearer intent when writing tests.

--- a/src/main/java/de/retest/web/RecheckWebOptions.java
+++ b/src/main/java/de/retest/web/RecheckWebOptions.java
@@ -1,6 +1,9 @@
 package de.retest.web;
 
 import de.retest.recheck.RecheckOptions;
+import de.retest.recheck.persistence.NamingStrategy;
+import de.retest.recheck.persistence.ProjectLayout;
+import de.retest.recheck.ui.descriptors.idproviders.RetestIdProvider;
 import de.retest.web.screenshot.ScreenshotProvider;
 import de.retest.web.screenshot.ScreenshotProviders;
 import de.retest.web.selenium.AutocheckingCheckNamingStrategy;
@@ -72,6 +75,54 @@ public class RecheckWebOptions extends RecheckOptions {
 		 */
 		public RecheckWebOptionsBuilder enableScreenshots() {
 			return screenshotProvider( ScreenshotProviders.DEFAULT );
+		}
+
+		@Override
+		public RecheckWebOptionsBuilder namingStrategy( final NamingStrategy namingStrategy ) {
+			super.namingStrategy( namingStrategy );
+			return this;
+		}
+
+		@Override
+		public RecheckWebOptionsBuilder projectLayout( final ProjectLayout projectLayout ) {
+			super.projectLayout( projectLayout );
+			return this;
+		}
+
+		@Override
+		public RecheckWebOptionsBuilder suiteName( final String suiteName ) {
+			super.suiteName( suiteName );
+			return this;
+		}
+
+		@Override
+		public RecheckWebOptionsBuilder enableReportUpload() {
+			super.enableReportUpload();
+			return this;
+		}
+
+		@Override
+		public RecheckWebOptionsBuilder setIgnore( final String filterName ) {
+			super.setIgnore( filterName );
+			return this;
+		}
+
+		@Override
+		public RecheckWebOptionsBuilder ignoreNothing() {
+			super.ignoreNothing();
+			return this;
+		}
+
+		@Override
+		public RecheckWebOptionsBuilder addIgnore( final String filterName ) {
+			super.addIgnore( filterName );
+			return this;
+		}
+
+		@Override
+		public RecheckWebOptionsBuilder retestIdProvider( final RetestIdProvider retestIdProvider ) {
+			super.retestIdProvider( retestIdProvider );
+			return this;
 		}
 
 		@Override


### PR DESCRIPTION
*Before submission, please check that ...*

- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [ ] ~the necessary tests are either created or updated.~
- [x] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [x] you updated the changelog.
- [x] you updated necessary documentation within [retest/docs](https://github.com/retest/docs).

<!-- Note: You can always ask a maintainer to help you with the above tasks. -->

## Description

Override methods on the parent builder (`RecheckOptionsBuilder`) and always return an instance of `RecheckWebOptionsBuilder`.

### State of this PR

There is a reference to the old behaviour in the documentation, I'll post a PR there shortly.