### PR TITLE
Update recheck-web using Jitpack

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
 		<dependency>
 			<groupId>de.retest</groupId>
 			<artifactId>recheck</artifactId>
-			<version>1.11.0</version>
+			<version>eea473b84e94921272fc1856ad5e2c5cc28a3371</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
 TL;DR

Only change is setting the Jitpack version, so someone can use recheck-web with the latest recheck changes (i.e. metadata-ignore).
