### PR TITLE
Allow AutocheckingWebElement to implement Locatable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Table of Contents
 
 ### Bug Fixes
 
+* Fix unchecked `ClassCastExceptions` when using the `Actions`-API with the `AutocheckingDriver`.
+
 ### New Features
 
 * Calling `driver.switchTo().window( name )` will now perform a check when using a `AutocheckingRecheckDriver`.

--- a/src/main/java/de/retest/web/selenium/AutocheckingWebElement.java
+++ b/src/main/java/de/retest/web/selenium/AutocheckingWebElement.java
@@ -12,13 +12,15 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.WrapsDriver;
+import org.openqa.selenium.interactions.Coordinates;
+import org.openqa.selenium.interactions.Locatable;
 import org.openqa.selenium.internal.WrapsElement;
 
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor( access = AccessLevel.PRIVATE )
-public class AutocheckingWebElement implements WebElement, WrapsDriver, WrapsElement {
+public class AutocheckingWebElement implements WebElement, WrapsDriver, WrapsElement, Locatable {
 
 	private final WebElement wrappedElement;
 	private final AutocheckingRecheckDriver driver;
@@ -157,5 +159,14 @@ public class AutocheckingWebElement implements WebElement, WrapsDriver, WrapsEle
 	@Override
 	public String toString() {
 		return wrappedElement.toString();
+	}
+
+	@Override
+	public Coordinates getCoordinates() {
+		if ( wrappedElement instanceof Locatable ) {
+			return ((Locatable) wrappedElement).getCoordinates();
+		}
+		throw new IllegalStateException(
+				String.format( "Element is not instance of %s.", Locatable.class.getSimpleName() ) );
 	}
 }

--- a/src/test/java/de/retest/web/selenium/AutocheckingWebElementIT.java
+++ b/src/test/java/de/retest/web/selenium/AutocheckingWebElementIT.java
@@ -1,0 +1,47 @@
+package de.retest.web.selenium;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.spy;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.openqa.selenium.interactions.Actions;
+
+import de.retest.recheck.RecheckOptions;
+import de.retest.recheck.junit.jupiter.RecheckExtension;
+import de.retest.recheck.persistence.SeparatePathsProjectLayout;
+import de.retest.web.testutils.PageFactory;
+import de.retest.web.testutils.WebDriverFactory;
+import de.retest.web.testutils.WebDriverFactory.Driver;
+
+@ExtendWith( RecheckExtension.class )
+class AutocheckingWebElementIT {
+
+	AutocheckingRecheckDriver driver;
+	AutocheckingWebElement cut;
+
+	@BeforeEach
+	void setUp( @TempDir Path temp ) {
+		driver = new AutocheckingRecheckDriver( WebDriverFactory.driver( Driver.CHROME ), RecheckOptions.builder() //
+				// No Golden Master should be created with this test, thus it will never fail in Recheck#capTest
+				.projectLayout( new SeparatePathsProjectLayout( temp.resolve( "states" ), temp.resolve( "reports" ) ) ) //
+				.build() );
+
+		driver.skipCheck().get( PageFactory.page( PageFactory.Page.CENTER ) );
+
+		cut = spy( driver.findElement( By.id( "center" ) ) );
+	}
+
+	@Test
+	void actions_should_be_able_to_move_to_element() {
+		final Actions actions = new Actions( driver ) //
+				.moveToElement( cut );
+
+		// Apparently, this does not call Location#getCoordinates
+		assertThatCode( actions::perform ).doesNotThrowAnyException();
+	}
+}

--- a/src/test/java/de/retest/web/selenium/AutocheckingWebElementTest.java
+++ b/src/test/java/de/retest/web/selenium/AutocheckingWebElementTest.java
@@ -1,5 +1,7 @@
 package de.retest.web.selenium;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -8,6 +10,7 @@ import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.Locatable;
 
 class AutocheckingWebElementTest {
 
@@ -94,4 +97,28 @@ class AutocheckingWebElementTest {
 		autoCheckElement.isSelected();
 		verify( delegate, times( 1 ) ).isSelected();
 	}
+
+	@Test
+	void getCoordinate_should_call_wrapped_if_instance_of_locatable() {
+		final LocatableElement delegate = mock( LocatableElement.class ); // Is instanceof Locatable
+		final AutocheckingWebElement cut =
+				AutocheckingWebElement.of( delegate, mock( AutocheckingRecheckDriver.class ) );
+
+		assertThatCode( cut::getCoordinates ).doesNotThrowAnyException();
+
+		verify( delegate ).getCoordinates();
+	}
+
+	@Test
+	void getCoordinate_should_throw_if_not_instance_of_locatable() {
+		final WebElement delegate = mock( WebElement.class );
+		final AutocheckingWebElement cut =
+				AutocheckingWebElement.of( delegate, mock( AutocheckingRecheckDriver.class ) );
+
+		assertThatThrownBy( cut::getCoordinates ) //
+				.isInstanceOf( IllegalStateException.class ) //
+				.hasMessage( String.format( "Element is not instance of %s.", Locatable.class.getSimpleName() ) );
+	}
+
+	interface LocatableElement extends WebElement, Locatable {}
 }


### PR DESCRIPTION
*Before submission, please check that ...*

- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [x] the necessary tests are either created or updated.
- [x] all status checks (GitHub Actions, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [x] you updated the changelog.
- [x] ~you updated necessary documentation within [retest/docs](https://github.com/retest/docs).~ *(not needed)*

<!-- Note: You can always ask a maintainer to help you with the above tasks. -->

## Description

> TL;DR This fixes unchecked casting within the Actions API.

This is related to RET-2071.

Apparently, the Actions API does some unchecked casting. When using any instance of `AutocheckingDriver` will cause this exception.

```
Actions builder = new Actions(driver);
builder.moveToElement(element).perform();
```

But, as the integration test shows, the actual method `Locatable#getCoordinates` is never called, but I added a sensible implementation and test for that. Since I need an actual browser for the implementation (because there is some weird stuff going on in the background), I made sure that no Golden Masters are created&mdash;to have the test pass and because they are not important in this context.

### State of this PR

The test failures are related to #627 and should be fixed once this PR is merged.
