### PR TITLE
Feature/add shadow dom test

### DIFF
--- a/.retest/filter/shadow.filter
+++ b/.retest/filter/shadow.filter
@@ -1,0 +1,2 @@
+import: metadata.filter
+import: style-attributes.filter

--- a/src/test/java/de/retest/web/it/ShadowIT.java
+++ b/src/test/java/de/retest/web/it/ShadowIT.java
@@ -1,0 +1,79 @@
+package de.retest.web.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+
+import de.retest.recheck.Recheck;
+import de.retest.recheck.RecheckImpl;
+import de.retest.recheck.RecheckOptions;
+import de.retest.recheck.persistence.SeparatePathsProjectLayout;
+
+public class ShadowIT {
+
+	Recheck re;
+
+	@BeforeEach
+	void setUp( @TempDir Path path ) {
+		re = new RecheckImpl( RecheckOptions.builder() //
+				// Move the project layout within a custom directory, so that the Golden Master is created every time
+				.projectLayout( new SeparatePathsProjectLayout( path.resolve( "states" ), path.resolve( "reports" ) ) ) //
+				// Ignore attribute style of button for now (pressed), as this test does not modify the styles itself
+				.setIgnore( "shadow.filter" ) //
+				.build() );
+	}
+
+	@AfterEach
+	void tearDown() {
+		re.cap();
+	}
+
+	@ParameterizedTest( name = "shadow-page-{1}" )
+	@MethodSource( "de.retest.web.testutils.WebDriverFactory#drivers" )
+	void shadow_dom_can_only_detect_light_dom_changes( WebDriver driver, String name ) {
+		re.startTest( "shadow-page-" + name );
+
+		driver.get( ShadowIT.class.getResource( "/pages/shadow/index.html" ).toExternalForm() );
+
+		re.check( driver, "shadow" );
+
+		driver.findElement( By.id( "change" ) ).click();
+
+		re.check( driver, "shadow" );
+
+		try {
+			re.capTest();
+		} catch ( AssertionError e ) {
+			assertThat( e ).hasMessageContaining( // 
+					"\tbutton (change) at 'html[1]/body[1]/rt-layout[1]/button[1]':\n"
+							+ "\t\tdisabled: expected=\"(default or absent)\", expected=\"true\"\n"
+							+ "\tre-card (card1) at 'html[1]/body[1]/rt-layout[1]/rt-card-deck[1]/rt-card[1]':\n"
+							+ "\t\tfooter: expected=\"First\", actual=\"Left\"\n"
+							+ "\t\theader: expected=\"Card 1\", actual=\"Card Left\"\n"
+							+ "\tbutton (hello_world) at 'html[1]/body[1]/rt-layout[1]/rt-card-deck[1]/rt-card[1]/div[1]/button[1]':\n"
+							+ "\t\tclass: expected=\"btn btn-success\", actual=\"btn btn-primary\"\n"
+							+ "\tre-card (card2) at 'html[1]/body[1]/rt-layout[1]/rt-card-deck[1]/rt-card[2]':\n"
+							+ "\t\theader: expected=\"Card 2\", actual=\"Card Middle\"\n"
+							+ "\t\tfooter: expected=\"(default or absent)\", actual=\"Middle\"\n"
+							+ "\tbutton (hello_world-1) at 'html[1]/body[1]/rt-layout[1]/rt-card-deck[1]/rt-card[2]/div[1]/button[1]':\n"
+							+ "\t\tclass: expected=\"btn btn-warning\", actual=\"btn btn-secondary\"\n"
+							+ "\tre-card (card3) at 'html[1]/body[1]/rt-layout[1]/rt-card-deck[1]/rt-card[3]':\n"
+							+ "\t\tfooter: expected=\"Last\", actual=\"Right\"\n"
+							+ "\t\theader: expected=\"Card 3\", actual=\"Card Right\"\n"
+							+ "\tbutton (hello_world-2) at 'html[1]/body[1]/rt-layout[1]/rt-card-deck[1]/rt-card[3]/div[1]/button[1]':\n"
+							+ "\t\tclass: expected=\"btn btn-danger\", actual=\"btn btn-success\"\n"
+							+ "\tre-copyright (copyright) at 'html[1]/body[1]/rt-layout[1]/rt-copyright[1]':\n"
+							+ "\t\tyear: expected=\"2020\", actual=\"2021\"" );
+		} finally {
+			driver.quit();
+		}
+	}
+}

--- a/src/test/resources/pages/shadow/assets/css/card.css
+++ b/src/test/resources/pages/shadow/assets/css/card.css
@@ -1,0 +1,45 @@
+.card-deck {
+    display: grid;
+    grid-auto-flow: column;
+    align-items: stretch;
+}
+
+.card-deck ::slotted(rt-card:first-child) {
+    margin-right: 0.5rem;
+}
+
+.card-deck ::slotted(rt-card) {
+    margin-left: 0.5rem;
+    margin-right: 0.5rem;
+}
+
+.card-deck ::slotted(rt-card:last-child) {
+    margin-left: 0.5rem;
+}
+
+.card {
+    border-radius: 0.25rem;
+    border: 1px solid rgba(0, 0, 0, 0.125);
+    height: 100%;
+}
+
+.card-body {
+    padding: 1.25rem;
+}
+
+.card-header,
+.card-footer :not(:empty) {
+    padding: 0.75rem 1.25rem;
+    background-color: rgba(0, 0, 0, 0.03);
+}
+
+.card-header {
+    font-weight: bold;
+    margin-bottom: 0;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.125);
+}
+
+.card-footer :not(:empty) {
+    margin-top: 0;
+    border-top: 1px solid rgba(0, 0, 0, 0.125);
+}

--- a/src/test/resources/pages/shadow/assets/css/layout.css
+++ b/src/test/resources/pages/shadow/assets/css/layout.css
@@ -1,0 +1,37 @@
+#logo {
+    font-size: 5rem;
+}
+
+header,
+main,
+footer {
+    padding: 0.5rem;
+}
+
+header,
+footer {
+    left: 0;
+    right: 0;
+}
+
+header {
+    position: sticky;
+    top: 0;
+    display: grid;
+    grid-auto-flow: column;
+    align-items: center;
+    grid-template-columns: min-content auto min-content;
+}
+
+header h1 {
+    font-variant: small-caps;
+}
+
+footer {
+    position: fixed;
+    bottom: 0;
+}
+
+footer p {
+    padding: 0;
+}

--- a/src/test/resources/pages/shadow/assets/images/retest.svg
+++ b/src/test/resources/pages/shadow/assets/images/retest.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <symbol id="logo" width="1em" height="1em" version="1.1" viewBox="0 0 300 300" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+        <path d="m127.54 273.79-127.54-57.036v-152.21c0-35.616 28.824-64.344 64.559-64.344h208.87zm-106.36-76.188s51.327 9.156 77.37 13.692c9.0181 1.596 18.205-2.016 23.683-9.492 21.407-28.476 73.409-98.028 73.409-98.028s-55.963 99.204-72.566 128.69c-2.6127 4.62-8.3438 6.552-13.148 4.368-23.767-10.416-88.748-39.228-88.748-39.228z" fill="#BED031" fill-rule="evenodd"/>
+    </symbol>
+<svg>

--- a/src/test/resources/pages/shadow/assets/js/index.js
+++ b/src/test/resources/pages/shadow/assets/js/index.js
@@ -1,0 +1,227 @@
+class LayoutHTMLElement extends HTMLElement {
+
+	constructor() {
+		super();
+	}
+
+	static get observedAttributes() {
+		return ['title'];
+	}
+
+	attributeChangedCallback(name, oldValue, newValue) {
+		this._update();
+	}
+
+	connectedCallback() {
+		const shadow = this.attachShadow({ mode: 'open' });
+		shadow.innerHTML = `
+			<header>
+				<link rel="stylesheet" href="assets/css/layout.css">
+				<slot name="icon">
+					<svg id="logo" width="1em" height="1em" fill="currentColor">
+						<use href="assets/images/retest.svg#logo"/>
+					</svg>
+				</slot>
+				<h1 id="title"></h1>
+				<slot name="context"></slot>
+			</header>
+
+			<main>
+				<slot name="main"></slot>
+			</main>
+
+			<footer>
+				<slot name="footer"></slot>
+			</footer>
+		`;
+		this._update();
+	}
+
+	attributeChangedCallback(name, oldValue, newValue) {
+		this._update();
+	}
+
+	_update() {
+		if (this.shadowRoot) {
+			const title = this.shadowRoot.getElementById("title");
+			if (title) {
+				title.innerHTML = this.title;
+			}
+		}
+	}
+
+	get title() {
+		return this.getAttribute("title");
+	}
+
+	set title(title) {
+		this.setAttribute("title", title);
+	}
+}
+
+class CardDeckHTMLElement extends HTMLElement {
+
+	constructor() {
+		super();
+	}
+
+	connectedCallback() {
+		const shadow = this.attachShadow({ mode: 'open' });
+		shadow.innerHTML = `
+			<link rel="stylesheet" href="assets/css/card.css">
+			<div class="card-deck">
+				<slot></slot>
+			</div>
+		`;
+	}
+}
+
+class CardHTMLElement extends HTMLElement {
+
+	constructor() {
+		super();
+	}
+
+	static get observedAttributes() {
+		return ['header', 'footer'];
+	}
+
+	attributeChangedCallback(name, oldValue, newValue) {
+		this._update();
+	}
+
+	connectedCallback() {
+		this.attachShadow({ mode: 'open' });
+		this._update();
+	}
+
+	_update() {
+		if (this.shadowRoot) {
+			this.shadowRoot.innerHTML = `
+				<link rel="stylesheet" href="assets/css/card.css">
+				<div class="card">
+					<div class="card-header">
+						<slot name="header">
+							<div id="header" class="card-text">${this.header}</div>
+						</slot>
+					</div>
+					<div class="card-body">
+						<slot name="body"></slot>
+					</div>
+					${ this.footer
+					? `<div class="card-footer">
+							<slot name="footer">
+								<div  class="text-muted small">${this.footer}</div>
+							</slot>
+						</div>`
+					: ""
+				}
+				</div>
+				`;
+		}
+	}
+
+	get header() {
+		return this.getAttribute("header");
+	}
+
+	set header(title) {
+		this.setAttribute("header", title);
+	}
+
+	get footer() {
+		return this.getAttribute("footer");
+	}
+
+	set footer(title) {
+		this.setAttribute("footer", title);
+	}
+}
+
+class CopyrightHTMLELement extends HTMLElement {
+
+	constructor() {
+		super();
+	}
+
+	static get observedAttributes() {
+		return ['company', 'year'];
+	}
+
+	attributeChangedCallback(name, oldValue, newValue) {
+		this._update();
+	}
+
+	connectedCallback() {
+		const shadow = this.attachShadow({ mode: 'open' });
+		shadow.innerHTML = `<span id="text" style="color: gray; font-size: 70%;"></span>`;
+		this._update();
+	}
+
+	_update() {
+		if (this.shadowRoot) {
+			const text = this.shadowRoot.getElementById("text")
+			if (text) {
+				text.innerHTML = `&copy; ${this.year} ${this.company}`
+			}
+		}
+	}
+
+	get company() {
+		return this.getAttribute("company");
+	}
+
+	set company(company) {
+		this.setAttribute("company", company);
+	}
+
+	get year() {
+		return this.getAttribute("year");
+	}
+
+	set year(year) {
+		this.setAttribute("year", year);
+	}
+}
+
+(function () {
+	'use strict';
+
+	// Feature detect
+	if (!(window.customElements && document.body.attachShadow)) {
+		return;
+	}
+
+	customElements.define('rt-layout', LayoutHTMLElement);
+	customElements.define('rt-card-deck', CardDeckHTMLElement);
+	customElements.define('rt-card', CardHTMLElement);
+	customElements.define('rt-copyright', CopyrightHTMLELement);
+
+	const replaceCardData = [{ header: "Card Left", footer: "Left" }, { header: "Card Middle", footer: "Middle" }, { header: "Card Right", footer: "Right" }]
+	const replaceButtonClasses = [["btn-success", "btn-primary"], ["btn-warning", "btn-secondary"], ["btn-danger", "btn-success"]];
+
+	const change = document.getElementById("change")
+	change.onclick = () => {
+		// Find all light dom cards
+		const cards = document.querySelectorAll("rt-card");
+		cards.forEach((node, i) => {
+			const data = replaceCardData[i];
+			node.header = data.header;
+			node.footer = data.footer;
+		})
+
+		// Find light dom copyright
+		const copy = document.getElementById("copyright");
+		copy.year = 2021;
+
+		// Find all light dom buttons within a card body
+		const buttons = document.querySelectorAll("rt-card button");
+		buttons.forEach((node, i) => {
+			const buttonClasses = replaceButtonClasses[i];
+			node.classList.replace(buttonClasses[0], buttonClasses[1]);
+		});
+
+		// Disable button, since change is only one way
+		change.disabled = true;
+	}
+})();

--- a/src/test/resources/pages/shadow/index.html
+++ b/src/test/resources/pages/shadow/index.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+	<meta http-equiv="X-UA-Compatible" content="ie=edge">
+	<title>Shadow DOM</title>
+
+	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css">
+</head>
+
+<body>
+	<rt-layout title="Shadow Dom Example">
+		<button id="change" class="btn btn-primary" slot="context">Change</button>
+		<rt-card-deck slot="main">
+			<rt-card id="card-1" header="Card 1" footer="First">
+				<div slot="body">
+					<button class="btn btn-success">Hello World</button>
+				</div>
+			</rt-card>
+			<rt-card id="card-2" header="Card 2">
+				<div slot="body">
+					<button class="btn btn-warning">Hello World</button>
+				</div>
+			</rt-card>
+			<rt-card id="card-3" header="Card 3" footer="Last">
+				<div slot="body">
+					<button class="btn btn-danger">Hello World</button>
+				</div>
+			</rt-card>
+		</rt-card-deck>
+		<rt-copyright id="copyright" company="retest" year="2020" slot="footer"></rt-copyright>
+	</rt-layout>
+
+	<script src="assets/js/index.js"></script>
+</body>
+
+</html>


### PR DESCRIPTION
*Before submission, please check that ...*

- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [x] the necessary tests are either created or updated.
- [ ] all status checks (GitHub Actions, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [x] ~you updated the changelog.~ *(not necessary)*
- [ ] you updated necessary documentation within [retest/docs](https://github.com/retest/docs). *(pending)*

## Description

> TL;DR This adds a test for the current state on [shadow DOMs](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM).

The example is custom build, using guides from [google developers](https://developers.google.com/web/fundamentals/web-components/shadowdom). It features open, closed and nested shadow elements through the use of custom elements. Furthermore, it makes use of both _true shadow DOM_ and _light DOM_. 

1. The included logo is an optimized logo from our website, embedded as a [symbol into the svg](https://css-tricks.com/svg-sprites-use-better-icon-fonts/), so that it can be styled and referenced from outside. This creates a closed shadow DOM.
2. A layout using custom elements is created, which build themselves using custom attributes that are synced to the shadow DOM, automatically updating it on changes.
3. Slots are used to inject light DOM into the custom components, which are accessible from the outside.

The differences are introduced with a click of a button. These are designed to introduce changes to all aspects of the shadow DOM. It modifies the attributes of custom elements, light elements and through this, indirectly has effect on the shadow DOM (because of data binding).

This test does not use templates for rendering the shadow DOM, because templates might be a separate thing that we need to consider at some time in the future.

All in all, this test should suffice for most scenarios when working with shadow DOMs. Of course, almost everything is possible with the web, and we will see, if it does.

The test uses its own temp directory, because we are only interested in the actual changes, as we have no use for the generated Golden Masters right now. Secondly, it references its own filter instead of the global `recheck.ignore` to the test report all differences as expected, without changes in the `recheck.ignore` having an side-effect on this test.

To have a more representable example, this uses some minor [bootstrap CSS](https://getbootstrap.com/), mostly the reboot and button elements. As this introduces an external dependency, I am not sure how this might affect the elements. However, we could decide to include this as a local stylesheet.

### State of shadow DOM

As the introduced test shows, we currently only gather changes on the custom elements as well as the light DOM. The actual changes that happen in the shadow DOM are currently not tracked.

Based on small initial tests, it should be fairly easy&trade; to implement a working solution that works for open shadow roots. However, we will potentially need to discuss how we want to handle light DOM, as, although it is physically moved inside the shadow DOM, it is still accessible from the outside.

### State of this PR

Due to changes that introduced pseudo-elements #623, the test does not currently have the expected result. This is only the case for the "change" button, which gets disabled once clicked. However, the Alignment gets confused by this and lists it as `inserted-deleted` element. Right now, the test shows the expected output, which differ from the actual output because of this. This can be addressed the following ways:

1. Have the test assert the wrong message, so that it will pass.
2. Wait until merging, until #624 is implemented.

My opinion: The test already shows that the basics are working and the bug is outside the scope of this PR. However, it would introduce a dirty commit history (i.e. a commit that has to be reverted) and since this PR is not critical, we could just leave it as a draft until scenario 2 is done.

I will add documentation so that it is clear to what extend this is working right now, as I don't see that we will implement a proper working solution for this release.

### Additional Context

I would like to add this to our assets website as an example, so that it can be referenced throughout our documentation and other articles. This would allow us to remove the website from this repo and only reference it in the test.

*This does not work with IE11.*