### PR TITLE
Run tests with newest JDK 14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,10 +40,10 @@ jobs:
     - name: Compile
       run: mvn --batch-mode clean package -DskipTests
 
-    - name: Set up JDK 13
+    - name: Set up JDK 14
       uses: actions/setup-java@v1
       with:
-        java-version: 13
+        java-version: 14
 
     - name: Test
       run: >


### PR DESCRIPTION
Finally I can get rid of this. 😉

PS: https://community.sonarsource.com/t/sonarcloud-knows-how-to-scan-your-java-14-code/28410

PPS: You have to update your SonarCloud token.