### PR TITLE
Feature/fix pseudo elements

### DIFF
--- a/.retest/filter/interaction-pseudo-elements.filter
+++ b/.retest/filter/interaction-pseudo-elements.filter
@@ -1,0 +1,5 @@
+# Ignore every metadata
+import: metadata.filter
+
+# Ignore outline, since this is changed (however briefly) on click of a button/link
+attribute-regex=outline-.*

--- a/src/main/resources/javascript/getAllElementsByPath.js
+++ b/src/main/resources/javascript/getAllElementsByPath.js
@@ -501,6 +501,13 @@ function addPseudoElements(node, nodePath, allElements) {
                     continue;
                 }
             }
+            else {
+                // Ignore state specific changes
+                // TODO: This is a hack! Ideally, each pseudo element only checks their applicable cssAttributes, as they cannot take all (see https://www.w3.org/TR/css-pseudo-4)
+                if (style["outline"] !== parentStyle["outline"]) {
+                    continue;
+                }
+            }
 			var path = nodePath + "/#pseudo" + pseudo + "[1]";
 			var extractedAttributes = {
 					"pseudo": allElements.find(elem => elem[0] === nodePath)[1].shown,

--- a/src/main/resources/javascript/getAllElementsByPath.js
+++ b/src/main/resources/javascript/getAllElementsByPath.js
@@ -494,7 +494,13 @@ function addPseudoElements(node, nodePath, allElements) {
 			var style = getComputedPseudoStyleSafely(node, pseudo);
 			if (!style || !parentStyle) {
 				continue;
-			}
+            }
+            if (pseudo === "::before" || pseudo === "::after") {
+                // TODO: This is w3c standard, but what do the different browsers implement (null, "")?
+                if (style["content"] === "none") {
+                    continue;
+                }
+            }
 			var path = nodePath + "/#pseudo" + pseudo + "[1]";
 			var extractedAttributes = {
 					"pseudo": allElements.find(elem => elem[0] === nodePath)[1].shown,

--- a/src/test/java/de/retest/web/it/InteractionPseudoElementIT.java
+++ b/src/test/java/de/retest/web/it/InteractionPseudoElementIT.java
@@ -1,0 +1,61 @@
+package de.retest.web.it;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import de.retest.recheck.Recheck;
+import de.retest.recheck.RecheckImpl;
+import de.retest.recheck.RecheckOptions;
+import de.retest.recheck.persistence.SeparatePathsProjectLayout;
+import de.retest.web.testutils.PageFactory;
+import de.retest.web.testutils.WebDriverFactory;
+
+class InteractionPseudoElementIT {
+
+	Recheck re;
+	WebDriver driver;
+
+	@BeforeEach
+	void setUp( @TempDir final Path temp ) {
+		re = new RecheckImpl( RecheckOptions.builder() //
+				.disableReportUpload() //
+				.projectLayout( new SeparatePathsProjectLayout( temp.resolve( "state" ), temp.resolve( "reports" ) ) ) //
+				.setIgnore( "interaction-pseudo-elements.filter" ) //
+				.build() );
+
+		driver = WebDriverFactory.driver( WebDriverFactory.Driver.CHROME );
+	}
+
+	@AfterEach
+	void tearDown() {
+		driver.quit();
+		re.cap();
+	}
+
+	@Test
+	void ghost_pseudo_elements_should_not_appear_because_of_css_changes() {
+		re.startTest();
+
+		driver.get( PageFactory.toPageUrlString( "pseudo/index.html" ) );
+
+		final WebElement withoutPseudo = driver.findElement( By.id( "link-without-pseudo" ) );
+		re.check( driver, "click" );
+		withoutPseudo.click();
+		re.check( driver, "click" ); // This should not capture any differences
+
+		assertThatThrownBy( re::capTest ).hasMessageEndingWith(
+				"2 check(s) in 'de.retest.web.it.InteractionPseudoElementIT' found the following difference(s):\n"
+						+ "Test 'ghost_pseudo_elements_should_not_appear_because_of_css_changes' has 1 difference(s) in 2 state(s):\n"
+						+ "click resulted in:\n"
+						+ "\tNo Golden Master found. First time test was run? Created new Golden Master, so don't forget to commit..." );
+	}
+}

--- a/src/test/java/de/retest/web/it/InteractionPseudoElementIT.java
+++ b/src/test/java/de/retest/web/it/InteractionPseudoElementIT.java
@@ -1,12 +1,11 @@
 package de.retest.web.it;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import java.nio.file.Path;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
@@ -15,10 +14,11 @@ import org.openqa.selenium.WebElement;
 import de.retest.recheck.Recheck;
 import de.retest.recheck.RecheckImpl;
 import de.retest.recheck.RecheckOptions;
-import de.retest.recheck.persistence.SeparatePathsProjectLayout;
+import de.retest.recheck.junit.jupiter.RecheckExtension;
 import de.retest.web.testutils.PageFactory;
 import de.retest.web.testutils.WebDriverFactory;
 
+@ExtendWith( RecheckExtension.class )
 class InteractionPseudoElementIT {
 
 	Recheck re;
@@ -28,7 +28,6 @@ class InteractionPseudoElementIT {
 	void setUp( @TempDir final Path temp ) {
 		re = new RecheckImpl( RecheckOptions.builder() //
 				.disableReportUpload() //
-				.projectLayout( new SeparatePathsProjectLayout( temp.resolve( "state" ), temp.resolve( "reports" ) ) ) //
 				.setIgnore( "interaction-pseudo-elements.filter" ) //
 				.build() );
 
@@ -38,24 +37,15 @@ class InteractionPseudoElementIT {
 	@AfterEach
 	void tearDown() {
 		driver.quit();
-		re.cap();
 	}
 
 	@Test
 	void ghost_pseudo_elements_should_not_appear_because_of_css_changes() {
-		re.startTest();
-
 		driver.get( PageFactory.toPageUrlString( "pseudo/index.html" ) );
 
 		final WebElement withoutPseudo = driver.findElement( By.id( "link-without-pseudo" ) );
-		re.check( driver, "click" );
+		re.check( driver, "click" ); // Check before click
 		withoutPseudo.click();
 		re.check( driver, "click" ); // This should not capture any differences
-
-		assertThatThrownBy( re::capTest ).hasMessageEndingWith(
-				"2 check(s) in 'de.retest.web.it.InteractionPseudoElementIT' found the following difference(s):\n"
-						+ "Test 'ghost_pseudo_elements_should_not_appear_because_of_css_changes' has 1 difference(s) in 2 state(s):\n"
-						+ "click resulted in:\n"
-						+ "\tNo Golden Master found. First time test was run? Created new Golden Master, so don't forget to commit..." );
 	}
 }

--- a/src/test/resources/pages/pseudo/index.css
+++ b/src/test/resources/pages/pseudo/index.css
@@ -1,0 +1,31 @@
+*, *::before, *::after {
+	margin: 0;
+	padding: 0;
+	box-sizing: border-box;
+}
+
+.header, .main {
+	padding: 1em;
+}
+
+.group > .description {
+	font-size: 80%;
+	color: gray;
+	margin-top: 0.25em;
+}
+
+.header {
+	position: sticky;
+	top: 0;
+	background-color: lightgray;
+	z-index: 100;
+}
+
+#link-without-pseudo:pressed {
+	outline-color: red;
+}
+
+.main[data-state=changed] #link-without-pseudo {
+	text-decoration: none;
+	color: lime;
+}

--- a/src/test/resources/pages/pseudo/index.html
+++ b/src/test/resources/pages/pseudo/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>Pseudo Elements</title>
+
+	<link rel="stylesheet" href="index.css">
+</head>
+
+<body>
+	<header class="header">
+		<button id="btn-change" data-target=".main">Toggle</button>
+	</header>
+
+	<main class="main">
+		<div class="group">
+			<a href="#" id="link-without-pseudo">Link without pseudo element</a>
+			<div class="description">This link does not have a pseudo element, but changes outline state when pressed</div>
+		</div>
+	</main>
+
+	<script src="index.js"></script>
+
+</body>
+
+</html>

--- a/src/test/resources/pages/pseudo/index.js
+++ b/src/test/resources/pages/pseudo/index.js
@@ -1,0 +1,15 @@
+
+
+window.onload = () => {
+    const change = document.getElementById( "btn-change" );
+    change.onclick = () => {
+        const target = document.querySelector( change.getAttribute( "data-target" ) );
+        if ( target ) {
+            if ( target.getAttribute( "data-state" ) ) {
+                target.removeAttribute( "data-state" );
+            } else {
+                target.setAttribute( "data-state", "changed" );
+            }
+        }
+    }
+};

--- a/src/test/resources/retest/recheck/de.retest.web.it.InteractionPseudoElementIT/ghost_pseudo_elements_should_not_appear_because_of_css_changes.click.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.web.it.InteractionPseudoElementIT/ghost_pseudo_elements_should_not_appear_because_of_css_changes.click.recheck/retest.xml
@@ -1,0 +1,625 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<reTestXmlDataContainer xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" reTestVersion="1.12.0-SNAPSHOT" dataType="de.retest.recheck.ui.descriptors.SutState" dataTypeVersion="4">
+	<data xsi:type="sutState">
+		<descriptors retestId="html" screenId="1" screen="Pseudo Elements" title="Pseudo Elements">
+			<identifyingAttributes>
+				<attributes>
+					<attribute key="absolute-outline" xsi:type="outlineAttribute">
+						<x>0</x>
+						<y>0</y>
+						<height>119</height>
+						<width>1200</width>
+					</attribute>
+					<attribute key="outline" xsi:type="outlineAttribute">
+						<x>0</x>
+						<y>0</y>
+						<height>119</height>
+						<width>1200</width>
+					</attribute>
+					<attribute key="path" xsi:type="pathAttribute">html[1]</attribute>
+					<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
+					<attribute key="type" xsi:type="stringAttribute">html</attribute>
+				</attributes>
+			</identifyingAttributes>
+			<attributes>
+				<attributes>
+					<entry>
+						<key>box-sizing</key>
+						<value xsi:type="xsd:string">border-box</value>
+					</entry>
+					<entry>
+						<key>lang</key>
+						<value xsi:type="xsd:string">en</value>
+					</entry>
+					<entry>
+						<key>shown</key>
+						<value xsi:type="xsd:string">true</value>
+					</entry>
+				</attributes>
+			</attributes>
+			<containedElements retestId="head">
+				<identifyingAttributes>
+					<attributes>
+						<attribute key="absolute-outline" xsi:type="outlineAttribute">
+							<x>0</x>
+							<y>0</y>
+							<height>0</height>
+							<width>0</width>
+						</attribute>
+						<attribute key="outline" xsi:type="outlineAttribute">
+							<x>0</x>
+							<y>0</y>
+							<height>-119</height>
+							<width>-1200</width>
+						</attribute>
+						<attribute key="path" xsi:type="pathAttribute">html[1]/head[1]</attribute>
+						<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
+						<attribute key="type" xsi:type="stringAttribute">head</attribute>
+					</attributes>
+				</identifyingAttributes>
+				<attributes>
+					<attributes>
+						<entry>
+							<key>shown</key>
+							<value xsi:type="xsd:string">false</value>
+						</entry>
+					</attributes>
+				</attributes>
+				<containedElements retestId="meta">
+					<identifyingAttributes>
+						<attributes>
+							<attribute key="absolute-outline" xsi:type="outlineAttribute">
+								<x>0</x>
+								<y>0</y>
+								<height>0</height>
+								<width>0</width>
+							</attribute>
+							<attribute key="outline" xsi:type="outlineAttribute">
+								<x>0</x>
+								<y>0</y>
+								<height>0</height>
+								<width>0</width>
+							</attribute>
+							<attribute key="path" xsi:type="pathAttribute">html[1]/head[1]/meta[1]</attribute>
+							<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
+							<attribute key="type" xsi:type="stringAttribute">meta</attribute>
+						</attributes>
+					</identifyingAttributes>
+					<attributes>
+						<attributes>
+							<entry>
+								<key>charset</key>
+								<value xsi:type="xsd:string">UTF-8</value>
+							</entry>
+							<entry>
+								<key>shown</key>
+								<value xsi:type="xsd:string">false</value>
+							</entry>
+						</attributes>
+					</attributes>
+				</containedElements>
+				<containedElements retestId="viewport">
+					<identifyingAttributes>
+						<attributes>
+							<attribute key="absolute-outline" xsi:type="outlineAttribute">
+								<x>0</x>
+								<y>0</y>
+								<height>0</height>
+								<width>0</width>
+							</attribute>
+							<attribute key="name" xsi:type="stringAttribute">viewport</attribute>
+							<attribute key="outline" xsi:type="outlineAttribute">
+								<x>0</x>
+								<y>0</y>
+								<height>0</height>
+								<width>0</width>
+							</attribute>
+							<attribute key="path" xsi:type="pathAttribute">html[1]/head[1]/meta[2]</attribute>
+							<attribute key="suffix" xsi:type="suffixAttribute">2</attribute>
+							<attribute key="type" xsi:type="stringAttribute">meta</attribute>
+						</attributes>
+					</identifyingAttributes>
+					<attributes>
+						<attributes>
+							<entry>
+								<key>content</key>
+								<value xsi:type="xsd:string">width=device-width, initial-scale=1.0</value>
+							</entry>
+							<entry>
+								<key>shown</key>
+								<value xsi:type="xsd:string">false</value>
+							</entry>
+						</attributes>
+					</attributes>
+				</containedElements>
+				<containedElements retestId="pseudo_elements">
+					<identifyingAttributes>
+						<attributes>
+							<attribute key="absolute-outline" xsi:type="outlineAttribute">
+								<x>0</x>
+								<y>0</y>
+								<height>0</height>
+								<width>0</width>
+							</attribute>
+							<attribute key="outline" xsi:type="outlineAttribute">
+								<x>0</x>
+								<y>0</y>
+								<height>0</height>
+								<width>0</width>
+							</attribute>
+							<attribute key="path" xsi:type="pathAttribute">html[1]/head[1]/title[1]</attribute>
+							<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
+							<attribute key="text" xsi:type="textAttribute">Pseudo Elements</attribute>
+							<attribute key="type" xsi:type="stringAttribute">title</attribute>
+						</attributes>
+					</identifyingAttributes>
+					<attributes>
+						<attributes>
+							<entry>
+								<key>shown</key>
+								<value xsi:type="xsd:string">false</value>
+							</entry>
+						</attributes>
+					</attributes>
+				</containedElements>
+			</containedElements>
+			<containedElements retestId="body">
+				<identifyingAttributes>
+					<attributes>
+						<attribute key="absolute-outline" xsi:type="outlineAttribute">
+							<x>0</x>
+							<y>0</y>
+							<height>119</height>
+							<width>1200</width>
+						</attribute>
+						<attribute key="outline" xsi:type="outlineAttribute">
+							<x>0</x>
+							<y>0</y>
+							<height>0</height>
+							<width>0</width>
+						</attribute>
+						<attribute key="path" xsi:type="pathAttribute">html[1]/body[1]</attribute>
+						<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
+						<attribute key="type" xsi:type="stringAttribute">body</attribute>
+					</attributes>
+				</identifyingAttributes>
+				<attributes>
+					<attributes>
+						<entry>
+							<key>shown</key>
+							<value xsi:type="xsd:string">true</value>
+						</entry>
+					</attributes>
+				</attributes>
+				<containedElements retestId="header">
+					<identifyingAttributes>
+						<attributes>
+							<attribute key="absolute-outline" xsi:type="outlineAttribute">
+								<x>0</x>
+								<y>0</y>
+								<height>51</height>
+								<width>1200</width>
+							</attribute>
+							<attribute key="class" xsi:type="stringAttribute">header</attribute>
+							<attribute key="outline" xsi:type="outlineAttribute">
+								<x>0</x>
+								<y>0</y>
+								<height>-68</height>
+								<width>0</width>
+							</attribute>
+							<attribute key="path" xsi:type="pathAttribute">html[1]/body[1]/header[1]</attribute>
+							<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
+							<attribute key="type" xsi:type="stringAttribute">header</attribute>
+						</attributes>
+					</identifyingAttributes>
+					<attributes>
+						<attributes>
+							<entry>
+								<key>background-color</key>
+								<value xsi:type="xsd:string">rgb(211, 211, 211)</value>
+							</entry>
+							<entry>
+								<key>padding-bottom</key>
+								<value xsi:type="xsd:string">16px</value>
+							</entry>
+							<entry>
+								<key>padding-left</key>
+								<value xsi:type="xsd:string">16px</value>
+							</entry>
+							<entry>
+								<key>padding-right</key>
+								<value xsi:type="xsd:string">16px</value>
+							</entry>
+							<entry>
+								<key>padding-top</key>
+								<value xsi:type="xsd:string">16px</value>
+							</entry>
+							<entry>
+								<key>position</key>
+								<value xsi:type="xsd:string">sticky</value>
+							</entry>
+							<entry>
+								<key>shown</key>
+								<value xsi:type="xsd:string">true</value>
+							</entry>
+							<entry>
+								<key>z-index</key>
+								<value xsi:type="xsd:string">100</value>
+							</entry>
+						</attributes>
+					</attributes>
+					<containedElements retestId="toggle">
+						<identifyingAttributes>
+							<attributes>
+								<attribute key="absolute-outline" xsi:type="outlineAttribute">
+									<x>16</x>
+									<y>16</y>
+									<height>19</height>
+									<width>43</width>
+								</attribute>
+								<attribute key="id" xsi:type="stringAttribute">btn-change</attribute>
+								<attribute key="outline" xsi:type="outlineAttribute">
+									<x>16</x>
+									<y>16</y>
+									<height>-32</height>
+									<width>-1157</width>
+								</attribute>
+								<attribute key="path" xsi:type="pathAttribute">html[1]/body[1]/header[1]/button[1]</attribute>
+								<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
+								<attribute key="text" xsi:type="textAttribute">Toggle</attribute>
+								<attribute key="type" xsi:type="stringAttribute">button</attribute>
+							</attributes>
+						</identifyingAttributes>
+						<attributes>
+							<attributes>
+								<entry>
+									<key>align-items</key>
+									<value xsi:type="xsd:string">flex-start</value>
+								</entry>
+								<entry>
+									<key>background-color</key>
+									<value xsi:type="xsd:string">rgb(239, 239, 239)</value>
+								</entry>
+								<entry>
+									<key>border-bottom-color</key>
+									<value xsi:type="xsd:string">rgb(118, 118, 118)</value>
+								</entry>
+								<entry>
+									<key>border-bottom-style</key>
+									<value xsi:type="xsd:string">outset</value>
+								</entry>
+								<entry>
+									<key>border-bottom-width</key>
+									<value xsi:type="xsd:string">2px</value>
+								</entry>
+								<entry>
+									<key>border-left-color</key>
+									<value xsi:type="xsd:string">rgb(118, 118, 118)</value>
+								</entry>
+								<entry>
+									<key>border-left-style</key>
+									<value xsi:type="xsd:string">outset</value>
+								</entry>
+								<entry>
+									<key>border-left-width</key>
+									<value xsi:type="xsd:string">2px</value>
+								</entry>
+								<entry>
+									<key>border-right-color</key>
+									<value xsi:type="xsd:string">rgb(118, 118, 118)</value>
+								</entry>
+								<entry>
+									<key>border-right-style</key>
+									<value xsi:type="xsd:string">outset</value>
+								</entry>
+								<entry>
+									<key>border-right-width</key>
+									<value xsi:type="xsd:string">2px</value>
+								</entry>
+								<entry>
+									<key>border-top-color</key>
+									<value xsi:type="xsd:string">rgb(118, 118, 118)</value>
+								</entry>
+								<entry>
+									<key>border-top-style</key>
+									<value xsi:type="xsd:string">outset</value>
+								</entry>
+								<entry>
+									<key>border-top-width</key>
+									<value xsi:type="xsd:string">2px</value>
+								</entry>
+								<entry>
+									<key>data-target</key>
+									<value xsi:type="xsd:string">.main</value>
+								</entry>
+								<entry>
+									<key>display</key>
+									<value xsi:type="xsd:string">inline-block</value>
+								</entry>
+								<entry>
+									<key>font-family</key>
+									<value xsi:type="xsd:string">Arial</value>
+								</entry>
+								<entry>
+									<key>font-size</key>
+									<value xsi:type="xsd:string">13.3333px</value>
+								</entry>
+								<entry>
+									<key>read-only</key>
+								</entry>
+								<entry>
+									<key>shown</key>
+									<value xsi:type="xsd:string">true</value>
+								</entry>
+								<entry>
+									<key>text-align</key>
+									<value xsi:type="xsd:string">center</value>
+								</entry>
+							</attributes>
+						</attributes>
+					</containedElements>
+				</containedElements>
+				<containedElements retestId="main">
+					<identifyingAttributes>
+						<attributes>
+							<attribute key="absolute-outline" xsi:type="outlineAttribute">
+								<x>0</x>
+								<y>51</y>
+								<height>68</height>
+								<width>1200</width>
+							</attribute>
+							<attribute key="class" xsi:type="stringAttribute">main</attribute>
+							<attribute key="outline" xsi:type="outlineAttribute">
+								<x>0</x>
+								<y>51</y>
+								<height>-51</height>
+								<width>0</width>
+							</attribute>
+							<attribute key="path" xsi:type="pathAttribute">html[1]/body[1]/main[1]</attribute>
+							<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
+							<attribute key="type" xsi:type="stringAttribute">main</attribute>
+						</attributes>
+					</identifyingAttributes>
+					<attributes>
+						<attributes>
+							<entry>
+								<key>padding-bottom</key>
+								<value xsi:type="xsd:string">16px</value>
+							</entry>
+							<entry>
+								<key>padding-left</key>
+								<value xsi:type="xsd:string">16px</value>
+							</entry>
+							<entry>
+								<key>padding-right</key>
+								<value xsi:type="xsd:string">16px</value>
+							</entry>
+							<entry>
+								<key>padding-top</key>
+								<value xsi:type="xsd:string">16px</value>
+							</entry>
+							<entry>
+								<key>shown</key>
+								<value xsi:type="xsd:string">true</value>
+							</entry>
+						</attributes>
+					</attributes>
+					<containedElements retestId="div">
+						<identifyingAttributes>
+							<attributes>
+								<attribute key="absolute-outline" xsi:type="outlineAttribute">
+									<x>16</x>
+									<y>67</y>
+									<height>36</height>
+									<width>1168</width>
+								</attribute>
+								<attribute key="class" xsi:type="stringAttribute">group</attribute>
+								<attribute key="outline" xsi:type="outlineAttribute">
+									<x>16</x>
+									<y>16</y>
+									<height>-32</height>
+									<width>-32</width>
+								</attribute>
+								<attribute key="path" xsi:type="pathAttribute">html[1]/body[1]/main[1]/div[1]</attribute>
+								<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
+								<attribute key="type" xsi:type="stringAttribute">div</attribute>
+							</attributes>
+						</identifyingAttributes>
+						<attributes>
+							<attributes>
+								<entry>
+									<key>shown</key>
+									<value xsi:type="xsd:string">true</value>
+								</entry>
+							</attributes>
+						</attributes>
+						<containedElements retestId="link_without">
+							<identifyingAttributes>
+								<attributes>
+									<attribute key="absolute-outline" xsi:type="outlineAttribute">
+										<x>16</x>
+										<y>67</y>
+										<height>17</height>
+										<width>187</width>
+									</attribute>
+									<attribute key="id" xsi:type="stringAttribute">link-without-pseudo</attribute>
+									<attribute key="outline" xsi:type="outlineAttribute">
+										<x>0</x>
+										<y>0</y>
+										<height>-19</height>
+										<width>-981</width>
+									</attribute>
+									<attribute key="path" xsi:type="pathAttribute">html[1]/body[1]/main[1]/div[1]/a[1]</attribute>
+									<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
+									<attribute key="text" xsi:type="textAttribute">Link without pseudo element</attribute>
+									<attribute key="type" xsi:type="stringAttribute">a</attribute>
+								</attributes>
+							</identifyingAttributes>
+							<attributes>
+								<attributes>
+									<entry>
+										<key>href</key>
+										<value xsi:type="xsd:string">#</value>
+									</entry>
+									<entry>
+										<key>shown</key>
+										<value xsi:type="xsd:string">true</value>
+									</entry>
+								</attributes>
+							</attributes>
+						</containedElements>
+						<containedElements retestId="this_link_does">
+							<identifyingAttributes>
+								<attributes>
+									<attribute key="absolute-outline" xsi:type="outlineAttribute">
+										<x>16</x>
+										<y>88</y>
+										<height>15</height>
+										<width>1168</width>
+									</attribute>
+									<attribute key="class" xsi:type="stringAttribute">description</attribute>
+									<attribute key="outline" xsi:type="outlineAttribute">
+										<x>0</x>
+										<y>21</y>
+										<height>-21</height>
+										<width>0</width>
+									</attribute>
+									<attribute key="path" xsi:type="pathAttribute">html[1]/body[1]/main[1]/div[1]/div[1]</attribute>
+									<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
+									<attribute key="text" xsi:type="textAttribute">This link does not have a pseudo element, but changes outline state when pressed</attribute>
+									<attribute key="type" xsi:type="stringAttribute">div</attribute>
+								</attributes>
+							</identifyingAttributes>
+							<attributes>
+								<attributes>
+									<entry>
+										<key>border-bottom-color</key>
+										<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
+									</entry>
+									<entry>
+										<key>border-left-color</key>
+										<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
+									</entry>
+									<entry>
+										<key>border-right-color</key>
+										<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
+									</entry>
+									<entry>
+										<key>border-top-color</key>
+										<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
+									</entry>
+									<entry>
+										<key>caret-color</key>
+										<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
+									</entry>
+									<entry>
+										<key>color</key>
+										<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
+									</entry>
+									<entry>
+										<key>column-rule-color</key>
+										<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
+									</entry>
+									<entry>
+										<key>font-size</key>
+										<value xsi:type="xsd:string">12.8px</value>
+									</entry>
+									<entry>
+										<key>margin-top</key>
+										<value xsi:type="xsd:string">3.2px</value>
+									</entry>
+									<entry>
+										<key>outline-color</key>
+										<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
+									</entry>
+									<entry>
+										<key>shown</key>
+										<value xsi:type="xsd:string">true</value>
+									</entry>
+									<entry>
+										<key>text-decoration-color</key>
+										<value xsi:type="xsd:string">rgb(128, 128, 128)</value>
+									</entry>
+								</attributes>
+							</attributes>
+						</containedElements>
+					</containedElements>
+				</containedElements>
+			</containedElements>
+		</descriptors>
+		<metadata>
+			<entry>
+				<key>driver.type</key>
+				<value>ChromeDriver</value>
+			</entry>
+			<entry>
+				<key>time.offset</key>
+				<value>+02:00</value>
+			</entry>
+			<entry>
+				<key>os.arch</key>
+				<value></value>
+			</entry>
+			<entry>
+				<key>check.type</key>
+				<value>driver</value>
+			</entry>
+			<entry>
+				<key>vcs.commit</key>
+				<value>13f8f9f5464f2ceb39258b0ca3ea6dc2dfc078cb</value>
+			</entry>
+			<entry>
+				<key>window.height</key>
+				<value>800</value>
+			</entry>
+			<entry>
+				<key>vcs.branch</key>
+				<value>feature/fix-pseudo-elements</value>
+			</entry>
+			<entry>
+				<key>url</key>
+				<value>file:///C:/Users/bastd/Documents/Work/Company/Repo/open/recheck-web/src/test/resources/pages/pseudo/index.html</value>
+			</entry>
+			<entry>
+				<key>machine.name</key>
+				<value>PC</value>
+			</entry>
+			<entry>
+				<key>os.version</key>
+				<value></value>
+			</entry>
+			<entry>
+				<key>browser.name</key>
+				<value>chrome</value>
+			</entry>
+			<entry>
+				<key>browser.version</key>
+				<value>85.0.4183.83</value>
+			</entry>
+			<entry>
+				<key>time.time</key>
+				<value>13:10:04.4988377</value>
+			</entry>
+			<entry>
+				<key>time.zone</key>
+				<value>Europe/Berlin</value>
+			</entry>
+			<entry>
+				<key>window.width</key>
+				<value>1200</value>
+			</entry>
+			<entry>
+				<key>os.name</key>
+				<value>WINDOWS</value>
+			</entry>
+			<entry>
+				<key>time.date</key>
+				<value>2020-08-29</value>
+			</entry>
+			<entry>
+				<key>vcs.name</key>
+				<value>git</value>
+			</entry>
+		</metadata>
+	</data>
+</reTestXmlDataContainer>


### PR DESCRIPTION
*Before submission, please check that ...*

- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [ ] the necessary tests are either created or updated.
- [ ] all status checks (GitHub Actions, SonarCloud, etc.) pass.
- [ ] your commit history is cleaned up.
- [x] ~you updated the changelog.~ (*This is not released yet, so not necessary*)
- [x] ~you updated necessary documentation within [retest/docs](https://github.com/retest/docs).~ (*see above*)

<!-- Note: You can always ask a maintainer to help you with the above tasks. -->

## Description

> TL;DR This should fix ghost pseudo elements that are added, despite not rendered by the browser.

As already described by #625, ghost pseudo elements cause the alignment algorithm to get confused, which produces `"a" has been inserted` and `"a" has been deleted` difference. This PR should address the most pressing problems and catch the currently known cases (mostly as a workaround).

### Bug

I have added a test which shows only one occurrence of the bug. It appears consistently, if a button (or link) is pressed and a check is generated at this exact moment or a few moments later&mdash;I have yet to figure out, when Selenium "completes" a click. Because buttons make use of a pseudo class (`:pressed`), it will change some properties of the button (e.g. `outline`) to show the button has been pressed. 

This has the current algorithm detect changes in the parents' and the pseudo elements' style and generate a pseudo element which then confuses the alignment algorithm.

#### Problem

1. Inherited attributes

    In general, attributes of a parent is inherited by the child element. Since pseudo elements (especially `::before` and `::after`) are considered direct children of the parent attributes. 

    Strangely enough, pseudo class changes are not propagated to the `getComputedStyle(parent, "$pseudo")` which returns the old CSS attributes (i.e. not pressed). I have tried to add the parents' states to the query, but the browser refuses to give the current state. I can only assume that this is by design, that pseudo classes (e.g. `:hover`) are not passed down to the child to allow them to respond independently to them.

2. Rendering of pseudo elements

    While most pseudo elements are always present (although rarely used), the `::before` and `::after` pseudo elements are not always added to the render tree. That is because the specification describes they should only be added if their content attribute is not `"none"`. This is currently ignored by the implementation, which only looks at the inherited attributes.

3. CSS Attributes

    According to the [specification](https://www.w3.org/TR/css-pseudo-4), not all attributes are allowed on pseudo elements. However, we query attributes on the pseudo elements that will never affect the element (e.g. outline) and thus return a false value.

### Implementation

1. The most used pseudo elements (`::before`, `::after`) are easy to exclude, following the specification. 
2. The other pseudo elements are not trivial, because they can only be identified by their CSS Attributes. However, since this is much work, I have only included a workaround for the current problem (i.e. hack) and will discuss a more concrete solution in a separate issue (*issue link pending*).

### State of this PR

1. Revert the first commits, as they are only included to have the test run. This should partly be addressed by #638.
2. There are tests failing, some of them make sense, but others now produce the dreaded *inserted-deleted* difference. I did not do a great amount of investigation (mostly because of the now lacking accepting possibilities), but wanted to get this PR on the way to gather opinions. @githubert would it be too much to ask to glance over them, since you have already battled those in the previous PRs (we could do that together, too)?
3. This requires more testing? What tests are covered by the existing `PseudoElementIT`?

### Additional Context

1. I will discuss a proper solution as part of a separate issue (*issue link pending*).
1. This is related to #624, although the original test have been fixed?
1. Please refer to the [pseudo element specification](https://www.w3.org/TR/css-pseudo-4).
1. There is a [draft](https://developer.mozilla.org/en-US/docs/Web/API/CSSPseudoElement) to make pseudo elements more accessible to JavaScript. However, it will take some time until the major browsers will support this.