### PR TITLE
Feature/fix close quits driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Table of Contents
 
 ### Bug Fixes
 
+* Fix `AutocheckingRecheckDriver#close` and `AutocheckingRecheckDriver#quit` competing with the recheck lifecycle. This now requires that both lifecycles are called properly. Hint: Use the recheck extensions for the latter.
+
 ### New Features
 
 ### Improvements

--- a/src/main/java/de/retest/web/selenium/AutocheckingRecheckDriver.java
+++ b/src/main/java/de/retest/web/selenium/AutocheckingRecheckDriver.java
@@ -96,23 +96,6 @@ public class AutocheckingRecheckDriver extends UnbreakableDriver implements Rech
 	}
 
 	@Override
-	public void close() {
-		// Is this sensible? What about tests using separate sessions?
-		cap();
-		super.close();
-	}
-
-	@Override
-	public void quit() {
-		try {
-			// Is this sensible? What about tests using separate sessions?
-			cap();
-		} finally {
-			super.quit();
-		}
-	}
-
-	@Override
 	protected WebElement wrap( final WebElement element ) {
 		return AutocheckingWebElement.of( element, this );
 	}

--- a/src/test/java/de/retest/web/it/SimpleAutocheckingDriverShowcaseIT.java
+++ b/src/test/java/de/retest/web/it/SimpleAutocheckingDriverShowcaseIT.java
@@ -54,6 +54,7 @@ public class SimpleAutocheckingDriverShowcaseIT {
 	@After
 	public void tearDown() {
 		driver.quit();
+		driver.cap();
 	}
 
 }

--- a/src/test/java/de/retest/web/it/WikipediaIT.java
+++ b/src/test/java/de/retest/web/it/WikipediaIT.java
@@ -41,7 +41,7 @@ class WikipediaIT {
 
 	@AfterEach
 	void tearDown() throws Exception {
-		driver.close();
+		driver.quit();
 	}
 
 }


### PR DESCRIPTION
*Before submission, please check that ...*

- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [x] the necessary tests are either created or updated.
- [x] all status checks (GitHub Actions, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [x] you updated the changelog.
- [x] ~you updated necessary documentation within [retest/docs](https://github.com/retest/docs).~ *Should be noted in several places to call the recheck lifecycle*

<!-- Note: You can always ask a maintainer to help you with the above tasks. -->

## Description

> TL;DR Do not mix the recheck lifecycle and driver lifecycle to prevent strange side-effects.

When experimenting with multiple open windows and tabs, I noticed that some strange behavior when closing some windows and tabs (via `driver.close()`)  and using the `RecheckDriver`, where in some instances `driver.close()` quit the whole driver instead of just closing the tab.

These issue solely appears when the `Recheck` instance is managed by an `AutocheckingRecheckDriver`.

### State of this PR

While I understand the intention of just using the `WebDriver` like you are used to (without calling specific recheck functions), the mixing of both lifecycles caused some weird behavior on side of recheck. 

I would therefore argue that you should use the extensions to handle the recheck lifecycle and call the driver lifecycle like you are used to. However, I am open for discussion (especially the `quit` method).

Since the documentation mentions on several pages to properly call the recheck lifecycle, I would not consider this a breaking change, because it should not hurt to call the lifecycle multiple times (as was the case when using a recheck extension).
