### PR TITLE
Check sides instead of corners for isCovered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Table of Contents
 ### Improvements
 
 * Keep the order of the HTML elements preserved in the underlying result (internal change), which makes a couple things easier.
+* Change how covered elements are detected in order to handle rounded buttons
 
 
 [1.10.3] (2020-03-16)

--- a/src/main/resources/javascript/getAllElementsByPath.js
+++ b/src/main/resources/javascript/getAllElementsByPath.js
@@ -189,7 +189,7 @@ var cssAttributes = [
 var ELEMENT_NODE = 1;
 var TEXT_NODE = 3;
 var DOCUMENT_TYPE_NODE = 10;
-const BOUNDING_PRECISION = 2;
+const BOUNDING_PRECISION = 1;
 
 var Counter = /** @class */ (function () {
     function Counter() {
@@ -299,23 +299,19 @@ function hasAutofocus(node) {
 function isCovered(node) {
     // TODO Handle false negatives for elements outside of viewport
     if (typeof node.getBoundingClientRect === "function") {
-	    var boundingRect = node.getBoundingClientRect();
+        var boundingRect = node.getBoundingClientRect();
 
-	    var boundingLeft = boundingRect.left + BOUNDING_PRECISION;
-	    var boundingRight = boundingRect.right - BOUNDING_PRECISION;
-	    var boundingTop = boundingRect.top + BOUNDING_PRECISION;
-	    var boundingBottom = boundingRect.bottom - BOUNDING_PRECISION;
-	
-	    var topLeft = document.elementFromPoint(boundingLeft, boundingTop);
-	    var topRight = document.elementFromPoint(boundingRight, boundingTop);
-	    var bottomLeft = document.elementFromPoint(boundingLeft, boundingBottom);
-	    var bottomRight = document.elementFromPoint(boundingRight, boundingBottom);
-	    if ((topLeft != null && !node.contains(topLeft))
-	    	|| (topRight != null && !node.contains(topRight))
-	    	|| (bottomLeft != null && !node.contains(bottomLeft)) 
-	    	|| (bottomRight != null && !node.contains(bottomRight))) {
-	        return true;
-	    }
+        var top = document.elementFromPoint(boundingRect.left + (boundingRect.width / 2), boundingRect.top + BOUNDING_PRECISION);
+        var bottom = document.elementFromPoint(boundingRect.left + (boundingRect.width / 2), boundingRect.bottom - BOUNDING_PRECISION);
+        var left = document.elementFromPoint(boundingRect.left + BOUNDING_PRECISION, boundingRect.top + (boundingRect.height / 2));
+        var right = document.elementFromPoint(boundingRect.right - BOUNDING_PRECISION, boundingRect.top + (boundingRect.height / 2));
+
+        if ((top != null && !node.contains(top))
+            && (bottom != null && !node.contains(bottom))
+            && (left != null && !node.contains(left))
+            && (right != null && !node.contains(right))) {
+            return true;
+        }
     }
 
     return false;

--- a/src/test/resources/retest/recheck/de.retest.web.RecheckSeleniumAdapterIT/warnings_should_be_notified_properly_on_breaking_change.a.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.RecheckSeleniumAdapterIT/warnings_should_be_notified_properly_on_breaking_change.a.recheck/retest.xml
@@ -65,7 +65,7 @@
 					<attributes>
 						<entry>
 							<key>covered</key>
-							<value xsi:type="xsd:string">true</value>
+							<value xsi:type="xsd:string">false</value>
 						</entry>
 						<entry>
 							<key>shown</key>
@@ -98,7 +98,7 @@
 						<attributes>
 							<entry>
 								<key>covered</key>
-								<value xsi:type="xsd:string">true</value>
+								<value xsi:type="xsd:string">false</value>
 							</entry>
 							<entry>
 								<key>shown</key>

--- a/src/test/resources/retest/recheck/de.retest.web.RecheckSeleniumAdapterIT/warnings_should_be_notified_properly_on_breaking_change.b.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.RecheckSeleniumAdapterIT/warnings_should_be_notified_properly_on_breaking_change.b.recheck/retest.xml
@@ -65,7 +65,7 @@
 					<attributes>
 						<entry>
 							<key>covered</key>
-							<value xsi:type="xsd:string">true</value>
+							<value xsi:type="xsd:string">false</value>
 						</entry>
 						<entry>
 							<key>shown</key>
@@ -98,7 +98,7 @@
 						<attributes>
 							<entry>
 								<key>covered</key>
-								<value xsi:type="xsd:string">true</value>
+								<value xsi:type="xsd:string">false</value>
 							</entry>
 							<entry>
 								<key>shown</key>

--- a/src/test/resources/retest/recheck/de.retest.web.RecheckSeleniumAdapterIT/warnings_should_be_notified_properly_on_breaking_change.open.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.RecheckSeleniumAdapterIT/warnings_should_be_notified_properly_on_breaking_change.open.recheck/retest.xml
@@ -65,7 +65,7 @@
 					<attributes>
 						<entry>
 							<key>covered</key>
-							<value xsi:type="xsd:string">true</value>
+							<value xsi:type="xsd:string">false</value>
 						</entry>
 						<entry>
 							<key>shown</key>
@@ -98,7 +98,7 @@
 						<attributes>
 							<entry>
 								<key>covered</key>
-								<value xsi:type="xsd:string">true</value>
+								<value xsi:type="xsd:string">false</value>
 							</entry>
 							<entry>
 								<key>shown</key>

--- a/src/test/resources/retest/recheck/de.retest.web.it.FormPageIT/form-page-ChromeDriver.open.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.it.FormPageIT/form-page-ChromeDriver.open.recheck/retest.xml
@@ -8542,7 +8542,7 @@
 					<attributes>
 						<entry>
 							<key>covered</key>
-							<value xsi:type="xsd:string">true</value>
+							<value xsi:type="xsd:string">false</value>
 						</entry>
 						<entry>
 							<key>shown</key>
@@ -8575,7 +8575,7 @@
 						<attributes>
 							<entry>
 								<key>covered</key>
-								<value xsi:type="xsd:string">true</value>
+								<value xsi:type="xsd:string">false</value>
 							</entry>
 							<entry>
 								<key>shown</key>

--- a/src/test/resources/retest/recheck/de.retest.web.it.FormPageIT/form-page-FirefoxDriver.open.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.it.FormPageIT/form-page-FirefoxDriver.open.recheck/retest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<reTestXmlDataContainer xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" reTestVersion="1.10.2" dataType="de.retest.recheck.ui.descriptors.SutState" dataTypeVersion="4">
+<reTestXmlDataContainer xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" reTestVersion="1.11.1" dataType="de.retest.recheck.ui.descriptors.SutState" dataTypeVersion="4">
 	<data xsi:type="sutState">
 		<descriptors retestId="html" screenId="1" screen="We Leave From Here" title="We Leave From Here">
 			<identifyingAttributes>
@@ -9342,7 +9342,7 @@
 					<attributes>
 						<entry>
 							<key>covered</key>
-							<value xsi:type="xsd:string">true</value>
+							<value xsi:type="xsd:string">false</value>
 						</entry>
 						<entry>
 							<key>shown</key>
@@ -9375,7 +9375,7 @@
 						<attributes>
 							<entry>
 								<key>covered</key>
-								<value xsi:type="xsd:string">true</value>
+								<value xsi:type="xsd:string">false</value>
 							</entry>
 							<entry>
 								<key>shown</key>

--- a/src/test/resources/retest/recheck/de.retest.web.it.FramePageIT/frame-page-ChromeDriver.open.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.it.FramePageIT/frame-page-ChromeDriver.open.recheck/retest.xml
@@ -77,7 +77,7 @@
 					<attributes>
 						<entry>
 							<key>covered</key>
-							<value xsi:type="xsd:string">true</value>
+							<value xsi:type="xsd:string">false</value>
 						</entry>
 						<entry>
 							<key>shown</key>
@@ -110,7 +110,7 @@
 						<attributes>
 							<entry>
 								<key>covered</key>
-								<value xsi:type="xsd:string">true</value>
+								<value xsi:type="xsd:string">false</value>
 							</entry>
 							<entry>
 								<key>shown</key>
@@ -59582,7 +59582,7 @@
 																			<attributes>
 																				<entry>
 																					<key>covered</key>
-																					<value xsi:type="xsd:string">true</value>
+																					<value xsi:type="xsd:string">false</value>
 																				</entry>
 																				<entry>
 																					<key>shown</key>

--- a/src/test/resources/retest/recheck/de.retest.web.it.FramePageIT/frame-page-FirefoxDriver.open.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.it.FramePageIT/frame-page-FirefoxDriver.open.recheck/retest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<reTestXmlDataContainer xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" reTestVersion="1.10.2" dataType="de.retest.recheck.ui.descriptors.SutState" dataTypeVersion="4">
+<reTestXmlDataContainer xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" reTestVersion="1.11.1" dataType="de.retest.recheck.ui.descriptors.SutState" dataTypeVersion="4">
 	<data xsi:type="sutState">
 		<descriptors retestId="html" screenId="1" screen="Multi Frame" title="Multi Frame">
 			<identifyingAttributes>
@@ -85,7 +85,7 @@
 					<attributes>
 						<entry>
 							<key>covered</key>
-							<value xsi:type="xsd:string">true</value>
+							<value xsi:type="xsd:string">false</value>
 						</entry>
 						<entry>
 							<key>shown</key>
@@ -118,7 +118,7 @@
 						<attributes>
 							<entry>
 								<key>covered</key>
-								<value xsi:type="xsd:string">true</value>
+								<value xsi:type="xsd:string">false</value>
 							</entry>
 							<entry>
 								<key>shown</key>
@@ -59491,7 +59491,7 @@
 																					<attributes>
 																						<entry>
 																							<key>covered</key>
-																							<value xsi:type="xsd:string">true</value>
+																							<value xsi:type="xsd:string">false</value>
 																						</entry>
 																						<entry>
 																							<key>shown</key>
@@ -59523,7 +59523,7 @@
 																						<attributes>
 																							<entry>
 																								<key>covered</key>
-																								<value xsi:type="xsd:string">true</value>
+																								<value xsi:type="xsd:string">false</value>
 																							</entry>
 																							<entry>
 																								<key>shown</key>
@@ -59560,7 +59560,7 @@
 																						<attributes>
 																							<entry>
 																								<key>covered</key>
-																								<value xsi:type="xsd:string">true</value>
+																								<value xsi:type="xsd:string">false</value>
 																							</entry>
 																							<entry>
 																								<key>shown</key>
@@ -59597,7 +59597,7 @@
 																						<attributes>
 																							<entry>
 																								<key>covered</key>
-																								<value xsi:type="xsd:string">true</value>
+																								<value xsi:type="xsd:string">false</value>
 																							</entry>
 																							<entry>
 																								<key>shown</key>
@@ -59634,7 +59634,7 @@
 																						<attributes>
 																							<entry>
 																								<key>covered</key>
-																								<value xsi:type="xsd:string">true</value>
+																								<value xsi:type="xsd:string">false</value>
 																							</entry>
 																							<entry>
 																								<key>shown</key>
@@ -59674,7 +59674,7 @@
 																			<attributes>
 																				<entry>
 																					<key>covered</key>
-																					<value xsi:type="xsd:string">true</value>
+																					<value xsi:type="xsd:string">false</value>
 																				</entry>
 																				<entry>
 																					<key>shown</key>

--- a/src/test/resources/retest/recheck/de.retest.web.it.RecheckRemoteWebElementIT/empty-article-FirefoxDriver.open.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.it.RecheckRemoteWebElementIT/empty-article-FirefoxDriver.open.recheck/retest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<reTestXmlDataContainer xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" reTestVersion="1.10.2" dataType="de.retest.recheck.ui.descriptors.SutState" dataTypeVersion="4">
+<reTestXmlDataContainer xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" reTestVersion="1.11.1" dataType="de.retest.recheck.ui.descriptors.SutState" dataTypeVersion="4">
 	<data xsi:type="sutState">
 		<descriptors retestId="article" screenId="1" screen="WebElement" title="html[1]/body[1]/article[1]">
 			<identifyingAttributes>
@@ -25,7 +25,7 @@
 				<attributes>
 					<entry>
 						<key>covered</key>
-						<value xsi:type="xsd:string">true</value>
+						<value xsi:type="xsd:string">false</value>
 					</entry>
 					<entry>
 						<key>shown</key>

--- a/src/test/resources/retest/recheck/de.retest.web.it.RecheckRemoteWebElementIT/findElement-equals-driver-ChromeDriver.open.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.it.RecheckRemoteWebElementIT/findElement-equals-driver-ChromeDriver.open.recheck/retest.xml
@@ -8538,7 +8538,7 @@
 					<attributes>
 						<entry>
 							<key>covered</key>
-							<value xsi:type="xsd:string">true</value>
+							<value xsi:type="xsd:string">false</value>
 						</entry>
 						<entry>
 							<key>shown</key>
@@ -8571,7 +8571,7 @@
 						<attributes>
 							<entry>
 								<key>covered</key>
-								<value xsi:type="xsd:string">true</value>
+								<value xsi:type="xsd:string">false</value>
 							</entry>
 							<entry>
 								<key>shown</key>

--- a/src/test/resources/retest/recheck/de.retest.web.it.RecheckRemoteWebElementIT/findElement-equals-driver-FirefoxDriver.open.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.it.RecheckRemoteWebElementIT/findElement-equals-driver-FirefoxDriver.open.recheck/retest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<reTestXmlDataContainer xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" reTestVersion="1.10.2" dataType="de.retest.recheck.ui.descriptors.SutState" dataTypeVersion="4">
+<reTestXmlDataContainer xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" reTestVersion="1.11.1" dataType="de.retest.recheck.ui.descriptors.SutState" dataTypeVersion="4">
 	<data xsi:type="sutState">
 		<descriptors retestId="html" screenId="1" screen="We Leave From Here" title="We Leave From Here">
 			<identifyingAttributes>
@@ -9338,7 +9338,7 @@
 					<attributes>
 						<entry>
 							<key>covered</key>
-							<value xsi:type="xsd:string">true</value>
+							<value xsi:type="xsd:string">false</value>
 						</entry>
 						<entry>
 							<key>shown</key>
@@ -9371,7 +9371,7 @@
 						<attributes>
 							<entry>
 								<key>covered</key>
-								<value xsi:type="xsd:string">true</value>
+								<value xsi:type="xsd:string">false</value>
 							</entry>
 							<entry>
 								<key>shown</key>

--- a/src/test/resources/retest/recheck/de.retest.web.it.ShowcaseIT/showcase-ChromeDriver.open.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.it.ShowcaseIT/showcase-ChromeDriver.open.recheck/retest.xml
@@ -4156,7 +4156,7 @@
 														</entry>
 														<entry>
 															<key>covered</key>
-															<value xsi:type="xsd:string">true</value>
+															<value xsi:type="xsd:string">false</value>
 														</entry>
 														<entry>
 															<key>outline-color</key>
@@ -8832,7 +8832,7 @@
 													</entry>
 													<entry>
 														<key>covered</key>
-														<value xsi:type="xsd:string">true</value>
+														<value xsi:type="xsd:string">false</value>
 													</entry>
 													<entry>
 														<key>data-target</key>
@@ -8994,7 +8994,7 @@
 											<attributes>
 												<entry>
 													<key>covered</key>
-													<value xsi:type="xsd:string">true</value>
+													<value xsi:type="xsd:string">false</value>
 												</entry>
 												<entry>
 													<key>display</key>
@@ -9099,7 +9099,7 @@
 														</entry>
 														<entry>
 															<key>covered</key>
-															<value xsi:type="xsd:string">true</value>
+															<value xsi:type="xsd:string">false</value>
 														</entry>
 														<entry>
 															<key>display</key>
@@ -10570,7 +10570,7 @@
 											<attributes>
 												<entry>
 													<key>covered</key>
-													<value xsi:type="xsd:string">true</value>
+													<value xsi:type="xsd:string">false</value>
 												</entry>
 												<entry>
 													<key>display</key>
@@ -11277,7 +11277,7 @@
 														</entry>
 														<entry>
 															<key>covered</key>
-															<value xsi:type="xsd:string">true</value>
+															<value xsi:type="xsd:string">false</value>
 														</entry>
 														<entry>
 															<key>display</key>
@@ -11571,7 +11571,7 @@
 					<attributes>
 						<entry>
 							<key>covered</key>
-							<value xsi:type="xsd:string">true</value>
+							<value xsi:type="xsd:string">false</value>
 						</entry>
 						<entry>
 							<key>prefix</key>
@@ -12167,7 +12167,7 @@
 						<attributes>
 							<entry>
 								<key>covered</key>
-								<value xsi:type="xsd:string">true</value>
+								<value xsi:type="xsd:string">false</value>
 							</entry>
 							<entry>
 								<key>shown</key>

--- a/src/test/resources/retest/recheck/de.retest.web.it.ShowcaseIT/showcase-FirefoxDriver.open.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.it.ShowcaseIT/showcase-FirefoxDriver.open.recheck/retest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<reTestXmlDataContainer xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" reTestVersion="1.10.2" dataType="de.retest.recheck.ui.descriptors.SutState" dataTypeVersion="4">
+<reTestXmlDataContainer xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" reTestVersion="1.11.1" dataType="de.retest.recheck.ui.descriptors.SutState" dataTypeVersion="4">
 	<data xsi:type="sutState">
 		<descriptors retestId="html" screenId="1" screen="retest - Java Swing GUI Testing" title="retest - Java Swing GUI Testing">
 			<identifyingAttributes>
@@ -4074,7 +4074,7 @@
 													<attributes>
 														<entry>
 															<key>covered</key>
-															<value xsi:type="xsd:string">true</value>
+															<value xsi:type="xsd:string">false</value>
 														</entry>
 														<entry>
 															<key>shown</key>
@@ -4148,7 +4148,7 @@
 														<attributes>
 															<entry>
 																<key>covered</key>
-																<value xsi:type="xsd:string">true</value>
+																<value xsi:type="xsd:string">false</value>
 															</entry>
 															<entry>
 																<key>shown</key>
@@ -5324,7 +5324,7 @@
 														</entry>
 														<entry>
 															<key>covered</key>
-															<value xsi:type="xsd:string">true</value>
+															<value xsi:type="xsd:string">false</value>
 														</entry>
 														<entry>
 															<key>outline-color</key>
@@ -9992,7 +9992,7 @@
 													</entry>
 													<entry>
 														<key>covered</key>
-														<value xsi:type="xsd:string">true</value>
+														<value xsi:type="xsd:string">false</value>
 													</entry>
 													<entry>
 														<key>data-target</key>
@@ -10154,7 +10154,7 @@
 											<attributes>
 												<entry>
 													<key>covered</key>
-													<value xsi:type="xsd:string">true</value>
+													<value xsi:type="xsd:string">false</value>
 												</entry>
 												<entry>
 													<key>display</key>
@@ -10259,7 +10259,7 @@
 														</entry>
 														<entry>
 															<key>covered</key>
-															<value xsi:type="xsd:string">true</value>
+															<value xsi:type="xsd:string">false</value>
 														</entry>
 														<entry>
 															<key>display</key>
@@ -11730,7 +11730,7 @@
 											<attributes>
 												<entry>
 													<key>covered</key>
-													<value xsi:type="xsd:string">true</value>
+													<value xsi:type="xsd:string">false</value>
 												</entry>
 												<entry>
 													<key>display</key>
@@ -12437,7 +12437,7 @@
 														</entry>
 														<entry>
 															<key>covered</key>
-															<value xsi:type="xsd:string">true</value>
+															<value xsi:type="xsd:string">false</value>
 														</entry>
 														<entry>
 															<key>display</key>
@@ -12727,7 +12727,7 @@
 					<attributes>
 						<entry>
 							<key>covered</key>
-							<value xsi:type="xsd:string">true</value>
+							<value xsi:type="xsd:string">false</value>
 						</entry>
 						<entry>
 							<key>prefix</key>
@@ -13323,7 +13323,7 @@
 						<attributes>
 							<entry>
 								<key>covered</key>
-								<value xsi:type="xsd:string">true</value>
+								<value xsi:type="xsd:string">false</value>
 							</entry>
 							<entry>
 								<key>shown</key>

--- a/src/test/resources/retest/recheck/de.retest.web.it.SimpleAutocheckingDriverShowcaseIT/index.00.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.it.SimpleAutocheckingDriverShowcaseIT/index.00.recheck/retest.xml
@@ -8538,7 +8538,7 @@
 					<attributes>
 						<entry>
 							<key>covered</key>
-							<value xsi:type="xsd:string">true</value>
+							<value xsi:type="xsd:string">false</value>
 						</entry>
 						<entry>
 							<key>shown</key>
@@ -8571,7 +8571,7 @@
 						<attributes>
 							<entry>
 								<key>covered</key>
-								<value xsi:type="xsd:string">true</value>
+								<value xsi:type="xsd:string">false</value>
 							</entry>
 							<entry>
 								<key>shown</key>

--- a/src/test/resources/retest/recheck/de.retest.web.it.SimpleAutocheckingDriverShowcaseIT/index.01.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.it.SimpleAutocheckingDriverShowcaseIT/index.01.recheck/retest.xml
@@ -8542,7 +8542,7 @@
 					<attributes>
 						<entry>
 							<key>covered</key>
-							<value xsi:type="xsd:string">true</value>
+							<value xsi:type="xsd:string">false</value>
 						</entry>
 						<entry>
 							<key>shown</key>
@@ -8575,7 +8575,7 @@
 						<attributes>
 							<entry>
 								<key>covered</key>
-								<value xsi:type="xsd:string">true</value>
+								<value xsi:type="xsd:string">false</value>
 							</entry>
 							<entry>
 								<key>shown</key>

--- a/src/test/resources/retest/recheck/de.retest.web.it.SimpleAutocheckingDriverShowcaseIT/index.02.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.it.SimpleAutocheckingDriverShowcaseIT/index.02.recheck/retest.xml
@@ -8546,7 +8546,7 @@
 					<attributes>
 						<entry>
 							<key>covered</key>
-							<value xsi:type="xsd:string">true</value>
+							<value xsi:type="xsd:string">false</value>
 						</entry>
 						<entry>
 							<key>shown</key>
@@ -8579,7 +8579,7 @@
 						<attributes>
 							<entry>
 								<key>covered</key>
-								<value xsi:type="xsd:string">true</value>
+								<value xsi:type="xsd:string">false</value>
 							</entry>
 							<entry>
 								<key>shown</key>

--- a/src/test/resources/retest/recheck/de.retest.web.it.SimpleAutocheckingDriverShowcaseIT/index.03.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.it.SimpleAutocheckingDriverShowcaseIT/index.03.recheck/retest.xml
@@ -8546,7 +8546,7 @@
 					<attributes>
 						<entry>
 							<key>covered</key>
-							<value xsi:type="xsd:string">true</value>
+							<value xsi:type="xsd:string">false</value>
 						</entry>
 						<entry>
 							<key>shown</key>
@@ -8579,7 +8579,7 @@
 						<attributes>
 							<entry>
 								<key>covered</key>
-								<value xsi:type="xsd:string">true</value>
+								<value xsi:type="xsd:string">false</value>
 							</entry>
 							<entry>
 								<key>shown</key>

--- a/src/test/resources/retest/recheck/de.retest.web.it.SimpleAutocheckingDriverShowcaseIT/index.04.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.it.SimpleAutocheckingDriverShowcaseIT/index.04.recheck/retest.xml
@@ -8546,7 +8546,7 @@
 					<attributes>
 						<entry>
 							<key>covered</key>
-							<value xsi:type="xsd:string">true</value>
+							<value xsi:type="xsd:string">false</value>
 						</entry>
 						<entry>
 							<key>shown</key>
@@ -8579,7 +8579,7 @@
 						<attributes>
 							<entry>
 								<key>covered</key>
-								<value xsi:type="xsd:string">true</value>
+								<value xsi:type="xsd:string">false</value>
 							</entry>
 							<entry>
 								<key>shown</key>

--- a/src/test/resources/retest/recheck/de.retest.web.it.SimpleAutocheckingDriverShowcaseIT/index.05.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.it.SimpleAutocheckingDriverShowcaseIT/index.05.recheck/retest.xml
@@ -8546,7 +8546,7 @@
 					<attributes>
 						<entry>
 							<key>covered</key>
-							<value xsi:type="xsd:string">true</value>
+							<value xsi:type="xsd:string">false</value>
 						</entry>
 						<entry>
 							<key>shown</key>
@@ -8579,7 +8579,7 @@
 						<attributes>
 							<entry>
 								<key>covered</key>
-								<value xsi:type="xsd:string">true</value>
+								<value xsi:type="xsd:string">false</value>
 							</entry>
 							<entry>
 								<key>shown</key>

--- a/src/test/resources/retest/recheck/de.retest.web.it.SimplePageDiffIT/testSimpleChange.open.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.it.SimplePageDiffIT/testSimpleChange.open.recheck/retest.xml
@@ -2959,7 +2959,7 @@
 					<attributes>
 						<entry>
 							<key>covered</key>
-							<value xsi:type="xsd:string">true</value>
+							<value xsi:type="xsd:string">false</value>
 						</entry>
 						<entry>
 							<key>shown</key>
@@ -2992,7 +2992,7 @@
 						<attributes>
 							<entry>
 								<key>covered</key>
-								<value xsi:type="xsd:string">true</value>
+								<value xsi:type="xsd:string">false</value>
 							</entry>
 							<entry>
 								<key>shown</key>

--- a/src/test/resources/retest/recheck/de.retest.web.it.SimplePageIT/simple-page-ChromeDriver.open.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.it.SimplePageIT/simple-page-ChromeDriver.open.recheck/retest.xml
@@ -2959,7 +2959,7 @@
 					<attributes>
 						<entry>
 							<key>covered</key>
-							<value xsi:type="xsd:string">true</value>
+							<value xsi:type="xsd:string">false</value>
 						</entry>
 						<entry>
 							<key>shown</key>
@@ -2992,7 +2992,7 @@
 						<attributes>
 							<entry>
 								<key>covered</key>
-								<value xsi:type="xsd:string">true</value>
+								<value xsi:type="xsd:string">false</value>
 							</entry>
 							<entry>
 								<key>shown</key>

--- a/src/test/resources/retest/recheck/de.retest.web.it.SimplePageIT/simple-page-FirefoxDriver.open.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.it.SimplePageIT/simple-page-FirefoxDriver.open.recheck/retest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<reTestXmlDataContainer xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" reTestVersion="1.10.2" dataType="de.retest.recheck.ui.descriptors.SutState" dataTypeVersion="4">
+<reTestXmlDataContainer xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" reTestVersion="1.11.1" dataType="de.retest.recheck.ui.descriptors.SutState" dataTypeVersion="4">
 	<data xsi:type="sutState">
 		<descriptors retestId="html" screenId="1" screen="Hello WebDriver" title="Hello WebDriver">
 			<identifyingAttributes>
@@ -2979,7 +2979,7 @@
 					<attributes>
 						<entry>
 							<key>covered</key>
-							<value xsi:type="xsd:string">true</value>
+							<value xsi:type="xsd:string">false</value>
 						</entry>
 						<entry>
 							<key>shown</key>
@@ -3012,7 +3012,7 @@
 						<attributes>
 							<entry>
 								<key>covered</key>
-								<value xsi:type="xsd:string">true</value>
+								<value xsi:type="xsd:string">false</value>
 							</entry>
 							<entry>
 								<key>shown</key>

--- a/src/test/resources/retest/recheck/de.retest.web.it.SimpleRecheckShowcaseIT/simpleShowcase.index.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.it.SimpleRecheckShowcaseIT/simpleShowcase.index.recheck/retest.xml
@@ -4156,7 +4156,7 @@
 														</entry>
 														<entry>
 															<key>covered</key>
-															<value xsi:type="xsd:string">true</value>
+															<value xsi:type="xsd:string">false</value>
 														</entry>
 														<entry>
 															<key>outline-color</key>
@@ -8832,7 +8832,7 @@
 													</entry>
 													<entry>
 														<key>covered</key>
-														<value xsi:type="xsd:string">true</value>
+														<value xsi:type="xsd:string">false</value>
 													</entry>
 													<entry>
 														<key>data-target</key>
@@ -8994,7 +8994,7 @@
 											<attributes>
 												<entry>
 													<key>covered</key>
-													<value xsi:type="xsd:string">true</value>
+													<value xsi:type="xsd:string">false</value>
 												</entry>
 												<entry>
 													<key>display</key>
@@ -9099,7 +9099,7 @@
 														</entry>
 														<entry>
 															<key>covered</key>
-															<value xsi:type="xsd:string">true</value>
+															<value xsi:type="xsd:string">false</value>
 														</entry>
 														<entry>
 															<key>display</key>
@@ -10570,7 +10570,7 @@
 											<attributes>
 												<entry>
 													<key>covered</key>
-													<value xsi:type="xsd:string">true</value>
+													<value xsi:type="xsd:string">false</value>
 												</entry>
 												<entry>
 													<key>display</key>
@@ -11277,7 +11277,7 @@
 														</entry>
 														<entry>
 															<key>covered</key>
-															<value xsi:type="xsd:string">true</value>
+															<value xsi:type="xsd:string">false</value>
 														</entry>
 														<entry>
 															<key>display</key>
@@ -11571,7 +11571,7 @@
 					<attributes>
 						<entry>
 							<key>covered</key>
-							<value xsi:type="xsd:string">true</value>
+							<value xsi:type="xsd:string">false</value>
 						</entry>
 						<entry>
 							<key>prefix</key>
@@ -12167,7 +12167,7 @@
 						<attributes>
 							<entry>
 								<key>covered</key>
-								<value xsi:type="xsd:string">true</value>
+								<value xsi:type="xsd:string">false</value>
 							</entry>
 							<entry>
 								<key>shown</key>

--- a/src/test/resources/retest/recheck/de.retest.web.it.SpecialContainerIT/special-container-ChromeDriver.click.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.it.SpecialContainerIT/special-container-ChromeDriver.click.recheck/retest.xml
@@ -65,7 +65,7 @@
 					<attributes>
 						<entry>
 							<key>covered</key>
-							<value xsi:type="xsd:string">true</value>
+							<value xsi:type="xsd:string">false</value>
 						</entry>
 						<entry>
 							<key>shown</key>
@@ -98,7 +98,7 @@
 						<attributes>
 							<entry>
 								<key>covered</key>
-								<value xsi:type="xsd:string">true</value>
+								<value xsi:type="xsd:string">false</value>
 							</entry>
 							<entry>
 								<key>shown</key>

--- a/src/test/resources/retest/recheck/de.retest.web.it.SpecialContainerIT/special-container-ChromeDriver.open.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.it.SpecialContainerIT/special-container-ChromeDriver.open.recheck/retest.xml
@@ -65,7 +65,7 @@
 					<attributes>
 						<entry>
 							<key>covered</key>
-							<value xsi:type="xsd:string">true</value>
+							<value xsi:type="xsd:string">false</value>
 						</entry>
 						<entry>
 							<key>shown</key>
@@ -98,7 +98,7 @@
 						<attributes>
 							<entry>
 								<key>covered</key>
-								<value xsi:type="xsd:string">true</value>
+								<value xsi:type="xsd:string">false</value>
 							</entry>
 							<entry>
 								<key>shown</key>

--- a/src/test/resources/retest/recheck/de.retest.web.it.SpecialContainerIT/special-container-FirefoxDriver.click.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.it.SpecialContainerIT/special-container-FirefoxDriver.click.recheck/retest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<reTestXmlDataContainer xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" reTestVersion="1.10.2" dataType="de.retest.recheck.ui.descriptors.SutState" dataTypeVersion="4">
+<reTestXmlDataContainer xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" reTestVersion="1.11.1" dataType="de.retest.recheck.ui.descriptors.SutState" dataTypeVersion="4">
 	<data xsi:type="sutState">
 		<descriptors retestId="html" screenId="1" screen="Welcome to the Test of Recheck-web" title="Welcome to the Test of Recheck-web">
 			<identifyingAttributes>
@@ -73,7 +73,7 @@
 					<attributes>
 						<entry>
 							<key>covered</key>
-							<value xsi:type="xsd:string">true</value>
+							<value xsi:type="xsd:string">false</value>
 						</entry>
 						<entry>
 							<key>shown</key>
@@ -106,7 +106,7 @@
 						<attributes>
 							<entry>
 								<key>covered</key>
-								<value xsi:type="xsd:string">true</value>
+								<value xsi:type="xsd:string">false</value>
 							</entry>
 							<entry>
 								<key>shown</key>

--- a/src/test/resources/retest/recheck/de.retest.web.it.SpecialContainerIT/special-container-FirefoxDriver.open.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.it.SpecialContainerIT/special-container-FirefoxDriver.open.recheck/retest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<reTestXmlDataContainer xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" reTestVersion="1.10.2" dataType="de.retest.recheck.ui.descriptors.SutState" dataTypeVersion="4">
+<reTestXmlDataContainer xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" reTestVersion="1.11.1" dataType="de.retest.recheck.ui.descriptors.SutState" dataTypeVersion="4">
 	<data xsi:type="sutState">
 		<descriptors retestId="html" screenId="1" screen="Welcome to the Test of Recheck-web" title="Welcome to the Test of Recheck-web">
 			<identifyingAttributes>
@@ -73,7 +73,7 @@
 					<attributes>
 						<entry>
 							<key>covered</key>
-							<value xsi:type="xsd:string">true</value>
+							<value xsi:type="xsd:string">false</value>
 						</entry>
 						<entry>
 							<key>shown</key>
@@ -106,7 +106,7 @@
 						<attributes>
 							<entry>
 								<key>covered</key>
-								<value xsi:type="xsd:string">true</value>
+								<value xsi:type="xsd:string">false</value>
 							</entry>
 							<entry>
 								<key>shown</key>

--- a/src/test/resources/retest/recheck/de.retest.web.it.TestHealerCssSelectorIT/setup.00.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.it.TestHealerCssSelectorIT/setup.00.recheck/retest.xml
@@ -1811,7 +1811,7 @@
 					<attributes>
 						<entry>
 							<key>covered</key>
-							<value xsi:type="xsd:string">true</value>
+							<value xsi:type="xsd:string">false</value>
 						</entry>
 						<entry>
 							<key>shown</key>
@@ -1844,7 +1844,7 @@
 						<attributes>
 							<entry>
 								<key>covered</key>
-								<value xsi:type="xsd:string">true</value>
+								<value xsi:type="xsd:string">false</value>
 							</entry>
 							<entry>
 								<key>shown</key>

--- a/src/test/resources/retest/recheck/de.retest.web.it.TestHealerCssSelectorIT/setup.01.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.it.TestHealerCssSelectorIT/setup.01.recheck/retest.xml
@@ -1811,7 +1811,7 @@
 					<attributes>
 						<entry>
 							<key>covered</key>
-							<value xsi:type="xsd:string">true</value>
+							<value xsi:type="xsd:string">false</value>
 						</entry>
 						<entry>
 							<key>shown</key>
@@ -1844,7 +1844,7 @@
 						<attributes>
 							<entry>
 								<key>covered</key>
-								<value xsi:type="xsd:string">true</value>
+								<value xsi:type="xsd:string">false</value>
 							</entry>
 							<entry>
 								<key>shown</key>


### PR DESCRIPTION
This should make the detection more reliable, and solve problems with
rounded corners.

*Before submission, please check that ...*

- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [x] the necessary tests are either created or updated.
- [x] all status checks (GitHub Actions, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [x] you updated the changelog.
- [ ] ~you updated necessary documentation within [retest/docs](https://github.com/retest/docs).~

## Description

Earlier we tried to check if an element is covered by some other elements by checking of the corners are obscured. On rounded elements these corners may not exist. The check now tries to see of any of the middle-points on all four sides are obscured. This should also work with elliptic elements.

### State of this PR

It may still turn out that there are edge cases that need to be handled, but for now this seems to work as intended.
