### PR TITLE
Feature/enable report upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,3 +51,5 @@ jobs:
         -Dsonar.host.url=https://sonarcloud.io
         -Dsonar.organization=retest
         -Dsonar.projectKey=de.retest:recheck-web
+      env:
+        RECHECK_API_KEY: ${{ secrets.RECHECK_API_KEY }}

--- a/.retest/retest.properties
+++ b/.retest/retest.properties
@@ -1,2 +1,3 @@
 de.retest.recheck.ignore.attributes=absolute-outline
 de.retest.recheck.web.screenshot.provider=none
+de.retest.recheck.rehub.reportUploadEnabled=true


### PR DESCRIPTION
*Before submission, please check that ...*

- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [x] ~the necessary tests are either created or updated.~
- [ ] all status checks (GitHub Actions, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [x] ~you updated the changelog.~
- [x] ~you updated necessary documentation within [retest/docs](https://github.com/retest/docs).~

<!-- Note: You can always ask a maintainer to help you with the above tasks. -->

## Description

> TL;DR Enable report uploads again to allow GM repairs

Since tests are currently failing, we need to enable the report upload again, as running them locally might not produce the same result. Thus I have added the respective property and make the `RECHECK_API_KEY` accessible for a GitHub Action.

The `RECHECK_API_KEY` is only added for the test step to minimize exposure time and make it more clear where the key is actually used.

### State of this PR

There are multiple ways that we could go about this:

1. Use the below `retest.properties` and add the property: Adjusting would, however, require a new branch (in a rare case the upload would break, etc.).
2. Use maven arguments and add a secret: We have discussed this briefly when we removed the report upload from Travis, since we have used maven arguments there, but we never implemented that because we saw no use at that time. However, GitHubs' encrypted secrets seem a bit overkill, but there is no alternative as far as I am aware of.

This should work, but the `RECHECK_API_KEY` for our team account must be added before to be sure the upload actually works.

```log
java.lang.AssertionError: Please set a valid recheck API key within the environment, using 'RECHECK_API_KEY'.
	at de.retest.web.it.FormPageIT.setUp(FormPageIT.java:26)
```

In order for this to be merged, the upcoming PR for the test repair must be merged first to ensure a passing build.