### PR TITLE
Feature/retestid without gm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Table of Contents
 ### Improvements
 
 * Always override the system metadata (i.e. on "architecture"), so that we do not end up with mixed info.
+* Since `retestId` is now created deterministically, we can reference it before we even have a Golden Master. So if you know what the `retestId` will gona be (e.g. your element has a specific text, HTML ID or you have your own `RetestIdProvider`), you can already use it in the test. 
 
 --------------------------------------------------------------------------------
 

--- a/src/main/java/de/retest/web/selenium/By.java
+++ b/src/main/java/de/retest/web/selenium/By.java
@@ -31,7 +31,7 @@ public abstract class By extends org.openqa.selenium.By {
 		return resultFromActual.applyRetestId( resultFromExpected.getRetestId() );
 	}
 
-	private static Element findElement( final List<Element> children, final Predicate<Element> predicate ) {
+	public static Element findElement( final List<Element> children, final Predicate<Element> predicate ) {
 		for ( final Element element : children ) {
 			if ( predicate.test( element ) ) {
 				return element;

--- a/src/main/java/de/retest/web/selenium/ByBestMatchToRetestId.java
+++ b/src/main/java/de/retest/web/selenium/ByBestMatchToRetestId.java
@@ -52,6 +52,11 @@ public class ByBestMatchToRetestId extends By implements Serializable {
 	 * @return Maybe an element whose children have a different retest ID than in the Golden Master.
 	 */
 	public Element findElement( final RootElement lastExpectedState, final RootElement lastActualState ) {
+		if ( lastExpectedState == null ) {
+			// find by retestId even in case of just creating the state
+			return de.retest.web.selenium.By.findElement( lastActualState.getContainedElements(),
+					element -> retestId.equals( element.getRetestId() ) );
+		}
 		final Element result = de.retest.web.selenium.By.findElement( lastExpectedState, lastActualState,
 				element -> retestId.equals( element.getRetestId() ) );
 		if ( result == null ) {

--- a/src/main/java/de/retest/web/selenium/UnbreakableDriver.java
+++ b/src/main/java/de/retest/web/selenium/UnbreakableDriver.java
@@ -64,10 +64,6 @@ public class UnbreakableDriver implements WebDriver, JavascriptExecutor, FindsBy
 	}
 
 	public WebElement findElement( final ByBestMatchToRetestId by ) {
-		if ( lastExpectedState == null ) {
-			throw new IllegalStateException( "You must use the " + RecheckWebImpl.class.getSimpleName()
-					+ " and first check the state before being able to use the retest ID locator." );
-		}
 		final Element searchedFor = by.findElement( lastExpectedState, lastActualState );
 		final WebElement element =
 				wrappedDriver.findElement( By.xpath( searchedFor.getIdentifyingAttributes().getPath() ) );

--- a/src/test/java/de/retest/web/it/SimpleRetestIdShowcaseIT.java
+++ b/src/test/java/de/retest/web/it/SimpleRetestIdShowcaseIT.java
@@ -3,6 +3,8 @@ package de.retest.web.it;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import org.apache.commons.io.FileUtils;
+import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -55,8 +57,15 @@ public class SimpleRetestIdShowcaseIT {
 
 		driver.findElement( By.retestId( "contact" ) ).click();
 
-		// Usually, we conclude the test case, but since we expect differences, this will fail.
-		// re.capTest();
+		// Works even if the GM is not yet created, if retestId is deterministic
+		re.check( driver, "new_state" );
+		driver.findElement( By.retestId( "for_testers" ) ).click();
+
+		// Usually, we conclude the test case with re.capTest(),
+		// but since we expect differences, we check these.
+		Assertions.assertThatThrownBy( () -> re.capTest() ).hasMessageContainingAll( //
+				"text: expected=\"Contact\", actual=\"Support\"", //
+				"No Golden Master found. First time test was run?" );
 	}
 
 	@After
@@ -65,6 +74,10 @@ public class SimpleRetestIdShowcaseIT {
 
 		// Produce the result file.
 		//		re.cap();
+
+		// Not standard! Ensure we delete the GM that was created
+		FileUtils.deleteQuietly( Paths.get( "src/test/resources/retest/recheck",
+				"de.retest.web.it.SimpleRetestIdShowcaseIT", "simple-showcase.new_state.recheck" ).toFile() );
 	}
 
 }

--- a/src/test/resources/pages/showcase/retest-changed.html
+++ b/src/test/resources/pages/showcase/retest-changed.html
@@ -61,7 +61,7 @@
 	            <a class="mobile-btn" href="https://retest.de/en/#" title="Hide navigation">Hide navigation</a>
 
                <ul id="nav" class="nav">
-	              <li><span><a href="https://www.retest.de/en/for-testers/index.html">For Testers</a></span>
+	              <li><span><a href="#">For Testers</a></span>
                      <ul>
                         <li><a href="https://www.retest.de/en/for-testers/test-automation-without-programming.html">Automation without Programming</a></li>
                         <li><a href="https://www.retest.de/en/for-testers/robust-tests.html">Robust Tests</a></li>
@@ -304,7 +304,7 @@
 
             <ul class="copyright">
                <li>Copyright © 2018 ReTest GmbH</li>
-               <li id="impressumslink"><span><a id="help" href="https://www.retest.de//kontakt.html">Support</a></span></li>
+               <li id="impressumslink"><span><a id="help" href="#">Support</a></span></li>
             </ul>
 
          </div>


### PR DESCRIPTION
- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [ ] the necessary tests are either created or updated.
- [x] all status checks (GitHub Actions, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [x] you updated the changelog.
- [ ] you updated necessary documentation within [retest/docs](https://github.com/retest/docs).

## Description

TL;DR:
Allow the retestId to be used, even if the Golden Master is just being created. This is especially handy when the retestId is deterministic, and in conjunction with Surili.
