### PR TITLE
Update Golden Masters to include a reset for outline-offset

### DIFF
--- a/src/test/resources/retest/recheck/de.retest.web.it.FormPageIT/form-page-ChromeDriver.open.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.it.FormPageIT/form-page-ChromeDriver.open.recheck/retest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<reTestXmlDataContainer xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" reTestVersion="1.11.2" dataType="de.retest.recheck.ui.descriptors.SutState" dataTypeVersion="4">
+<reTestXmlDataContainer xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" reTestVersion="1.12.0-SNAPSHOT" dataType="de.retest.recheck.ui.descriptors.SutState" dataTypeVersion="4">
 	<data xsi:type="sutState">
 		<descriptors retestId="html" screenId="1" screen="We Leave From Here" title="We Leave From Here">
 			<identifyingAttributes>
@@ -7654,10 +7654,6 @@
 								<entry>
 									<key>outline-color</key>
 									<value xsi:type="xsd:string">rgb(229, 151, 0)</value>
-								</entry>
-								<entry>
-									<key>outline-offset</key>
-									<value xsi:type="xsd:string">-2px</value>
 								</entry>
 								<entry>
 									<key>outline-width</key>

--- a/src/test/resources/retest/recheck/de.retest.web.it.RecheckRemoteWebElementIT/findElement-equals-driver-ChromeDriver.open.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.it.RecheckRemoteWebElementIT/findElement-equals-driver-ChromeDriver.open.recheck/retest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<reTestXmlDataContainer xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" reTestVersion="1.11.2" dataType="de.retest.recheck.ui.descriptors.SutState" dataTypeVersion="4">
+<reTestXmlDataContainer xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" reTestVersion="1.12.0-SNAPSHOT" dataType="de.retest.recheck.ui.descriptors.SutState" dataTypeVersion="4">
 	<data xsi:type="sutState">
 		<descriptors retestId="html" screenId="1" screen="We Leave From Here" title="We Leave From Here">
 			<identifyingAttributes>
@@ -7884,10 +7884,6 @@
 							<entry>
 								<key>outline-color</key>
 								<value xsi:type="xsd:string">rgb(229, 151, 0)</value>
-							</entry>
-							<entry>
-								<key>outline-offset</key>
-								<value xsi:type="xsd:string">-2px</value>
 							</entry>
 							<entry>
 								<key>outline-width</key>

--- a/src/test/resources/retest/recheck/de.retest.web.it.SimpleAutocheckingDriverShowcaseIT/index.00.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.it.SimpleAutocheckingDriverShowcaseIT/index.00.recheck/retest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<reTestXmlDataContainer xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" reTestVersion="1.11.2" dataType="de.retest.recheck.ui.descriptors.SutState" dataTypeVersion="4">
+<reTestXmlDataContainer xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" reTestVersion="1.12.0-SNAPSHOT" dataType="de.retest.recheck.ui.descriptors.SutState" dataTypeVersion="4">
 	<data xsi:type="sutState">
 		<descriptors retestId="html" screenId="1" screen="We Leave From Here" title="We Leave From Here">
 			<identifyingAttributes>
@@ -7884,10 +7884,6 @@
 							<entry>
 								<key>outline-color</key>
 								<value xsi:type="xsd:string">rgb(229, 151, 0)</value>
-							</entry>
-							<entry>
-								<key>outline-offset</key>
-								<value xsi:type="xsd:string">-2px</value>
 							</entry>
 							<entry>
 								<key>outline-width</key>

--- a/src/test/resources/retest/recheck/de.retest.web.it.SimpleAutocheckingDriverShowcaseIT/index.01.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.it.SimpleAutocheckingDriverShowcaseIT/index.01.recheck/retest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<reTestXmlDataContainer xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" reTestVersion="1.11.2" dataType="de.retest.recheck.ui.descriptors.SutState" dataTypeVersion="4">
+<reTestXmlDataContainer xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" reTestVersion="1.12.0-SNAPSHOT" dataType="de.retest.recheck.ui.descriptors.SutState" dataTypeVersion="4">
 	<data xsi:type="sutState">
 		<descriptors retestId="html" screenId="1" screen="We Leave From Here" title="We Leave From Here">
 			<identifyingAttributes>
@@ -7654,10 +7654,6 @@
 								<entry>
 									<key>outline-color</key>
 									<value xsi:type="xsd:string">rgb(229, 151, 0)</value>
-								</entry>
-								<entry>
-									<key>outline-offset</key>
-									<value xsi:type="xsd:string">-2px</value>
 								</entry>
 								<entry>
 									<key>outline-width</key>

--- a/src/test/resources/retest/recheck/de.retest.web.it.SimpleAutocheckingDriverShowcaseIT/index.02.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.it.SimpleAutocheckingDriverShowcaseIT/index.02.recheck/retest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<reTestXmlDataContainer xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" reTestVersion="1.11.2" dataType="de.retest.recheck.ui.descriptors.SutState" dataTypeVersion="4">
+<reTestXmlDataContainer xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" reTestVersion="1.12.0-SNAPSHOT" dataType="de.retest.recheck.ui.descriptors.SutState" dataTypeVersion="4">
 	<data xsi:type="sutState">
 		<descriptors retestId="html" screenId="1" screen="We Leave From Here" title="We Leave From Here">
 			<identifyingAttributes>
@@ -7888,10 +7888,6 @@
 							<entry>
 								<key>outline-color</key>
 								<value xsi:type="xsd:string">rgb(229, 151, 0)</value>
-							</entry>
-							<entry>
-								<key>outline-offset</key>
-								<value xsi:type="xsd:string">-2px</value>
 							</entry>
 							<entry>
 								<key>outline-width</key>

--- a/src/test/resources/retest/recheck/de.retest.web.it.SimpleAutocheckingDriverShowcaseIT/index.03.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.it.SimpleAutocheckingDriverShowcaseIT/index.03.recheck/retest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<reTestXmlDataContainer xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" reTestVersion="1.11.2" dataType="de.retest.recheck.ui.descriptors.SutState" dataTypeVersion="4">
+<reTestXmlDataContainer xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" reTestVersion="1.12.0-SNAPSHOT" dataType="de.retest.recheck.ui.descriptors.SutState" dataTypeVersion="4">
 	<data xsi:type="sutState">
 		<descriptors retestId="html" screenId="1" screen="We Leave From Here" title="We Leave From Here">
 			<identifyingAttributes>
@@ -3627,6 +3627,10 @@
 								<entry>
 									<key>outline-color</key>
 									<value xsi:type="xsd:string">rgb(229, 151, 0)</value>
+								</entry>
+								<entry>
+									<key>outline-offset</key>
+									<value xsi:type="xsd:string">2px</value>
 								</entry>
 								<entry>
 									<key>outline-width</key>

--- a/src/test/resources/retest/recheck/de.retest.web.it.SimpleAutocheckingDriverShowcaseIT/index.04.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.it.SimpleAutocheckingDriverShowcaseIT/index.04.recheck/retest.xml
@@ -8462,6 +8462,10 @@
 								<value xsi:type="xsd:string">rgb(229, 151, 0)</value>
 							</entry>
 							<entry>
+								<key>outline-offset</key>
+								<value xsi:type="xsd:string">1px</value>
+							</entry>
+							<entry>
 								<key>outline-width</key>
 								<value xsi:type="xsd:string">1px</value>
 							</entry>
@@ -8569,7 +8573,6 @@
 			</entry>
 			<entry>
 				<key>os.arch</key>
-				<value></value>
 			</entry>
 			<entry>
 				<key>check.type</key>
@@ -8597,7 +8600,6 @@
 			</entry>
 			<entry>
 				<key>os.version</key>
-				<value></value>
 			</entry>
 			<entry>
 				<key>browser.name</key>

--- a/src/test/resources/retest/recheck/de.retest.web.it.SimpleAutocheckingDriverShowcaseIT/index.05.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.it.SimpleAutocheckingDriverShowcaseIT/index.05.recheck/retest.xml
@@ -8462,6 +8462,10 @@
 								<value xsi:type="xsd:string">rgb(229, 151, 0)</value>
 							</entry>
 							<entry>
+								<key>outline-offset</key>
+								<value xsi:type="xsd:string">1px</value>
+							</entry>
+							<entry>
 								<key>outline-width</key>
 								<value xsi:type="xsd:string">1px</value>
 							</entry>
@@ -8569,7 +8573,6 @@
 			</entry>
 			<entry>
 				<key>os.arch</key>
-				<value></value>
 			</entry>
 			<entry>
 				<key>check.type</key>
@@ -8597,7 +8600,6 @@
 			</entry>
 			<entry>
 				<key>os.version</key>
-				<value></value>
 			</entry>
 			<entry>
 				<key>browser.name</key>


### PR DESCRIPTION
Apparently, I have used a snapshot version of review. But that should not be a problem.

*And again, no metadata changes. Really need to look into that...*